### PR TITLE
Add more dataset classification prompts & add datasets metadata

### DIFF
--- a/ab/gpt/TuneNNGen_1_3B_Classification_Onnx.py
+++ b/ab/gpt/TuneNNGen_1_3B_Classification_Onnx.py
@@ -1,6 +1,11 @@
+import json
 import sys
+from pathlib import Path
 import ab.nn.api as lemur
 import ab.gpt.TuneNNGen as TuneNNGen
+
+_DATASET_META = json.loads((Path(__file__).parent / 'conf' / 'dataset_meta.json').read_text())
+_META_FIELDS = ['num_train_images', 'img_size', 'num_channels', 'num_classes']
 
 def add_normalization_to_lemur(epoch=5):
     if getattr(lemur, '_normalization_patched', False):
@@ -62,6 +67,12 @@ def add_normalization_to_lemur(epoch=5):
         if 'norm_acc' in df.columns and 'norm_acc_2' in df.columns:
             df['better_dataset'] = df.apply(
                 lambda r: r['dataset'] if r['norm_acc'] >= r['norm_acc_2'] else r['dataset_2'], axis=1)
+        if 'dataset' in df.columns:
+            for field in _META_FIELDS:
+                df[f'{field}_1'] = df['dataset'].map(lambda d: _DATASET_META.get(d, {}).get(field))
+        if 'dataset_2' in df.columns:
+            for field in _META_FIELDS:
+                df[f'{field}_2'] = df['dataset_2'].map(lambda d: _DATASET_META.get(d, {}).get(field))
         return df
 
     if hasattr(original_lemur_data, 'cache_clear'):
