### PR TITLE
Add classification integration into the tuning pipeline

### DIFF
--- a/ab/gpt/ClassificationEval.py
+++ b/ab/gpt/ClassificationEval.py
@@ -11,29 +11,34 @@ from ab.gpt.util.Const import new_out_file
 import re
 
 def extract_answer(llm_output: str, valid_datasets: list) -> str | None:
-    """Find the first valid dataset name mentioned in the LLM output."""
+    """Find the first valid dataset name mentioned in the LLM output.
+
+    Three passes in order of strictness:
+    1. Exact match — handles clean one-word responses.
+    2. Whole-word regex — avoids prefix confusion (e.g. "cifar-10" inside "cifar-100").
+    3. Normalized whole-word regex — handles hyphens/underscores written as spaces.
+    """
     if not llm_output:
         return None
     text = llm_output.strip().lower()
-    # Exact match first (handles clean one-word responses)
-    for ds in valid_datasets:
-        ds_lower = ds.lower() #new
 
+    # Pass 1: exact match
+    for ds in valid_datasets:
         if text == ds.lower():
             return ds
-        if ds_lower in text:
-            return ds
 
-        ds_normalized = ds_lower.replace('-', ' ').replace('_', ' ')
-        if ds_normalized in text:
-            return ds
-    return None
-    # Substring fallback (handles "Answer: cifar-100" etc.)
+    # Pass 2: whole-word regex match
     for ds in valid_datasets:
         if re.search(r'\b' + re.escape(ds.lower()) + r'\b', text):
             return ds
-        # if ds.lower() in text:
-        #     return ds
+
+    # Pass 3: normalized whole-word match (hyphens/underscores → spaces)
+    text_normalized = text.replace('-', ' ').replace('_', ' ')
+    for ds in valid_datasets:
+        ds_normalized = ds.lower().replace('-', ' ').replace('_', ' ')
+        if re.search(r'\b' + re.escape(ds_normalized) + r'\b', text_normalized):
+            return ds
+
     return None
 
 

--- a/ab/gpt/ClassificationEval.py
+++ b/ab/gpt/ClassificationEval.py
@@ -71,6 +71,10 @@ def evaluate_epoch(models_base_dir: Path) -> dict:
                 if marker in raw_output:
                     raw_output = raw_output.split(marker, 1)[-1]
                     break
+            # Strip reasoning block emitted by thinking models (e.g. OlympicCoder, DeepSeek-R1)
+            # Keep only text after </think>; if no </think>, use the full output as-is
+            if '</think>' in raw_output:
+                raw_output = raw_output.split('</think>', 1)[-1]
             llm_output   = raw_output.strip()
             origdf       = pd.read_pickle(df_file)
             ground_truth = origdf.get('better_dataset')

--- a/ab/gpt/ClassificationEval.py
+++ b/ab/gpt/ClassificationEval.py
@@ -1,0 +1,104 @@
+"""
+Validates LLM outputs for the dataset-comparison classification task.
+No NN training — just checks if the predicted dataset name matches ground truth.
+"""
+import json, os
+from pathlib import Path
+import pandas as pd
+
+from ab.gpt.util.Const import new_out_file
+
+import re
+
+def extract_answer(llm_output: str, valid_datasets: list) -> str | None:
+    """Find the first valid dataset name mentioned in the LLM output."""
+    if not llm_output:
+        return None
+    text = llm_output.strip().lower()
+    # Exact match first (handles clean one-word responses)
+    for ds in valid_datasets:
+        ds_lower = ds.lower() #new
+
+        if text == ds.lower():
+            return ds
+        if ds_lower in text:
+            return ds
+
+        ds_normalized = ds_lower.replace('-', ' ').replace('_', ' ')
+        if ds_normalized in text:
+            return ds
+    return None
+    # Substring fallback (handles "Answer: cifar-100" etc.)
+    for ds in valid_datasets:
+        if re.search(r'\b' + re.escape(ds.lower()) + r'\b', text):
+            return ds
+        # if ds.lower() in text:
+        #     return ds
+    return None
+
+
+def evaluate_epoch(models_base_dir: Path) -> dict:
+    """
+    Scan all B* directories, compare LLM answer to ground truth better_dataset.
+    Writes classification_eval.json per model and returns aggregate stats.
+    """
+    results = []
+
+    for model_id in sorted(os.listdir(models_base_dir)):
+        model_dir = models_base_dir / model_id
+        if not model_dir.is_dir():
+            continue
+
+        out_file = model_dir / new_out_file
+        df_file  = model_dir / 'dataframe.df'
+
+        if not out_file.exists():
+            print(f'  [ClassificationEval] No output file for {model_id}, skipping.')
+            continue
+        if not df_file.exists():
+            print(f'  [ClassificationEval] No dataframe.df for {model_id}, skipping.')
+            continue
+
+        try:
+            raw_output   = out_file.read_text()
+            # Strip prompt leakage: keep only text after the response marker
+            for marker in ('### Response:', '<|im_start|>assistant', '<|assistant|>', '[/INST]'):
+                if marker in raw_output:
+                    raw_output = raw_output.split(marker, 1)[-1]
+                    break
+            llm_output   = raw_output.strip()
+            origdf       = pd.read_pickle(df_file)
+            ground_truth = origdf.get('better_dataset')
+            dataset_1    = origdf.get('dataset')
+            dataset_2    = origdf.get('dataset_2')
+
+            valid     = [d for d in [dataset_1, dataset_2] if d]
+            predicted = extract_answer(llm_output, valid)
+            correct   = bool(predicted and ground_truth and predicted == ground_truth)
+
+            per_model = {
+                'model_id':     model_id,
+                'predicted':    predicted,
+                'ground_truth': ground_truth,
+                'correct':      correct,
+                'dataset_1':    dataset_1,
+                'dataset_2':    dataset_2,
+                'raw_output':   llm_output[:200] if llm_output else '',
+            }
+            results.append(per_model)
+
+            with open(model_dir / 'classification_eval.json', 'w') as f:
+                json.dump(per_model, f, indent=4)
+
+            status = '✓' if correct else '✗'
+            print(f'  [{status}] {model_id}: predicted={predicted!r}  truth={ground_truth!r}')
+
+        except Exception as e:
+            print(f'  [ClassificationEval] Error for {model_id}: {e}')
+
+    total    = len(results)
+    n_correct = sum(1 for r in results if r['correct'])
+    accuracy = n_correct / total if total > 0 else 0.0
+
+    print(f'\n  [ClassificationEval] Accuracy: {n_correct}/{total} = {accuracy:.3f}')
+    return {'accuracy': accuracy, 'correct': n_correct, 'total': total, 'results': results}

--- a/ab/gpt/TuneNNGen.py
+++ b/ab/gpt/TuneNNGen.py
@@ -152,7 +152,8 @@ def main(num_train_epochs=NUM_TRAIN_EPOCHS, lr_scheduler=LR_SCHEDULER, max_grad_
          run_iterative_pipeline=False, cycles=5, models_per_cycle=150, samples_per_prompt=1, accuracy_threshold=0.40,
          min_selected_k=15, fallback_threshold=0.35, adaptive_threshold=False,
          novelty_check=True, resume_from_cycle=None, max_retries=3, use_optimized_training=True,
-         use_agents=USE_AGENTS, use_predictor=USE_PREDICTOR, use_backbone=False):
+         use_agents=USE_AGENTS, use_predictor=USE_PREDICTOR, use_backbone=False,
+         classification_mode=False):
     persist_llm_conf(llm_conf, enable_merge)
     # --- Pipeline mode intercept ---
     if run_iterative_pipeline:
@@ -342,7 +343,8 @@ unsloth_opt={unsloth_opt}, trans_mode={trans_mode}, prompt_batch={prompt_batch},
             use_agents=use_agents,
             use_predictor=use_predictor,
             enable_merge=enable_merge,
-            use_unsloth = unsloth_opt
+            use_unsloth=unsloth_opt,
+            classification_mode=classification_mode,
         )
 
         # Normal completion - auto merge best

--- a/ab/gpt/TuneNNGen_1_3B_Classification_Onnx.py
+++ b/ab/gpt/TuneNNGen_1_3B_Classification_Onnx.py
@@ -11,7 +11,6 @@ def add_normalization_to_lemur(epoch=5):
     import ab.nn.util.db.Query as Q
     from ab.nn.util.db.Query import tmp_data, fill_hyper_prm
 
-
     def _fixed_join_nn_query(sql, limit_clause, cur):
         join_conditions = []
         for c in (sql.same_columns or []):
@@ -32,8 +31,6 @@ def add_normalization_to_lemur(epoch=5):
         ''')
         return fill_hyper_prm(cur, sql.num_joint_nns)
 
-    # Q.join_nn_query = _fixed_join_nn_query
-    # print("[INFO] join_nn_query bug patched ✓")
     Q.join_nn_query = _fixed_join_nn_query
 
     # Also patch in Read.py where it's imported directly
@@ -67,7 +64,6 @@ def add_normalization_to_lemur(epoch=5):
                 lambda r: r['dataset'] if r['norm_acc'] >= r['norm_acc_2'] else r['dataset_2'], axis=1)
         return df
 
-    # Preserve cache_clear from original so lemur.data.cache_clear() still works
     if hasattr(original_lemur_data, 'cache_clear'):
         patched_lemur_data.cache_clear = original_lemur_data.cache_clear
 
@@ -75,18 +71,22 @@ def add_normalization_to_lemur(epoch=5):
     lemur._normalization_patched = True
     print("[INFO] Normalization patch applied to lemur.data ✓")
 
+
 def main(dry_run=False):
     add_normalization_to_lemur(epoch=5)
     TuneNNGen.main(
-        llm_conf='ds_coder_7b_instruct.json',
+        llm_conf='ds_coder_1.3b_instruct.json',
         llm_tune_conf='NN_dataset_compare.json',
         nn_gen_conf='NN_dataset_compare.json',
         nn_gen_conf_id='dataset_comparison',
-        max_new_tokens=512,  # OlympicCoder emits <think>...</think> before answering
+        max_new_tokens=150,     
+        prompt_batch=1,         # ONNX batch-padding causes empty outputs for shorter prompts
+        num_train_epochs=1,     # 1.3B degrades with > 1 inner epoch per outer cycle
         max_prompts=3 if dry_run else None,
-        onnx_run=False,
+        onnx_run=True,
         classification_mode=True,
     )
+
 
 if __name__ == '__main__':
     if '--test' in sys.argv:

--- a/ab/gpt/TuneNNGen_1_3B_code_.py
+++ b/ab/gpt/TuneNNGen_1_3B_code_.py
@@ -12,7 +12,7 @@ def add_normalization_to_lemur(epoch=5):
     from ab.nn.util.db.Query import tmp_data, fill_hyper_prm
 
 
-    def _fixed_join_nn_query(sql, cur):
+    def _fixed_join_nn_query(sql, limit_clause, cur):
         join_conditions = []
         for c in (sql.same_columns or []):
             join_conditions.append(f'd1.{c} = d2.{c}')
@@ -28,7 +28,7 @@ def add_normalization_to_lemur(epoch=5):
                 d2.prm_id AS prm_id_2
             FROM {tmp_data} d1
             JOIN {tmp_data} d2 ON {on_clause}
-            LIMIT 1000
+            {limit_clause}
         ''')
         return fill_hyper_prm(cur, sql.num_joint_nns)
 