@@ -76,8 +87,8 @@ def main(dry_run=False):
     add_normalization_to_lemur(epoch=5)
     TuneNNGen.main(
         llm_conf='ds_coder_1.3b_instruct.json',
-        llm_tune_conf='NN_dataset_compare.json',
-        nn_gen_conf='NN_dataset_compare.json',
+        llm_tune_conf='NN_dataset_compare_with_metadata.json',
+        nn_gen_conf='NN_dataset_compare_with_metadata.json',
         nn_gen_conf_id='dataset_comparison',
         max_new_tokens=150,     
         prompt_batch=1,         # ONNX batch-padding causes empty outputs for shorter prompts

--- a/ab/gpt/TuneNNGen_7B_Classification.py
+++ b/ab/gpt/TuneNNGen_7B_Classification.py
@@ -1,6 +1,11 @@
+import json
 import sys
+from pathlib import Path
 import ab.nn.api as lemur
 import ab.gpt.TuneNNGen as TuneNNGen
+
+_DATASET_META = json.loads((Path(__file__).parent / 'conf' / 'dataset_meta.json').read_text())
+_META_FIELDS = ['num_train_images', 'img_size', 'num_channels', 'num_classes']
 
 def add_normalization_to_lemur(epoch=5):
     if getattr(lemur, '_normalization_patched', False):
@@ -65,6 +70,12 @@ def add_normalization_to_lemur(epoch=5):
         if 'norm_acc' in df.columns and 'norm_acc_2' in df.columns:
             df['better_dataset'] = df.apply(
                 lambda r: r['dataset'] if r['norm_acc'] >= r['norm_acc_2'] else r['dataset_2'], axis=1)
+        if 'dataset' in df.columns:
+            for field in _META_FIELDS:
+                df[f'{field}_1'] = df['dataset'].map(lambda d: _DATASET_META.get(d, {}).get(field))
+        if 'dataset_2' in df.columns:
+            for field in _META_FIELDS:
+                df[f'{field}_2'] = df['dataset_2'].map(lambda d: _DATASET_META.get(d, {}).get(field))
         return df
 
     # Preserve cache_clear from original so lemur.data.cache_clear() still works
@@ -79,13 +90,14 @@ def main(dry_run=False):
     add_normalization_to_lemur(epoch=5)
     TuneNNGen.main(
         llm_conf='ds_coder_7b_instruct.json',
-        llm_tune_conf='NN_dataset_compare.json',
-        nn_gen_conf='NN_dataset_compare.json',
+        llm_tune_conf='NN_dataset_compare_with_metadata.json',
+        nn_gen_conf='NN_dataset_compare_with_metadata.json',
         nn_gen_conf_id='dataset_comparison',
         max_new_tokens=512,  # OlympicCoder emits <think>...</think> before answering
         max_prompts=3 if dry_run else None,
         onnx_run=False,
         classification_mode=True,
+        test_nn=30
     )
 
 if __name__ == '__main__':

--- a/ab/gpt/conf/prompt/test/NN_dataset_compare_code_based.json
+++ b/ab/gpt/conf/prompt/test/NN_dataset_compare_code_based.json
@@ -1,0 +1,36 @@
+{
+  "dataset_comparison": {
+    "comment": [],
+    "task": "img-classification",
+    "addon_task": "img-classification",
+    "num_joint_nns": 2,
+    "keep_same": ["epoch", "metric", "task", "nn"],
+    "no_repeat": ["dataset"],
+    "improve": false,
+    "nn_prefixes": [],
+    "output_type": "classification",
+    "nn_code_max_chars": 2000,
+    "max_new_tokens": 20,
+    "input_list": [
+      { "para": "nn_code",               "value": "nn_code" },
+      { "para": "epoch",                 "value": "epoch" },
+      { "para": "dataset_1",             "value": "dataset" },
+      { "para": "dataset_2",             "value": "dataset_2" }
+
+    ],
+    "prompt": [
+      "You are an expert in deep learning architecture analysis.",
+      "A neural network was trained on two image classification datasets for {epoch} epochs.",
+      "Analyze the architecture code below and predict on which dataset it achieves higher relative accuracy.",
+      "",
+      "Neural network code:",
+      "{nn_code}",
+      "",
+      "Which dataset does this network perform better on?",
+      "Answer with ONLY the dataset name, nothing else. One of: {dataset_1}, {dataset_2}"
+    ],
+    "output": [
+      "{better_dataset}"
+    ]
+  }
+}

--- a/ab/gpt/conf/prompt/test/NN_dataset_compare_normalized_acc.json
+++ b/ab/gpt/conf/prompt/test/NN_dataset_compare_normalized_acc.json
@@ -1,0 +1,43 @@
+{
+  "dataset_comparison": {
+    "comment": [],
+    "task": "img-classification",
+    "addon_task": "img-classification",
+    "num_joint_nns": 2,
+    "keep_same": ["epoch", "metric", "task", "nn"],
+    "no_repeat": ["dataset"],
+    "improve": false,
+    "nn_prefixes": [],
+    "output_type": "classification",
+    "nn_code_max_chars": 2000,
+    "max_new_tokens": 20,
+    "input_list": [
+      { "para": "nn_code",        "value": "nn_code" },
+      { "para": "epoch",          "value": "epoch" },
+      { "para": "dataset_1",      "value": "dataset" },
+      { "para": "norm_acc_1",     "value": "norm_acc" },
+      { "para": "dataset_2",      "value": "dataset_2" },
+      { "para": "norm_acc_2",     "value": "norm_acc_2" }
+     
+    ],
+
+    "prompt": [
+      "A neural network was trained on two different image classification datasets for {epoch} epochs.",
+      "",
+      "Neural Network Code:",
+      "{nn_code}",
+      "",
+      "Dataset 1: {dataset_1}",
+      "  - Normalized accuracy: {norm_acc_1}",
+      "",
+      "Dataset 2: {dataset_2}",
+      "  - Normalized accuracy: {norm_acc_2}",
+      "",
+      "On which dataset does this neural network perform better?",
+      "Answer with ONLY the dataset name, nothing else. One of: {dataset_1}, {dataset_2}"
+    ],
+    "output": [
+      "{better_dataset}"
+    ]
+  }
+}

--- a/ab/gpt/conf/prompt/test/NN_dataset_compare_with_metadata.json
+++ b/ab/gpt/conf/prompt/test/NN_dataset_compare_with_metadata.json
@@ -1,0 +1,55 @@
+{
+  "dataset_comparison": {
+    "comment": [],
+    "task": "img-classification",
+    "addon_task": "img-classification",
+    "num_joint_nns": 2,
+    "keep_same": ["epoch", "metric", "task", "nn"],
+    "no_repeat": ["dataset"],
+    "improve": false,
+    "nn_prefixes": [],
+    "output_type": "classification",
+    "nn_code_max_chars": 2000,
+    "max_new_tokens": 20,
+    "input_list": [
+      { "para": "nn_code",               "value": "nn_code" },
+      { "para": "epoch",                 "value": "epoch" },
+      { "para": "dataset_1",             "value": "dataset" },
+      { "para": "num_train_images_1",    "value": "num_train_images_1" },
+      { "para": "img_size_1",            "value": "img_size_1" },
+      { "para": "num_channels_1",        "value": "num_channels_1" },
+      { "para": "num_classes_1",         "value": "num_classes_1" },
+      { "para": "dataset_2",             "value": "dataset_2" },
+      { "para": "num_train_images_2",    "value": "num_train_images_2" },
+      { "para": "img_size_2",            "value": "img_size_2" },
+      { "para": "num_channels_2",        "value": "num_channels_2" },
+      { "para": "num_classes_2",         "value": "num_classes_2" }
+    ],
+
+    "prompt": [
+      "A neural network was trained on two different image classification datasets for {epoch} epochs.",
+      "",
+      "Network architecture:",
+      "{nn_code}",
+      "",
+      "Dataset 1: {dataset_1}",
+      "  - Training images: {num_train_images_1}",
+      "  - Image size: {img_size_1}x{img_size_1} px",
+      "  - Channels: {num_channels_1}",
+      "  - Number of classes: {num_classes_1}",
+      "",
+      "Dataset 2: {dataset_2}",
+      "  - Training images: {num_train_images_2}",
+      "  - Image size: {img_size_2}x{img_size_2} px",
+      "  - Channels: {num_channels_2}",
+      "  - Number of classes: {num_classes_2}",
+      "",
+      "Based on the network architecture and the properties of the two datasets,",
+      "on which dataset does this network achieve higher relative accuracy?",
+      "Answer with ONLY the dataset name, nothing else. One of: {dataset_1}, {dataset_2}"
+    ],
+    "output": [
+      "{better_dataset}"
+    ]
+  }
+}

--- a/ab/gpt/conf/prompt/train/NN_dataset_compare_code_based.json
+++ b/ab/gpt/conf/prompt/train/NN_dataset_compare_code_based.json
@@ -1,0 +1,37 @@
+{
+  "dataset_comparison": {
+    "comment": [],
+    "task": "img-classification",
+    "addon_task": "img-classification",
+    "num_joint_nns": 2,
+    "keep_same": ["epoch", "metric", "task", "nn"],
+    "no_repeat": ["dataset"],
+    "improve": false,
+    "nn_prefixes": [],
+    "output_type": "classification",
+    "nn_code_max_chars": 2000,
+    "max_new_tokens": 20,
+    "input_list": [
+      { "para": "nn_code",               "value": "nn_code" },
+      { "para": "epoch",                 "value": "epoch" },
+      { "para": "dataset_1",             "value": "dataset" },
+      { "para": "dataset_2",             "value": "dataset_2" }
+
+    ],
+
+    "prompt": [
+      "You are an expert in deep learning architecture analysis.",
+      "A neural network was trained on two image classification datasets for {epoch} epochs.",
+      "Analyze the architecture code below and predict on which dataset it achieves higher relative accuracy.",
+      "",
+      "Neural network code:",
+      "{nn_code}",
+      "",
+      "Which dataset does this network perform better on?",
+      "Answer with ONLY the dataset name, nothing else. One of: {dataset_1}, {dataset_2}"
+    ],
+    "output": [
+      "{better_dataset}"
+    ]
+  }
+}

--- a/ab/gpt/conf/prompt/train/NN_dataset_compare_normalized_acc.json
+++ b/ab/gpt/conf/prompt/train/NN_dataset_compare_normalized_acc.json
@@ -1,0 +1,43 @@
+{
+  "dataset_comparison": {
+    "comment": [],
+    "task": "img-classification",
+    "addon_task": "img-classification",
+    "num_joint_nns": 2,
+    "keep_same": ["epoch", "metric", "task", "nn"],
+    "no_repeat": ["dataset"],
+    "improve": false,
+    "nn_prefixes": [],
+    "output_type": "classification",
+    "nn_code_max_chars": 2000,
+    "max_new_tokens": 20,
+    "input_list": [
+      { "para": "nn_code",        "value": "nn_code" },
+      { "para": "epoch",          "value": "epoch" },
+      { "para": "dataset_1",      "value": "dataset" },
+      { "para": "norm_acc_1",     "value": "norm_acc" },
+      { "para": "dataset_2",      "value": "dataset_2" },
+      { "para": "norm_acc_2",     "value": "norm_acc_2" }
+     
+    ],
+
+    "prompt": [
+      "A neural network was trained on two different image classification datasets for {epoch} epochs.",
+      "",
+      "Neural Network Code:",
+      "{nn_code}",
+      "",
+      "Dataset 1: {dataset_1}",
+      "  - Normalized accuracy: {norm_acc_1}",
+      "",
+      "Dataset 2: {dataset_2}",
+      "  - Normalized accuracy: {norm_acc_2}",
+      "",
+      "On which dataset does this neural network perform better?",
+      "Answer with ONLY the dataset name, nothing else. One of: {dataset_1}, {dataset_2}"
+    ],
+    "output": [
+      "{better_dataset}"
+    ]
+  }
+}

--- a/ab/gpt/conf/prompt/train/NN_dataset_compare_with_metadata.json
+++ b/ab/gpt/conf/prompt/train/NN_dataset_compare_with_metadata.json
@@ -1,0 +1,55 @@
+{
+  "dataset_comparison": {
+    "comment": [],
+    "task": "img-classification",
+    "addon_task": "img-classification",
+    "num_joint_nns": 2,
+    "keep_same": ["epoch", "metric", "task", "nn"],
+    "no_repeat": ["dataset"],
+    "improve": false,
+    "nn_prefixes": [],
+    "output_type": "classification",
+    "nn_code_max_chars": 2000,
+    "max_new_tokens": 20,
+    "input_list": [
+      { "para": "nn_code",               "value": "nn_code" },
+      { "para": "epoch",                 "value": "epoch" },
+      { "para": "dataset_1",             "value": "dataset" },
+      { "para": "num_train_images_1",    "value": "num_train_images_1" },
+      { "para": "img_size_1",            "value": "img_size_1" },
+      { "para": "num_channels_1",        "value": "num_channels_1" },
+      { "para": "num_classes_1",         "value": "num_classes_1" },
+      { "para": "dataset_2",             "value": "dataset_2" },
+      { "para": "num_train_images_2",    "value": "num_train_images_2" },
+      { "para": "img_size_2",            "value": "img_size_2" },
+      { "para": "num_channels_2",        "value": "num_channels_2" },
+      { "para": "num_classes_2",         "value": "num_classes_2" }
+    ],
+
+    "prompt": [
+      "A neural network was trained on two different image classification datasets for {epoch} epochs.",
+      "",
+      "Network architecture:",
+      "{nn_code}",
+      "",
+      "Dataset 1: {dataset_1}",
+      "  - Training images: {num_train_images_1}",
+      "  - Image size: {img_size_1}x{img_size_1} px",
+      "  - Channels: {num_channels_1}",
+      "  - Number of classes: {num_classes_1}",
+      "",
+      "Dataset 2: {dataset_2}",
+      "  - Training images: {num_train_images_2}",
+      "  - Image size: {img_size_2}x{img_size_2} px",
+      "  - Channels: {num_channels_2}",
+      "  - Number of classes: {num_classes_2}",
+      "",
+      "Based on the network architecture and the properties of the two datasets,",
+      "on which dataset does this network achieve higher relative accuracy?",
+      "Answer with ONLY the dataset name, nothing else. One of: {dataset_1}, {dataset_2}"
+    ],
+    "output": [
+      "{better_dataset}"
+    ]
+  }
+}


### PR DESCRIPTION
Added two additional prompts for fine-tuning on predicting dataset. 

The first brings some of the dataset metadata into the prompt.
The second does not include any information about the datasets properties or accuracies, the LLM then is asked to predict the dataset depending solely on the model architecture. 