@@ -78,13 +78,14 @@ def add_normalization_to_lemur(epoch=5):
 def main(dry_run=False):
     add_normalization_to_lemur(epoch=5)
     TuneNNGen.main(
-        llm_conf='ds_coder_1.3b_instruct.json',
+        llm_conf='ds_coder_7b_instruct.json',
         llm_tune_conf='NN_dataset_compare.json',
         nn_gen_conf='NN_dataset_compare.json',
         nn_gen_conf_id='dataset_comparison',
-        max_new_tokens=64,
+        max_new_tokens=15,
         max_prompts=3 if dry_run else None,
-        onnx_run=True
+        onnx_run=False,
+        classification_mode=True,
     )
 
 if __name__ == '__main__':

--- a/ab/gpt/TuneNNGen_7B_Classification.py
+++ b/ab/gpt/TuneNNGen_7B_Classification.py
@@ -1,0 +1,99 @@
+import sys
+import ab.nn.api as lemur
+import ab.gpt.TuneNNGen as TuneNNGen
+
+def add_normalization_to_lemur(epoch=5):
+    if getattr(lemur, '_normalization_patched', False):
+        print("[INFO] Normalization patch already applied, skipping.")
+        return
+
+    # Patch join_nn_query to include dataset_2 in SQL SELECT
+    import ab.nn.util.db.Query as Q
+    from ab.nn.util.db.Query import tmp_data, fill_hyper_prm
+
+
+    def _fixed_join_nn_query(sql, limit_clause, cur):
+        join_conditions = []
+        for c in (sql.same_columns or []):
+            join_conditions.append(f'd1.{c} = d2.{c}')
+        for c in (sql.diff_columns or []):
+            join_conditions.append(f'd1.{c} != d2.{c}')
+        join_conditions.append('d1.id < d2.id')
+        on_clause = ' AND '.join(join_conditions)
+
+        cur.execute(f'''
+            SELECT d1.*, d2.nn AS nn_2, d2.nn_code AS nn_code_2,
+                d2.accuracy AS accuracy_2, d2.dataset AS dataset_2,
+                d2.epoch AS epoch_2, d2.metric AS metric_2,
+                d2.prm_id AS prm_id_2
+            FROM {tmp_data} d1
+            JOIN {tmp_data} d2 ON {on_clause}
+            {limit_clause}
+        ''')
+        return fill_hyper_prm(cur, sql.num_joint_nns)
+
+    # Q.join_nn_query = _fixed_join_nn_query
+    # print("[INFO] join_nn_query bug patched ✓")
+    Q.join_nn_query = _fixed_join_nn_query
+
+    # Also patch in Read.py where it's imported directly
+    import ab.nn.util.db.Read as _R
+    _R.join_nn_query = _fixed_join_nn_query
+
+    print("[INFO] join_nn_query bug patched ✓")
+    df_all = lemur.data(only_best_accuracy=False, task='img-classification')
+    best_per_dataset = (
+        df_all[df_all['epoch'] == epoch]
+        .groupby('dataset')['accuracy']
+        .max()
+        .to_dict()
+    )
+    print(f"[INFO] Normalization baseline (epoch {epoch}):")
+    for ds, best in sorted(best_per_dataset.items()):
+        print(f"  {ds:<20} best={best:.4f}")
+
+    original_lemur_data = lemur.data
+
+    def patched_lemur_data(*args, **kwargs):
+        df = original_lemur_data(*args, **kwargs)
+        if 'dataset' in df.columns and 'accuracy' in df.columns:
+            df['norm_acc'] = df.apply(
+                lambda r: round(r['accuracy'] / best_per_dataset.get(r['dataset'], 1.0), 4), axis=1)
+        if 'dataset_2' in df.columns and 'accuracy_2' in df.columns:
+            df['norm_acc_2'] = df.apply(
+                lambda r: round(r['accuracy_2'] / best_per_dataset.get(r['dataset_2'], 1.0), 4), axis=1)
+        if 'norm_acc' in df.columns and 'norm_acc_2' in df.columns:
+            df['better_dataset'] = df.apply(
+                lambda r: r['dataset'] if r['norm_acc'] >= r['norm_acc_2'] else r['dataset_2'], axis=1)
+        return df
+
+    # Preserve cache_clear from original so lemur.data.cache_clear() still works
+    if hasattr(original_lemur_data, 'cache_clear'):
+        patched_lemur_data.cache_clear = original_lemur_data.cache_clear
+
+    lemur.data = patched_lemur_data
+    lemur._normalization_patched = True
+    print("[INFO] Normalization patch applied to lemur.data ✓")
+
+def main(dry_run=False):
+    add_normalization_to_lemur(epoch=5)
+    TuneNNGen.main(
+        llm_conf='deepseek-coder-7b-instruct-v1.5.json',
+        llm_tune_conf='NN_dataset_compare.json',
+        nn_gen_conf='NN_dataset_compare.json',
+        nn_gen_conf_id='dataset_comparison',
+        max_new_tokens=512,  # OlympicCoder emits <think>...</think> before answering
+        max_prompts=3 if dry_run else None,
+        onnx_run=False,
+        classification_mode=True,
+    )
+
+if __name__ == '__main__':
+    if '--test' in sys.argv:
+        add_normalization_to_lemur(epoch=5)
+        df = lemur.data(only_best_accuracy=False, task='img-classification')
+        print(df[['nn', 'dataset', 'accuracy', 'norm_acc']].head(5).to_string(index=False))
+    elif '--dry-run' in sys.argv:
+        main(dry_run=True)
+    else:
+        main()

--- a/ab/gpt/agents/run_agent.py
+++ b/ab/gpt/agents/run_agent.py
@@ -48,8 +48,8 @@ def run_agent_controller(initial_state: dict):
     # Manager uses route function + edge map to decide next node
     workflow.add_conditional_edges("manager", route, edge_map)
 
-    # generator → evaluator directly (no manager in between — evaluation always follows generation)
-    workflow.add_edge("generator", "evaluator")
+    # generator routes based on next_action: "evaluate" → evaluator, "finetune" → finetuner
+    workflow.add_conditional_edges("generator", route, edge_map)
 
     # evaluator, finetuner, predictor all return to manager
     workflow.add_edge("evaluator", "manager")

--- a/ab/gpt/agents/state.py
+++ b/ab/gpt/agents/state.py
@@ -33,6 +33,7 @@ class AgentState(TypedDict, total=False):
     only_best_accuracy: bool
     max_prompts: Optional[int]
     trans_mode: bool
+    classification_mode: bool
     context_length: Optional[int]
     use_unsloth: bool
     unsloth_max_input_length: Optional[int]

--- a/ab/gpt/conf/llm/ds_coder_1.3b_instruct.json
+++ b/ab/gpt/conf/llm/ds_coder_1.3b_instruct.json
@@ -1,9 +1,9 @@
 {
   "base_model_name": "deepseek-ai/deepseek-coder-1.3b-instruct",
   "tokenizer_name": "deepseek-ai/deepseek-coder-1.3b-instruct",
-  "max_length": 512,
-  "model_max_length": 512,
-  "window_size": 512,
+  "max_length": 4096,
+  "model_max_length": 4096,
+  "window_size": 4096,
   "num_epochs": 100,
   "num_test_epochs": 2,
   "use_deepspeed": false,

--- a/ab/gpt/conf/prompt/test/NN_dataset_compare.json
+++ b/ab/gpt/conf/prompt/test/NN_dataset_compare.json
@@ -8,15 +8,17 @@
     "no_repeat": ["dataset"],
     "improve": false,
     "nn_prefixes": [],
-    
+    "output_type": "classification",
+    "nn_code_max_chars": 2000,
+    "max_new_tokens": 20,
     "input_list": [
       { "para": "nn_code",        "value": "nn_code" },
       { "para": "epoch",          "value": "epoch" },
       { "para": "dataset_1",      "value": "dataset" },
       { "para": "norm_acc_1",     "value": "norm_acc" },
       { "para": "dataset_2",      "value": "dataset_2" },
-      { "para": "norm_acc_2",     "value": "norm_acc_2" },
-      { "para": "better_dataset", "value": "better_dataset" }
+      { "para": "norm_acc_2",     "value": "norm_acc_2" }
+     
     ],
 
     "prompt": [
@@ -31,8 +33,8 @@
       "Dataset 2: {dataset_2}",
       "  - Normalized accuracy: {norm_acc_2}",
       "",
-      "On which dataset does this neural network achieve better relative performance?",
-      "Answer with ONLY the dataset name."
+      "On which dataset does this neural network perform better?",
+      "Answer with ONLY the dataset name, nothing else. One of: {dataset_1}, {dataset_2}"
     ],
     "output": [
       "{better_dataset}"

--- a/ab/gpt/conf/prompt/train/NN_dataset_compare.json
+++ b/ab/gpt/conf/prompt/train/NN_dataset_compare.json
@@ -8,15 +8,17 @@
     "no_repeat": ["dataset"],
     "improve": false,
     "nn_prefixes": [],
-    
+    "output_type": "classification",
+    "nn_code_max_chars": 2000,
+    "max_new_tokens": 20,
     "input_list": [
       { "para": "nn_code",        "value": "nn_code" },
       { "para": "epoch",          "value": "epoch" },
       { "para": "dataset_1",      "value": "dataset" },
       { "para": "norm_acc_1",     "value": "norm_acc" },
       { "para": "dataset_2",      "value": "dataset_2" },
-      { "para": "norm_acc_2",     "value": "norm_acc_2" },
-      { "para": "better_dataset", "value": "better_dataset" }
+      { "para": "norm_acc_2",     "value": "norm_acc_2" }
+     
     ],
 
     "prompt": [
@@ -31,8 +33,8 @@
       "Dataset 2: {dataset_2}",
       "  - Normalized accuracy: {norm_acc_2}",
       "",
-      "On which dataset does this neural network achieve better relative performance?",
-      "Answer with ONLY the dataset name."
+      "On which dataset does this neural network perform better?",
+      "Answer with ONLY the dataset name, nothing else. One of: {dataset_1}, {dataset_2}"
     ],
     "output": [
       "{better_dataset}"

--- a/ab/gpt/util/Chatbot.py
+++ b/ab/gpt/util/Chatbot.py
@@ -255,7 +255,8 @@ class ChatBot:
                 formatted_prompt,
                 return_tensors="pt",
                 truncation=True,
-                max_length=self.tokenizer.model_max_length - (max_new_tokens or 4096)
+                max_length=self.tokenizer.model_max_length - (max_new_tokens or 4096),
+                add_special_tokens=False,  # chat template already includes BOS; prevents EOS being appended
             )
 
 

--- a/ab/gpt/util/Chatbot.py
+++ b/ab/gpt/util/Chatbot.py
@@ -118,6 +118,7 @@ class ChatBot:
                 padding=True,
                 truncation=True,
                 max_length=max_input_len,
+                add_special_tokens=False,  # chat template already includes BOS; prevents EOS being appended
             )
         finally:
             self.tokenizer.padding_side = original_padding_side
@@ -142,10 +143,9 @@ class ChatBot:
                 device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 
         inputs = {k: v.to(device) for k, v in inputs.items()}
-        if 'attention_mask' in inputs:
-            input_lengths = inputs['attention_mask'].sum(dim=1).tolist()
-        else:
-            input_lengths = [inputs['input_ids'].shape[1]] * inputs['input_ids'].shape[0]
+        # With left-padding, all sequences in the batch share the same padded input length.
+        # The generated tokens start at index padded_input_length in each output row.
+        padded_input_length = inputs['input_ids'].shape[1]
 
         with torch.no_grad():
             outputs = self.model.generate(
@@ -162,7 +162,7 @@ class ChatBot:
 
         results = []
         for i in range(outputs.shape[0]):
-            generated_ids = outputs[i][int(input_lengths[i]):]
+            generated_ids = outputs[i][padded_input_length:]
             generated = self.tokenizer.decode(generated_ids, skip_special_tokens=True)
             nn = extract_code(generated)
             results.append((nn, extract_hyperparam(generated), extract_transform(generated), generated))
@@ -188,7 +188,7 @@ class ChatBot:
                 generation_kwargs = {
                     "max_new_tokens": max_new_tokens,
                     "do_sample": True,
-                    "max_len": max_len,
+                    "max_length": max_len,
                     "temperature": self.temperature,
                     "top_k": self.top_k,
                     "top_p": self.top_p,

--- a/ab/gpt/util/Tune.py
+++ b/ab/gpt/util/Tune.py
@@ -117,19 +117,40 @@ def nn_gen(
         for pr in key_config["prompt"]:
             prompt += pr + "\n"
 
-        data = (
-            lemur.data(only_best_accuracy=True, task=key_config["task"])
-            .groupby(by="nn")
-            .sample(n=1)[:test_nn]
-        )
+        num_joint_nns = key_config.get("num_joint_nns", 1)
+        use_join = num_joint_nns >= 2
 
-        addon_task = key_config.get("addon_task")
-        addon_data = lemur.data(only_best_accuracy=True, task=addon_task) if addon_task else None
+        if use_join:
+            from ab.nn.util.db.Query import JoinConf
+            data = lemur.data(
+                only_best_accuracy=True,
+                task=key_config["task"],
+                sql=JoinConf(
+                    num_joint_nns=num_joint_nns,
+                    same_columns=tuple(key_config.get("keep_same", [])),
+                    diff_columns=tuple(key_config.get("no_repeat", [])),
+                    enhance_nn=key_config.get("improve", False),
+                ),
+            )[:test_nn]
+            addon_data = None
+        else:
+            data = (
+                lemur.data(only_best_accuracy=True, task=key_config["task"])
+                .groupby(by="nn")
+                .sample(n=1)[:test_nn]
+            )
+            addon_task = key_config.get("addon_task")
+            addon_data = lemur.data(only_best_accuracy=True, task=addon_task) if addon_task else None
 
+        output_type = key_config.get("output_type", "code")
+
+        nn_code_max_chars = key_config.get("nn_code_max_chars")
         for _, row in data.iterrows():
             para_dict = {}
             for it in key_config["input_list"]:
                 para_dict[it["para"]] = row[it["value"]]
+            if nn_code_max_chars and "nn_code" in para_dict and isinstance(para_dict["nn_code"], str):
+                para_dict["nn_code"] = para_dict["nn_code"][:nn_code_max_chars]
 
             if addon_data is not None and not addon_data.empty:
                 available_addon = addon_data.loc[addon_data.nn != row["nn"]]
@@ -139,14 +160,14 @@ def nn_gen(
                         for it in key_config["addon_list"]:
                             para_dict[it["para"]] = addon_row[it["value"]]
 
-            prompts.append((prompt.format(**para_dict), row))
+            prompts.append((prompt.format(**para_dict), row, output_type))
 
     models_dir = synth_dir(out_path)
 
     if use_delta:
         for idx, prompt_data in tqdm(enumerate(prompts)):
             model_dir = models_dir / f"B{idx}"
-            prompt_text, origdf = prompt_data
+            prompt_text, origdf, output_type = prompt_data
 
             seed = epoch * 10000 + idx
             torch.manual_seed(seed)
@@ -279,7 +300,7 @@ def nn_gen(
     else:
         pending = []
         for idx, prompt_data in tqdm(enumerate(prompts)):
-            prompt_text, origdf = prompt_data
+            prompt_text, origdf, output_type = prompt_data
 
             if unsloth_max_input_length:
                 in_text = [{"role": "user", "content": prompt_text}]
@@ -289,7 +310,7 @@ def nn_gen(
                     print(f'Prompt is too long, skipping...')
                     continue
 
-            pending.append((idx, prompt_text, origdf))
+            pending.append((idx, prompt_text, origdf, output_type))
 
         if prompt_batch < 1:
             prompt_batch = 1
@@ -305,11 +326,18 @@ def nn_gen(
             else:
                 batch_outputs = [chat_bot.chat(p, engineer_prompt=False, max_new_tokens=max_new_tokens) for p in batch_prompts]
 
-            for (idx, prompt_text, origdf), output in zip(batch, batch_outputs):
+            for (idx, prompt_text, origdf, output_type), output in zip(batch, batch_outputs):
                 model_dir = models_dir / f"B{idx}"
                 code, hp, tr, full_out = output
 
                 makedirs(model_dir, exist_ok=True)
+
+                if output_type == 'classification':
+                    create_file(model_dir, new_out_file, full_out)
+                    if origdf is not None:
+                        origdf.to_pickle(model_dir / 'dataframe.df')
+                    continue
+
                 if save_llm_output:
                     create_file(model_dir, new_out_file, full_out)
 
@@ -486,6 +514,17 @@ def _has_generated_nn_code(out_path) -> bool:
     return False
 
 
+def _has_generated_output(out_path) -> bool:
+    """Returns True if at least one synthesized model directory B*/ contains full_output.txt."""
+    models_dir = synth_dir(out_path)
+    if not exists(models_dir):
+        return False
+    for bdir in glob.glob(str(models_dir / "B*")):
+        if isfile(os.path.join(bdir, new_out_file)):
+            return True
+    return False
+
+
 def generate_step(state: AgentState) -> dict:
     epoch = state["current_epoch"]
     skip_epoch = state.get("skip_epoch", 0)
@@ -528,14 +567,17 @@ def generate_step(state: AgentState) -> dict:
             use_backbone=state.get("use_backbone",False),
         )
 
-    if not _has_generated_nn_code(out_path):
-        print(f"[INFO] No code generated at epoch {epoch}, skipping evaluation")
+    classification_mode = state.get("classification_mode", False)
+    has_output = _has_generated_output(out_path) if classification_mode else _has_generated_nn_code(out_path)
+    if not has_output:
+        print(f"[INFO] No output generated at epoch {epoch}, skipping evaluation")
         return {"next_action": "finetune"}
 
     return {"next_action": "evaluate"}
 
 
-def _evaluate_epoch(epoch, out_path, nn_name_prefix, nn_train_epochs, trans_mode):
+def _evaluate_epoch(epoch, out_path, nn_name_prefix, nn_train_epochs, trans_mode,
+                    classification_mode=False):
     """
     Single source of truth for one evaluation epoch.
     Runs NNEval (trains generated NNs for nn_train_epochs and records accuracy).
@@ -546,7 +588,11 @@ def _evaluate_epoch(epoch, out_path, nn_name_prefix, nn_train_epochs, trans_mode
     results = {"epoch": epoch}
 
     if exists(models_dir):
-        if trans_mode:
+        if classification_mode:
+            from ab.gpt.ClassificationEval import evaluate_epoch as cls_eval
+            cls_result = cls_eval(models_dir)
+            results[f"epoch_{epoch + 1}_accuracy"] = cls_result["accuracy"]
+        elif trans_mode:
             try:
                 run_eval(epoch_num=epoch, FT_MODE=True)
                 print('[DEBUG] Release_memory.')
@@ -645,6 +691,7 @@ def evaluate_step(state: AgentState) -> dict:
         state.get("nn_name_prefix"),
         state["nn_train_epochs"],
         state.get("trans_mode", False),
+        state.get("classification_mode", False),
     )
 
     updates = {}
@@ -790,7 +837,8 @@ def tune(
     use_predictor=False,
     use_backbone=False,
     enable_merge=False,
-    use_unsloth=False
+    use_unsloth=False,
+    classification_mode=False,
 ):
     if not isinstance(conf_keys, (list, tuple)):
         conf_keys = (conf_keys,)
@@ -907,7 +955,8 @@ def tune(
 
         "use_predictor": use_predictor,
         "use_backbone": use_backbone,
-        "enable_merge": enable_merge
+        "enable_merge": enable_merge,
+        "classification_mode": classification_mode,
     }
 
     shutil.rmtree(epoch_dir(), ignore_errors=True)
@@ -927,7 +976,8 @@ def tune(
             else:
                 nn_gen(epoch, out_path, chat_bot, conf_keys, nn_train_epochs, prompt_dict, test_nn, max_new_tokens, save_llm_output, nn_name_prefix, unsloth_max_input_length, prompt_batch, use_backbone=use_backbone)
 
-            _evaluate_epoch(epoch, out_path, nn_name_prefix, nn_train_epochs, trans_mode)
+            _evaluate_epoch(epoch, out_path, nn_name_prefix, nn_train_epochs, trans_mode,
+                            classification_mode)
 
         print(f'[DEBUG]Perform finetune at epoch {epoch}.')
         model, chat_bot = _finetune_epoch(

--- a/ab/gpt/util/Tune_Onnx.py
+++ b/ab/gpt/util/Tune_Onnx.py
@@ -67,7 +67,8 @@ def flatten_chunks(data):
 def tune(test_nn, nn_train_epochs, skip_epoch, llm_path, llm_tune_conf, nn_gen_conf, conf_keys, llm_conf,
          training_args, peft_config, max_prompts=None, save_llm_output=True, max_new_tokens=16 * 1024,
          nn_name_prefix=None, temperature=1.0, top_k=50, top_p=0.9, test_metric=None, onnx_run=False, trans_mode=False,
-         prompt_batch=1, use_unsloth=False):
+         prompt_batch=1, use_unsloth=False,
+         classification_mode=False, use_agents=False, use_predictor=False, enable_merge=False, use_backbone=False):
 
     if not isinstance(conf_keys, (list, tuple)):
         conf_keys = (conf_keys,)
@@ -242,7 +243,7 @@ def tune(test_nn, nn_train_epochs, skip_epoch, llm_path, llm_tune_conf, nn_gen_c
         if epoch < skip_epoch:
             print(f'Skipped nn generation at epoch {epoch}')
         else:
-            nn_gen(epoch, out_path, chat_bot, conf_keys, nn_train_epochs, prompt_dict, test_nn, max_new_tokens, save_llm_output, nn_name_prefix, prompt_batch)
+            nn_gen(epoch, out_path, chat_bot, conf_keys, nn_train_epochs, prompt_dict, test_nn, max_new_tokens, save_llm_output, nn_name_prefix, prompt_batch, classification_mode=classification_mode)
         # ============================================================
         # FREE ONNX MODEL FROM GPU BEFORE FINE-TUNING
         # ============================================================
@@ -399,7 +400,7 @@ def tune(test_nn, nn_train_epochs, skip_epoch, llm_path, llm_tune_conf, nn_gen_c
             print('[INFO] ========================================')
 
           
-def nn_gen(epoch, out_path, chat_bot, conf_keys, nn_train_epochs, prompt_dict, test_nn, max_new_tokens, save_llm_output, nn_name_prefix, prompt_batch):
+def nn_gen(epoch, out_path, chat_bot, conf_keys, nn_train_epochs, prompt_dict, test_nn, max_new_tokens, save_llm_output, nn_name_prefix, prompt_batch, classification_mode=False):
   
     print('Preparing prompts for generation, this might take a while...')
     
@@ -422,6 +423,9 @@ def nn_gen(epoch, out_path, chat_bot, conf_keys, nn_train_epochs, prompt_dict, t
         # addon_task = prompt_dict_key.get('addon_task')
         # addon_data = lemur.data(only_best_accuracy=True, task=addon_task) if addon_task else None
         from ab.nn.api import JoinConf
+
+        output_type = key_config.get('output_type', 'code')
+        nn_code_max_chars = key_config.get('nn_code_max_chars')
 
         num_joint_nns = prompt_dict_key.get('num_joint_nns') or 1
         if num_joint_nns >= 2:
@@ -447,6 +451,9 @@ def nn_gen(epoch, out_path, chat_bot, conf_keys, nn_train_epochs, prompt_dict, t
             for it in prompt_dict_key['input_list']:
                 para_dict[it['para']] = row[it['value']]
 
+            if nn_code_max_chars and 'nn_code' in para_dict and isinstance(para_dict['nn_code'], str):
+                para_dict['nn_code'] = para_dict['nn_code'][:nn_code_max_chars]
+
             if addon_data is not None and not addon_data.empty:
                 available_addon = addon_data.loc[addon_data.nn != row['nn']]
                 if not available_addon.empty:
@@ -455,7 +462,7 @@ def nn_gen(epoch, out_path, chat_bot, conf_keys, nn_train_epochs, prompt_dict, t
                         for it in prompt_dict_key['addon_list']:
                             para_dict[it['para']] = addon_row[it['value']]
 
-            prompts.append((prompt.format(**para_dict), row))
+            prompts.append((prompt.format(**para_dict), row, output_type))
 
     models_dir = synth_dir(out_path)
     pending = list(enumerate(prompts))
@@ -475,8 +482,17 @@ def nn_gen(epoch, out_path, chat_bot, conf_keys, nn_train_epochs, prompt_dict, t
 
         for (idx, prompt_data), output in zip(batch, batch_outputs):
             model_dir = models_dir / f'B{idx}'
-            prompt, origdf = prompt_data
+            prompt, origdf, output_type = prompt_data
             code, hp, tr, full_out = output
+
+            makedirs(model_dir, exist_ok=True)
+
+            # Classification: save raw output + ground truth, skip code extraction
+            if output_type == 'classification':
+                create_file(model_dir, new_out_file, full_out)
+                if origdf is not None:
+                    origdf.to_pickle(model_dir / 'dataframe.df')
+                continue
 
             # DEBUG BLOCK - to check the output of the llm
             print(f"[DEBUG B{idx}] Generated output length: {len(full_out) if full_out else 0} chars")
@@ -485,8 +501,6 @@ def nn_gen(epoch, out_path, chat_bot, conf_keys, nn_train_epochs, prompt_dict, t
 
             if save_llm_output:
                 create_file(model_dir, new_out_file, full_out)
-
-            makedirs(model_dir, exist_ok=True)
 
             if use_delta and origdf is not None:
                 try:
@@ -557,7 +571,11 @@ def nn_gen(epoch, out_path, chat_bot, conf_keys, nn_train_epochs, prompt_dict, t
             release_memory()
 
     if exists(models_dir):
-        NNEval.main(nn_name_prefix, nn_train_epochs, epoch)
+        if classification_mode:
+            from ab.gpt.ClassificationEval import evaluate_epoch as cls_eval
+            cls_eval(models_dir)
+        else:
+            NNEval.main(nn_name_prefix, nn_train_epochs, epoch)
 
     print('[DEBUG] Release_memory.')
     release_memory()

--- a/ab/gpt/util/prompt/NNGenPrompt.py
+++ b/ab/gpt/util/prompt/NNGenPrompt.py
@@ -48,11 +48,14 @@ class NNGenPrompt(Prompt):
             # For JOIN queries, do NOT pass max_rows — the LIMIT applies before
             # the JOIN and causes an O(n²) correlated scan. Slice the result after.
             use_join = num_joint_nns >= 2
+            # For JOIN queries, cap rows to avoid O(n²) scan on the temp table.
+            # Slice to n_training_prompts after the fact instead of relying on LIMIT inside the JOIN.
+            join_cap = 1000
             data = lemur.data(
                 only_best_accuracy=only_best_accuracy,
                 task=key_dict.get('task'),
                 nn_prefixes=tuple(key_dict.get('nn_prefixes')),
-                max_rows=n_training_prompts,
+                max_rows=join_cap if use_join else n_training_prompts,
                 sql=None if not use_join else JoinConf(
                     num_joint_nns=num_joint_nns,
                     same_columns=tuple(key_dict.get('keep_same', [])),
@@ -73,6 +76,20 @@ class NNGenPrompt(Prompt):
                 para_dict = dict()
                 for it in prompt_dict[key]['input_list']:
                     para_dict[it['para']] = row[it['value']]
+
+                nn_code_max_chars = key_dict.get('nn_code_max_chars')
+                if nn_code_max_chars and 'nn_code' in para_dict and isinstance(para_dict['nn_code'], str):
+                    para_dict['nn_code'] = para_dict['nn_code'][:nn_code_max_chars]
+
+                # Inject columns referenced in the output template but absent from input_list
+                # (e.g. better_dataset for classification tasks). Only applies when output_type
+                # is 'classification' so other tasks are unaffected.
+                if key_dict.get('output_type') == 'classification':
+                    output_template = '\n'.join(key_dict['output'])
+                    for col in row.index:
+                        if f'{{{col}}}' in output_template and col not in para_dict:
+                            para_dict[col] = row[col]
+
                 inst = prompt.format(**para_dict)
 
                 # Compute delta if delta mode is enabled


### PR DESCRIPTION
Implementation of the evaluator for the dataset-comparison classification task. It scans model output directories, extracts the predicted dataset name from LLM responses (so far tested on DeepSeek 1.3B Instruct, DeepSeek Coder 7B Instruct and OlympicCoder 7B) with prompt-leakage stripping and normalized
substring matching), compares it against the ground truth (better_dataset) field,
and writes per-model (classification_eval.json) files along the run.

The evaluator is wired into the tuning pipeline (Tune.py) so that classification
accuracy is computed automatically at the end of each training epoch, replacing
the need for a separate manual evaluation step. 