### PR TITLE
Add self-contained iterative KTO fine-tuning pipeline for NNGPT

### DIFF
--- a/ab/gpt/TuneNNGenKTO.py
+++ b/ab/gpt/TuneNNGenKTO.py
@@ -34,7 +34,7 @@ from typing import Any, Dict, List, Optional
 
 import torch
 from datasets import Dataset
-from peft import LoraConfig, PeftModel
+from peft import PeftModel
 from transformers import TrainingArguments
 
 from ab.gpt.util.Const import conf_llm_dir, nngpt_dir
@@ -331,14 +331,15 @@ def run_kto(
     # ── 2. LoRA config ──────────────────────────────────────────────────────
     if tune_layers is None:
         tune_layers = range(START_LAYER, END_LAYER)
-    peft_config = LoraConfig(
+    from ab.gpt.util.KTO import kto_lora_config
+    peft_config = kto_lora_config(
+        target_modules=target_modules,
         r=r,
         lora_alpha=lora_alpha,
-        target_modules=list(target_modules) if not isinstance(target_modules, list) else target_modules,
-        layers_to_transform=list(tune_layers),
         lora_dropout=lora_dropout,
         bias=bias,
         task_type=task_type,
+        layers_to_transform=tune_layers,
     )
 
     # ── 3. Load model + tokenizer ───────────────────────────────────────────

--- a/ab/gpt/TuneNNGenKTO.py
+++ b/ab/gpt/TuneNNGenKTO.py
@@ -1,0 +1,566 @@
+"""
+ab/gpt/TuneNNGenKTO.py — KTO fine-tuning entry point.
+
+Analog of ab/gpt/TuneNNGen.py for KTO.  Spawned as a subprocess by
+KTOIterativeFinetuner.run_finetuning() once per cycle, after the
+KTODataManager has written the cycle's kto_train.jsonl.
+
+Two ways to invoke:
+
+  1. Per-cycle fine-tune (called by KTOIterativeFinetuner):
+       python -m ab.gpt.TuneNNGenKTO \\
+           --llm_conf ds_coder_1.3b_instruct.json \\
+           --kto_data_file out/kto_pipeline/cycle_3/chat_data_cycle_3/kto_train.jsonl \\
+           --peft out/kto_pipeline/cycle_2/checkpoint \\
+           --kto_beta 0.1 ...
+
+  2. Full iterative pipeline:
+       python -m ab.gpt.TuneNNGenKTO --run_iterative_pipeline \\
+           --llm_conf ds_coder_1.3b_instruct.json --cycles 21 ...
+       (Delegates to KTOIterativeFinetuner; same CLI as the iterative
+        module itself.)
+
+Output adapter is saved to out/qlora-kto/final/, which the iterative
+pipeline then isolates to out/kto_pipeline/cycle_N/checkpoint/.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import torch
+from datasets import Dataset
+from peft import LoraConfig, PeftModel
+from transformers import TrainingArguments
+
+from ab.gpt.util.Const import conf_llm_dir, nngpt_dir
+from ab.gpt.util.LLMUtil import quantization_config_4bit
+from ab.nn.util.Const import out_dir
+
+
+# ── Defaults (mirrors TuneNNGen.py style) ───────────────────────────────────
+LLM_CONF = "ds_coder_1.3b_instruct.json"
+NUM_TRAIN_EPOCHS = 5
+LR_SCHEDULER = "cosine"
+MAX_GRAD_NORM = 1.0
+PER_DEVICE_TRAIN_BATCH_SIZE = 2   # KTO requires actual batch size > 1 for valid KL estimation
+GRADIENT_ACCUMULATION_STEPS = 4
+WARMUP_RATIO = 0.05
+LOGGING_STEPS = 10
+LEARNING_RATE = 1e-5
+WEIGHT_DECAY = 0.01
+WARMUP_STEPS = 20
+OPTIMIZER = "paged_adamw_8bit"
+
+# LoRA hyperparameters
+R = 32
+LORA_ALPHA = 32
+LORA_DROPOUT = 0.05
+TARGET_MODULES = ("q_proj", "k_proj", "v_proj", "o_proj", "up_proj", "down_proj", "gate_proj")
+TASK_TYPE = "CAUSAL_LM"
+BIAS = "none"
+START_LAYER = 0
+END_LAYER = 24
+
+# KTO hyperparameters
+KTO_BETA = 0.1
+KTO_DESIRABLE_WEIGHT = 1.0
+KTO_UNDESIRABLE_WEIGHT = 1.0
+MAX_PROMPT_LENGTH = 4096
+MAX_COMPLETION_LENGTH = 2048
+
+# Where the final KTO adapter lands (KTOIterativeFinetuner copies it
+# out to out/kto_pipeline/cycle_N/checkpoint/)
+KTO_OUTPUT_DIR = out_dir / "qlora-kto" / "final"
+
+
+# ── Data loading ────────────────────────────────────────────────────────────
+
+def _load_kto_jsonl(path: Path) -> List[Dict[str, Any]]:
+    """Load a kto_train.jsonl produced by KTODataManager."""
+    records: List[Dict[str, Any]] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line_num, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError as e:
+                print(f"[KTO][WARN] line {line_num} of {path}: {e}")
+    print(f"[KTO] Loaded {len(records)} KTO records from {path}")
+    return records
+
+
+def _build_kto_dataset(records: List[Dict[str, Any]], tokenizer) -> Dataset:
+    """
+    Convert raw KTO records → HF Dataset with the three columns KTOTrainer
+    expects: prompt (str), completion (str), label (bool).
+
+    Records carry "prompt_messages" so the chat template is applied here
+    (at training time, using the live tokenizer) — guaranteeing the
+    prompt the trainer sees matches what the generator was conditioned on.
+    """
+    prompts: List[str] = []
+    completions: List[str] = []
+    labels: List[bool] = []
+
+    skipped = 0
+    for rec in records:
+        prompt_messages = rec.get("prompt_messages") or []
+        completion = rec.get("completion", "")
+        label = rec.get("label", None)
+        if not prompt_messages or not completion or label is None:
+            skipped += 1
+            continue
+
+        try:
+            prompt_str = tokenizer.apply_chat_template(
+                prompt_messages,
+                tokenize=False,
+                add_generation_prompt=True,
+            )
+        except Exception as e:
+            print(f"[KTO][WARN] chat-template render failed, falling back: {e}")
+            # Fallback: simple role-prefixed concatenation
+            prompt_str = "\n\n".join(
+                f"{m.get('role', 'user').upper()}: {m.get('content', '')}"
+                for m in prompt_messages
+            ) + "\n\nASSISTANT:"
+
+        prompts.append(prompt_str)
+        completions.append(completion)
+        labels.append(bool(label))
+
+    if skipped > 0:
+        print(f"[KTO][WARN] Skipped {skipped} malformed records (missing prompt/completion/label)")
+
+    n_des = sum(labels)
+    n_und = len(labels) - n_des
+    print(f"[KTO] Built dataset: {len(labels)} examples ({n_des} desirable, {n_und} undesirable)")
+
+    if len(labels) == 0:
+        raise RuntimeError("KTO dataset is empty after filtering — refusing to train")
+
+    return Dataset.from_dict({
+        "prompt": prompts,
+        "completion": completions,
+        "label": labels,
+    })
+
+
+# ── Model loading (mirrors Tune.py's LLM init flow) ─────────────────────────
+
+def _read_llm_conf(llm_conf: str) -> Dict[str, Any]:
+    """Read llm_conf JSON; resolve to conf/llm/ if relative."""
+    path = Path(llm_conf)
+    if not path.exists():
+        candidate = conf_llm_dir / path.name
+        if candidate.exists():
+            path = candidate
+    if not path.exists():
+        raise FileNotFoundError(f"LLM config not found: {llm_conf}")
+    with open(path) as f:
+        return json.load(f)
+
+
+def _load_base_model_and_tokenizer(
+    llm_conf_data: Dict[str, Any],
+    peft_path: Optional[str],
+    training_args: TrainingArguments,
+):
+    """
+    Load the base LLM (4-bit) and tokenizer, optionally merging a prior
+    LoRA adapter to provide a warm start.  Mirrors the pattern in
+    ab/gpt/util/Tune.py:tune().
+    """
+    from ab.gpt.util.LLM import LLM
+
+    base_model_name = llm_conf_data["base_model_name"]
+    context_length = llm_conf_data.get("context_length")
+
+    model_loader = LLM(
+        base_model_name,
+        quantization_config_4bit,
+        training_args=training_args,
+        context_length=context_length,
+    )
+    model = model_loader.get_model()
+    tokenizer = model_loader.get_tokenizer()
+
+    if peft_path:
+        print(f"[KTO] Loading previous LoRA adapter from: {peft_path}")
+        model = PeftModel.from_pretrained(model, peft_path, is_trainable=True)
+        model = model.merge_and_unload()
+        print("[KTO] Previous adapter merged into base model — fresh LoRA will be attached on top")
+
+    # ── Tokenizer hardening for DeepSeek v1.5 / mixed-template models ────────
+    # Some instruct-tunes (notably deepseek-coder-7b-instruct-v1.5) ship a
+    # tokenizer whose pad/eos differs from the model's `config.{pad,eos}_token_id`,
+    # producing the warning:
+    #   "tokenizer has new PAD/BOS/EOS tokens that differ from the model config"
+    # If left untouched, generation never emits an EOS the code-extractor
+    # recognises and every generation rolls until max_new_tokens, yielding
+    # unparseable trailing junk → ok=False on every sample.
+    #
+    # Force the model's generation config to use the tokenizer's tokens so
+    # both training and downstream inference agree.
+    try:
+        if tokenizer.pad_token_id is None and tokenizer.eos_token_id is not None:
+            tokenizer.pad_token = tokenizer.eos_token
+        model_cfg = getattr(model, "config", None)
+        gen_cfg = getattr(model, "generation_config", None)
+        if model_cfg is not None and tokenizer.pad_token_id is not None:
+            model_cfg.pad_token_id = tokenizer.pad_token_id
+        if model_cfg is not None and tokenizer.eos_token_id is not None:
+            model_cfg.eos_token_id = tokenizer.eos_token_id
+        if gen_cfg is not None and tokenizer.pad_token_id is not None:
+            gen_cfg.pad_token_id = tokenizer.pad_token_id
+        if gen_cfg is not None and tokenizer.eos_token_id is not None:
+            gen_cfg.eos_token_id = tokenizer.eos_token_id
+        print(f"[KTO] Aligned model pad/eos to tokenizer: "
+              f"pad={tokenizer.pad_token_id}, eos={tokenizer.eos_token_id}")
+    except Exception as e:
+        print(f"[KTO][WARN] Failed to align tokenizer/model special tokens: {e}")
+
+    return model, tokenizer
+
+
+# ── Standalone KTO entry point ──────────────────────────────────────────────
+
+def run_kto(
+    llm_conf: str = LLM_CONF,
+    kto_data_file: Optional[str] = None,
+    peft_path: Optional[str] = None,
+    # KTO hyperparameters
+    kto_beta: float = KTO_BETA,
+    kto_desirable_weight: float = KTO_DESIRABLE_WEIGHT,
+    kto_undesirable_weight: float = KTO_UNDESIRABLE_WEIGHT,
+    max_prompt_length: int = MAX_PROMPT_LENGTH,
+    max_completion_length: int = MAX_COMPLETION_LENGTH,
+    # Standard training hyperparameters
+    num_train_epochs: int = NUM_TRAIN_EPOCHS,
+    learning_rate: float = LEARNING_RATE,
+    weight_decay: float = WEIGHT_DECAY,
+    warmup_steps: Optional[int] = WARMUP_STEPS,
+    warmup_ratio: float = WARMUP_RATIO,
+    max_grad_norm: float = MAX_GRAD_NORM,
+    per_device_train_batch_size: int = PER_DEVICE_TRAIN_BATCH_SIZE,
+    per_device_eval_batch_size: Optional[int] = 1,
+    gradient_accumulation_steps: int = GRADIENT_ACCUMULATION_STEPS,
+    lr_scheduler_type: str = LR_SCHEDULER,
+    logging_steps: int = LOGGING_STEPS,
+    optimizer: str = OPTIMIZER,
+    # LoRA configuration
+    r: int = R,
+    lora_alpha: float = LORA_ALPHA,
+    lora_dropout: float = LORA_DROPOUT,
+    target_modules=TARGET_MODULES,
+    task_type: str = TASK_TYPE,
+    bias: str = BIAS,
+    tune_layers=None,
+    # Eval / save
+    evaluation_strategy: Optional[str] = "steps",
+    eval_steps: Optional[int] = 100,
+    save_strategy: Optional[str] = "steps",
+    save_steps: Optional[int] = 100,
+    save_total_limit: Optional[int] = 3,
+    load_best_model_at_end: bool = False,
+    metric_for_best_model: Optional[str] = "eval_loss",
+    output_dir: Optional[Path] = None,
+):
+    """
+    One-shot KTO fine-tune.  Loads the model + KTO dataset, attaches a
+    fresh LoRA adapter, runs KTOTrainer, and saves to output_dir.
+    """
+    if kto_data_file is None:
+        raise ValueError("--kto_data_file is required for KTO training")
+    kto_path = Path(kto_data_file)
+    if not kto_path.exists():
+        raise FileNotFoundError(f"KTO data file not found: {kto_path}")
+
+    output_dir = Path(output_dir) if output_dir else KTO_OUTPUT_DIR
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # ── 1. TrainingArguments (KTOConfig is a subclass — KTO class casts it) ─
+    bf16_ok = torch.cuda.is_available() and torch.cuda.is_bf16_supported()
+    training_kwargs = dict(
+        output_dir=str(nngpt_dir / "outputs_kto"),
+        num_train_epochs=num_train_epochs,
+        per_device_train_batch_size=per_device_train_batch_size,
+        gradient_accumulation_steps=gradient_accumulation_steps,
+        learning_rate=learning_rate,
+        weight_decay=weight_decay,
+        max_grad_norm=max_grad_norm,
+        lr_scheduler_type=lr_scheduler_type,
+        logging_steps=logging_steps,
+        optim=optimizer,
+        bf16=bf16_ok,
+        fp16=not bf16_ok,
+        gradient_checkpointing=True,
+        report_to=[],
+        remove_unused_columns=False,
+    )
+    if warmup_steps is not None:
+        training_kwargs["warmup_steps"] = warmup_steps
+    else:
+        training_kwargs["warmup_ratio"] = warmup_ratio
+    if per_device_eval_batch_size is not None:
+        training_kwargs["per_device_eval_batch_size"] = per_device_eval_batch_size
+    if evaluation_strategy is not None:
+        training_kwargs["eval_strategy"] = evaluation_strategy
+        if eval_steps is not None:
+            training_kwargs["eval_steps"] = eval_steps
+    if save_strategy is not None:
+        training_kwargs["save_strategy"] = save_strategy
+        if save_steps is not None:
+            training_kwargs["save_steps"] = save_steps
+        if save_total_limit is not None:
+            training_kwargs["save_total_limit"] = save_total_limit
+    if load_best_model_at_end:
+        training_kwargs["load_best_model_at_end"] = True
+        if metric_for_best_model is not None:
+            training_kwargs["metric_for_best_model"] = metric_for_best_model
+
+    training_args = TrainingArguments(**training_kwargs)
+
+    # ── 2. LoRA config ──────────────────────────────────────────────────────
+    if tune_layers is None:
+        tune_layers = range(START_LAYER, END_LAYER)
+    peft_config = LoraConfig(
+        r=r,
+        lora_alpha=lora_alpha,
+        target_modules=list(target_modules) if not isinstance(target_modules, list) else target_modules,
+        layers_to_transform=list(tune_layers),
+        lora_dropout=lora_dropout,
+        bias=bias,
+        task_type=task_type,
+    )
+
+    # ── 3. Load model + tokenizer ───────────────────────────────────────────
+    llm_conf_data = _read_llm_conf(llm_conf)
+    model, tokenizer = _load_base_model_and_tokenizer(
+        llm_conf_data, peft_path, training_args
+    )
+
+    # ── 4. Build KTO dataset ────────────────────────────────────────────────
+    records = _load_kto_jsonl(kto_path)
+    dataset = _build_kto_dataset(records, tokenizer)
+
+    # ── 5. KTO training ─────────────────────────────────────────────────────
+    # Late import so the module can also be used in pipeline-dispatch mode
+    # without paying the KTO trainer import cost up front.
+    from ab.gpt.util.KTO import KTO
+
+    kto = KTO(
+        model=model,
+        tokenizer=tokenizer,
+        training_args=training_args,
+        peft_config=peft_config,
+    )
+
+    kto.train(
+        dataset=dataset,
+        tokenizer=tokenizer,
+        output_dir=str(output_dir),
+        beta=kto_beta,
+        desirable_weight=kto_desirable_weight,
+        undesirable_weight=kto_undesirable_weight,
+        max_prompt_length=max_prompt_length,
+        max_completion_length=max_completion_length,
+    )
+
+    print(f"[KTO] Done.  Adapter saved to: {output_dir}")
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────────
+
+def main():
+    TARGET_MODULES_STR = ",".join(TARGET_MODULES)
+    parser = argparse.ArgumentParser(
+        description="KTO fine-tune (one-shot) or iterative KTO pipeline dispatch."
+    )
+
+    # Pipeline-dispatch route (delegates to KTOIterativeFinetuner)
+    parser.add_argument("--run_iterative_pipeline", action="store_true", default=False,
+                        help="Run the full iterative KTO pipeline (delegates to KTOIterativeFinetuner)")
+    parser.add_argument("--cycles", type=int, default=21)
+    parser.add_argument("--models_per_cycle", type=int, default=150)
+    parser.add_argument("--samples_per_prompt", type=int, default=1)
+    parser.add_argument("--accuracy_threshold", type=float, default=0.40)
+    parser.add_argument("--min_selected_k", type=int, default=15)
+    parser.add_argument("--fallback_threshold", type=float, default=0.35)
+    parser.add_argument("--adaptive_threshold", action="store_true", default=False)
+    parser.add_argument("--novelty_check", action="store_true", default=True)
+    parser.add_argument("--no_novelty_check", dest="novelty_check", action="store_false")
+    parser.add_argument("--resume_from_cycle", type=int, default=None)
+    parser.add_argument("--max_retries", type=int, default=3)
+    parser.add_argument("--use_optimized_training", action="store_true", default=True)
+    parser.add_argument("--no_optimized_training", dest="use_optimized_training", action="store_false")
+    parser.add_argument("--undesirable_floor_accuracy", type=float, default=0.10)
+    parser.add_argument("--undesirable_ratio", type=float, default=1.0)
+    parser.add_argument("--max_undesirable_per_cycle", type=int, default=500)
+    parser.add_argument("--kto_output_subdir", type=str, default="kto_pipeline")
+
+    # KTO standalone / shared
+    parser.add_argument("--llm_conf", type=str, default=LLM_CONF)
+    parser.add_argument("--kto_data_file", type=str, default=None,
+                        help="Path to kto_train.jsonl (standalone mode)")
+    parser.add_argument("--kto_checkpoint_dir", type=str, default=None,
+                        help="Where to save the final KTO adapter "
+                             "(default: out/qlora-kto/<kto_output_subdir>/final). "
+                             "Set per-run to avoid collisions when two runs train concurrently.")
+    parser.add_argument("--peft", dest="peft_path", type=str, default=None,
+                        help="Previous LoRA adapter to warm-start from (merged into base, then fresh LoRA on top)")
+
+    # KTO hyperparameters
+    parser.add_argument("--kto_beta", type=float, default=KTO_BETA)
+    parser.add_argument("--kto_desirable_weight", type=float, default=KTO_DESIRABLE_WEIGHT)
+    parser.add_argument("--kto_undesirable_weight", type=float, default=KTO_UNDESIRABLE_WEIGHT)
+    parser.add_argument("--max_prompt_length", type=int, default=MAX_PROMPT_LENGTH)
+    parser.add_argument("--max_completion_length", type=int, default=MAX_COMPLETION_LENGTH)
+
+    # Standard training knobs (mirror TuneNNGen.py)
+    parser.add_argument("-ne", "--num_train_epochs", type=int, default=NUM_TRAIN_EPOCHS)
+    parser.add_argument("-l", "--learning_rate", type=float, default=LEARNING_RATE)
+    parser.add_argument("--weight_decay", type=float, default=WEIGHT_DECAY)
+    parser.add_argument("--warmup_steps", type=int, default=WARMUP_STEPS)
+    parser.add_argument("--warmup_ratio", type=float, default=WARMUP_RATIO)
+    parser.add_argument("-g", "--max_grad_norm", type=float, default=MAX_GRAD_NORM)
+    parser.add_argument("-ls", "--lr_scheduler", dest="lr_scheduler_type", type=str, default=LR_SCHEDULER)
+    parser.add_argument("--per_device_train_batch_size", type=int, default=PER_DEVICE_TRAIN_BATCH_SIZE)
+    parser.add_argument("--per_device_eval_batch_size", type=int, default=1)
+    parser.add_argument("--gradient_accumulation_steps", type=int, default=GRADIENT_ACCUMULATION_STEPS)
+    parser.add_argument("--logging_steps", type=int, default=LOGGING_STEPS)
+    parser.add_argument("--optimizer", type=str, default=OPTIMIZER)
+
+    # LoRA
+    parser.add_argument("-r", "--r", type=int, default=R)
+    parser.add_argument("-a", "--lora_alpha", type=float, default=LORA_ALPHA)
+    parser.add_argument("-d", "--lora_dropout", type=float, default=LORA_DROPOUT)
+    parser.add_argument("-t", "--target_modules", type=lambda s: s.split(","), default=TARGET_MODULES,
+                        help=f"Comma-separated target modules (default: {TARGET_MODULES_STR})")
+    parser.add_argument("-y", "--task_type", type=str, default=TASK_TYPE)
+    parser.add_argument("-b", "--bias", type=str, default=BIAS)
+    parser.add_argument("-s", "--start_layer", type=int, default=START_LAYER)
+    parser.add_argument("-e", "--end_layer", type=int, default=END_LAYER)
+
+    # Eval / save (passed through from iterative pipeline)
+    parser.add_argument("--evaluation_strategy", type=str, default="steps")
+    parser.add_argument("--eval_steps", type=int, default=100)
+    parser.add_argument("--save_strategy", type=str, default="steps")
+    parser.add_argument("--save_steps", type=int, default=100)
+    parser.add_argument("--save_total_limit", type=int, default=3)
+    parser.add_argument("--load_best_model_at_end", action="store_true", default=False)
+    parser.add_argument("--metric_for_best_model", type=str, default="eval_loss")
+
+    # Inherited from TuneNNGen optimized-training preset — accepted but unused
+    # by KTO standalone training (KTO generator parameters live in the iterative
+    # pipeline, not here).  Defining them keeps the iterative-pipeline subprocess
+    # call signature compatible.
+    parser.add_argument("--max_new_tokens", type=int, default=8192)
+    parser.add_argument("--temperature", type=float, default=0.2)
+    parser.add_argument("--top_k", type=int, default=50)
+    parser.add_argument("--num_train_epochs_pipeline", type=int, default=None,
+                        help=argparse.SUPPRESS)
+
+    args = parser.parse_args()
+
+    # ── Route: iterative pipeline ───────────────────────────────────────────
+    if args.run_iterative_pipeline:
+        from ab.gpt.kto_iterative_finetune import KTOIterativeFinetuner
+
+        if args.resume_from_cycle is not None:
+            if args.resume_from_cycle < 1 or args.resume_from_cycle > args.cycles:
+                print(f"[ERROR] Invalid resume_from_cycle {args.resume_from_cycle}; "
+                      f"must be 1..{args.cycles}")
+                sys.exit(1)
+
+        pipeline = KTOIterativeFinetuner(
+            llm_conf=args.llm_conf,
+            cycles=args.cycles,
+            models_per_cycle=args.models_per_cycle,
+            samples_per_prompt=args.samples_per_prompt,
+            accuracy_threshold=args.accuracy_threshold,
+            min_selected_k=args.min_selected_k,
+            fallback_threshold=args.fallback_threshold,
+            adaptive_threshold=args.adaptive_threshold,
+            novelty_check=args.novelty_check,
+            resume_from_cycle=args.resume_from_cycle,
+            max_retries=args.max_retries,
+            use_optimized_training=args.use_optimized_training,
+            num_train_epochs=args.num_train_epochs,
+            undesirable_floor_accuracy=args.undesirable_floor_accuracy,
+            undesirable_ratio=args.undesirable_ratio,
+            max_undesirable_per_cycle=args.max_undesirable_per_cycle,
+            kto_beta=args.kto_beta,
+            kto_desirable_weight=args.kto_desirable_weight,
+            kto_undesirable_weight=args.kto_undesirable_weight,
+            kto_output_subdir=args.kto_output_subdir,
+        )
+        pipeline.run()
+        return
+
+    # ── Route: standalone KTO fine-tune ─────────────────────────────────────
+    if args.kto_data_file is None:
+        print("[ERROR] Either --run_iterative_pipeline or --kto_data_file must be provided")
+        sys.exit(1)
+
+    print(f"[KTO] Standalone KTO fine-tune")
+    print(f"  llm_conf:           {args.llm_conf}")
+    print(f"  kto_data_file:      {args.kto_data_file}")
+    print(f"  peft (warm-start):  {args.peft_path}")
+    print(f"  beta:               {args.kto_beta}")
+    print(f"  desirable_weight:   {args.kto_desirable_weight}")
+    print(f"  undesirable_weight: {args.kto_undesirable_weight}")
+    print(f"  num_train_epochs:   {args.num_train_epochs}")
+    effective_output_dir = Path(args.kto_checkpoint_dir) if args.kto_checkpoint_dir else KTO_OUTPUT_DIR
+    print(f"  output_dir:         {effective_output_dir}")
+
+    tune_layers = range(args.start_layer, args.end_layer)
+
+    run_kto(
+        llm_conf=args.llm_conf,
+        kto_data_file=args.kto_data_file,
+        peft_path=args.peft_path,
+        kto_beta=args.kto_beta,
+        kto_desirable_weight=args.kto_desirable_weight,
+        kto_undesirable_weight=args.kto_undesirable_weight,
+        max_prompt_length=args.max_prompt_length,
+        max_completion_length=args.max_completion_length,
+        num_train_epochs=args.num_train_epochs,
+        learning_rate=args.learning_rate,
+        weight_decay=args.weight_decay,
+        warmup_steps=args.warmup_steps,
+        warmup_ratio=args.warmup_ratio,
+        max_grad_norm=args.max_grad_norm,
+        per_device_train_batch_size=args.per_device_train_batch_size,
+        per_device_eval_batch_size=args.per_device_eval_batch_size,
+        gradient_accumulation_steps=args.gradient_accumulation_steps,
+        lr_scheduler_type=args.lr_scheduler_type,
+        logging_steps=args.logging_steps,
+        optimizer=args.optimizer,
+        r=args.r,
+        lora_alpha=args.lora_alpha,
+        lora_dropout=args.lora_dropout,
+        target_modules=args.target_modules,
+        task_type=args.task_type,
+        bias=args.bias,
+        tune_layers=tune_layers,
+        evaluation_strategy=args.evaluation_strategy,
+        eval_steps=args.eval_steps,
+        save_strategy=args.save_strategy,
+        save_steps=args.save_steps,
+        save_total_limit=args.save_total_limit,
+        load_best_model_at_end=args.load_best_model_at_end,
+        metric_for_best_model=args.metric_for_best_model,
+        output_dir=effective_output_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ab/gpt/kto_iterative_finetune.py
+++ b/ab/gpt/kto_iterative_finetune.py
@@ -1,0 +1,672 @@
+#!/usr/bin/env python
+
+
+import json
+import logging
+import shutil
+import subprocess
+import sys
+import time
+import traceback
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ab.gpt.iterative_finetune import IterativeFinetuner, logger
+from ab.gpt.iterative_pipeline.novelty_checker import NoveltyChecker
+from ab.gpt.iterative_pipeline.pipeline_validation import (
+    RetryHandler,
+    StageValidator,
+)
+from ab.gpt.iterative_pipeline.gpu_memory_manager import (
+    check_gpu_memory,
+    clear_gpu_cache,
+    ensure_gpu_memory,
+    get_gpu_memory_info,
+    kill_gpu_processes,
+)
+from ab.gpt.kto_pipeline.kto_data_manager import KTODataManager
+from ab.gpt.TuneNNGen import get_pipeline_defaults
+from ab.gpt.util.Const import nngpt_dir
+from ab.nn.util.Const import out_dir
+
+
+class KTOIterativeFinetuner(IterativeFinetuner):
+    """KTO version of the iterative fine-tuning pipeline."""
+
+    def __init__(
+        self,
+        llm_conf: str,
+        cycles: int = 21,
+        models_per_cycle: int = 150,
+        samples_per_prompt: int = 1,
+        accuracy_threshold: float = 0.40,
+        min_selected_k: int = 15,
+        fallback_threshold: float = 0.35,
+        adaptive_threshold: bool = False,
+        novelty_check: bool = True,
+        resume_from_cycle: Optional[int] = None,
+        max_retries: int = 3,
+        use_optimized_training: bool = True,
+        num_train_epochs: int = 5,
+        # ── KTO-specific knobs ────────────────────────────────────────────
+        undesirable_floor_accuracy: float = 0.10,
+        undesirable_ratio: float = 1.0,
+        max_undesirable_per_cycle: int = 500,
+        kto_beta: float = 0.1,
+        kto_desirable_weight: float = 1.0,
+        kto_undesirable_weight: float = 1.0,
+        kto_output_subdir: str = "kto_pipeline",
+    ):
+        # 1. Parent init sets up curation data, base SFT data_manager, logging,
+        #    novelty checker — all using out_dir/curation_output as the working
+        #    directory.  We accept those side-effects (they're idempotent) and
+        #    then redirect output to the KTO-specific tree.
+        super().__init__(
+            llm_conf=llm_conf,
+            cycles=cycles,
+            models_per_cycle=models_per_cycle,
+            samples_per_prompt=samples_per_prompt,
+            accuracy_threshold=accuracy_threshold,
+            min_selected_k=min_selected_k,
+            fallback_threshold=fallback_threshold,
+            adaptive_threshold=adaptive_threshold,
+            novelty_check=novelty_check,
+            resume_from_cycle=resume_from_cycle,
+            max_retries=max_retries,
+            use_optimized_training=use_optimized_training,
+            num_train_epochs=num_train_epochs,
+        )
+
+        # 2. Override output_dir → nngpt_dir/<kto_output_subdir>
+        # Must be under nngpt_dir so NNEval.py's relative_to(nngpt_dir) call
+        # in _collect_epoch_requests() does not raise ValueError.
+        kto_output = nngpt_dir / kto_output_subdir
+        kto_output.mkdir(parents=True, exist_ok=True)
+        self.output_dir = kto_output
+
+        
+        shared_log_marker = str(out_dir / "curation_output" / "iterative_pipeline.log")
+        for h in list(logger.handlers):
+            base = getattr(h, "baseFilename", None)
+            if base and Path(base) == Path(shared_log_marker):
+                logger.removeHandler(h)
+                try:
+                    h.close()
+                except Exception:
+                    pass
+
+        kto_log_file = self.output_dir / "iterative_pipeline.log"
+        formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+        # Avoid duplicate handlers if __init__ is called twice
+        existing_files = {
+            getattr(h, "baseFilename", None) for h in logger.handlers
+        }
+        if str(kto_log_file) not in existing_files:
+            fh = logging.FileHandler(kto_log_file)
+            fh.setFormatter(formatter)
+            logger.addHandler(fh)
+        logger.info(f"[KTO] Output directory: {self.output_dir}")
+
+        # 4. Re-init novelty checker with a KTO-specific cache so we don't
+        #    cross-contaminate the SFT run's seen-models set.
+        self.novelty_checker = NoveltyChecker(self.output_dir / "seen_models.json")
+        if self.novelty_check_enabled:
+            self._initialize_novelty_checker()
+
+        # 5. Replace data_manager with KTO-aware version.  Same interface
+        #    (augment_training_data signature is identical), so run_cycle in
+        #    the parent class works unchanged.
+        self.data_manager = KTODataManager(
+            base_data_dir=str(self.base_data_dir),
+            undesirable_cache_file=self.output_dir / "kto_undesirable_cache.jsonl",
+            undesirable_ratio=undesirable_ratio,
+            max_undesirable_per_cycle=max_undesirable_per_cycle,
+        )
+
+        # 6. KTO hyperparameters
+        self.undesirable_floor_accuracy = undesirable_floor_accuracy
+        self.undesirable_ratio = undesirable_ratio
+        self.max_undesirable_per_cycle = max_undesirable_per_cycle
+        self.kto_beta = kto_beta
+        self.kto_desirable_weight = kto_desirable_weight
+        self.kto_undesirable_weight = kto_undesirable_weight
+        self.kto_output_subdir = kto_output_subdir
+
+       
+        import os
+        seed_env = os.environ.get("KTO_SEED_CHECKPOINT", "").strip()
+        self.kto_seed_checkpoint = (
+            Path(seed_env) if seed_env else (out_dir / "qlora-sft" / "final")
+        )
+
+        # 7. Tracks which cycle is currently in flight (set by run_cycle).
+        #    Needed by filter_successful_novel to tag undesirables.
+        self._current_cycle: int = 0
+
+        logger.info(
+            f"[KTO] beta={self.kto_beta}, "
+            f"desirable_weight={self.kto_desirable_weight}, "
+            f"undesirable_weight={self.kto_undesirable_weight}, "
+            f"undesirable_floor={self.undesirable_floor_accuracy:.2f}, "
+            f"undesirable_ratio={self.undesirable_ratio}"
+        )
+
+    # ── lightweight overrides ────────────────────────────────────────────
+
+    def run_cycle(self, cycle: int) -> Dict[str, Any]:
+        """Track current cycle so filter_successful_novel can tag undesirables."""
+        self._current_cycle = cycle
+        return super().run_cycle(cycle)
+
+    def filter_successful_novel(
+        self,
+        generation_results: Dict[str, Any],
+        evaluation_results: Dict[str, Any],
+        starting_checksum: int = 0,
+    ) -> List[Dict[str, Any]]:
+        """
+        Inherit the parent's selection logic for desirables, then ALSO
+        scan the same evaluation result set for undesirables and record
+        them in the KTODataManager's accumulated cache.
+        """
+        selected = super().filter_successful_novel(
+            generation_results, evaluation_results, starting_checksum
+        )
+        selected_ids = {m["model_id"] for m in selected}
+
+        # Build a model_id → eval_info map (covers BOTH success=True and False)
+        eval_models = evaluation_results.get("models", [])
+        eval_by_id: Dict[str, Dict[str, Any]] = {
+            m["model_id"]: m for m in eval_models if "model_id" in m
+        }
+
+        # Locate this cycle's nneval directory so we can read code for
+        # models whose eval entry doesn't carry a code_file field.
+        cycle_nneval_dir = self.output_dir / f"cycle_{self._current_cycle}" / "nneval"
+
+        results_list = generation_results.get("results", [])
+        n_recorded = 0
+        n_recorded_extraction_fail = 0
+        n_skipped_no_code = 0
+        n_skipped_no_eval = 0
+
+        def _read_first_existing(*candidates: Optional[str]) -> Optional[str]:
+            for c in candidates:
+                if not c:
+                    continue
+                p = Path(c)
+                if p.exists():
+                    try:
+                        return p.read_text(encoding="utf-8", errors="replace")
+                    except Exception:
+                        continue
+            return None
+
+        def _is_error_stub(text: str) -> bool:
+            """
+            The generator writes a tiny stub like "# No code generated\n# Error: ..."
+            when the model itself crashed before producing any tokens (typically a
+            CUDA device-mismatch, OOM, or NaN).  These contain zero architectural
+            signal — recording them as KTO undesirables teaches the policy nothing
+            useful and pollutes the cache.  Reject by both prefix and total bulk.
+            """
+            stripped = text.strip()
+            if stripped.startswith("# No code generated"):
+                return True
+            # Heuristic: a real (failed) generation always contains at least one
+            # python keyword (class / def / import).  Pure error-stub text won't.
+            if len(stripped) < 100 and not any(
+                kw in stripped for kw in ("class ", "def ", "import ", "nn.Module")
+            ):
+                return True
+            return False
+
+        def _extract_acc_from_eval_info(info: Dict[str, Any]) -> Optional[float]:
+            """Pull accuracy out of a per-model eval_info.json payload."""
+            results = info.get("eval_results") if isinstance(info, dict) else None
+            if not isinstance(results, dict):
+                return None
+            acc = results.get("accuracy", results.get("acc"))
+            try:
+                return float(acc) if acc is not None else None
+            except (TypeError, ValueError):
+                return None
+
+        for i, result in enumerate(results_list):
+            model_id = f"gen_{starting_checksum + i:04d}"
+            if model_id in selected_ids:
+                continue  # already a desirable
+
+            
+            if not result.get("ok", False):
+                # Prefer raw_output (actual model text, even if unparseable)
+                # over fail_code (which can be a "# No code generated" stub
+                # when the model crashed before emitting any tokens).
+                bad_text = _read_first_existing(
+                    result.get("raw_output"),
+                    result.get("fail_code"),
+                )
+                if bad_text is None or not bad_text.strip():
+                    n_skipped_no_code += 1
+                    continue
+
+                if _is_error_stub(bad_text):
+                    # Crash-before-generation: nothing the policy can learn from.
+                    n_skipped_no_code += 1
+                    continue
+
+                metadata = {
+                    "accuracy": 0.0,
+                    "params": 0,
+                    "cycle": self._current_cycle,
+                    "checkpoint": "current",
+                }
+                failure_reason = result.get("error") or "code_extraction_failed"
+                if self.data_manager.record_undesirable(
+                    model_id, failure_reason, bad_text, metadata
+                ):
+                    n_recorded += 1
+                    n_recorded_extraction_fail += 1
+                else:
+                    n_skipped_no_code += 1
+                continue
+
+            # ── Path B: ok=True but not selected → eval-based undesirable ────
+            eval_info = eval_by_id.get(model_id)
+            if eval_info is None:
+                
+                model_eval_dir = cycle_nneval_dir / model_id
+                err_file = model_eval_dir / "error.txt"
+                info_file = model_eval_dir / "eval_info.json"
+                if err_file.exists():
+                    err_text = _read_first_existing(str(err_file)) or "evaluation_failed"
+                    eval_info = {"success": False, "error": err_text.strip()[:500]}
+                elif info_file.exists():
+                    try:
+                        info = json.loads(info_file.read_text())
+                        acc = _extract_acc_from_eval_info(info)
+                        eval_info = {"success": True, "accuracy": acc}
+                    except Exception:
+                        eval_info = None
+                if eval_info is None:
+                    # Genuinely no verdict for this model (never reached by the
+                    # evaluator before it died) — can't classify it.
+                    n_skipped_no_eval += 1
+                    continue
+
+            success = eval_info.get("success", False)
+            accuracy = eval_info.get("accuracy")
+
+            
+            code_file_str = eval_info.get("code_file") or ""
+            code_path = Path(code_file_str) if code_file_str else None
+            if code_path is None or not code_path.exists():
+                code_path = cycle_nneval_dir / model_id / "new_nn.py"
+            if not code_path.exists():
+                gen_file = result.get("file")
+                if gen_file:
+                    code_path = Path(gen_file)
+
+            if not code_path.exists():
+                n_skipped_no_code += 1
+                continue
+
+            try:
+                code = code_path.read_text(encoding="utf-8", errors="replace")
+            except Exception as e:
+                logger.warning(f"[KTO] Failed to read code for {model_id}: {e}")
+                n_skipped_no_code += 1
+                continue
+
+            # Decide failure reason for the undesirable label
+            if not success:
+                failure_reason = eval_info.get("error") or "evaluation_failed"
+            elif accuracy is not None and accuracy < self.undesirable_floor_accuracy:
+                failure_reason = "low_accuracy"
+            else:
+                # success=True, accuracy >= floor, but not selected → likely
+                # rejected for novelty.  Treat as a soft-negative example
+                # (still a real generation we want to weight low).
+                failure_reason = "not_novel_or_below_threshold"
+
+            metadata = {
+                "accuracy": accuracy if accuracy is not None else 0.0,
+                "params": result.get("params", 0),
+                "cycle": self._current_cycle,
+                "checkpoint": "current",
+            }
+
+            if self.data_manager.record_undesirable(
+                model_id, failure_reason, code, metadata
+            ):
+                n_recorded += 1
+
+        self.data_manager.save_undesirable_cache()
+
+        logger.info(
+            f"[KTO][cycle {self._current_cycle}] "
+            f"undesirables recorded this cycle: {n_recorded} "
+            f"(of which extraction-failures={n_recorded_extraction_fail}, "
+            f"skipped_no_code={n_skipped_no_code}, skipped_no_eval={n_skipped_no_eval}); "
+            f"cumulative cache size: {len(self.data_manager._accumulated_undesirable)}"
+        )
+
+        return selected
+
+    
+
+    def run_finetuning(self, cycle: int, data_dir: Path) -> Dict[str, Any]:
+        """
+        Run KTO fine-tuning for one cycle by spawning
+        `python -m ab.gpt.TuneNNGenKTO --kto_data_file <path/kto_train.jsonl> ...`
+        """
+        logger.info("")
+        logger.info("=" * 80)
+        logger.info(f"CYCLE {cycle}: FINE-TUNING (KTO)")
+        logger.info("=" * 80)
+        logger.info(f"Training data: {data_dir}")
+
+        import os
+        if "PYTORCH_CUDA_ALLOC_CONF" not in os.environ:
+            os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+            logger.info("Set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True")
+
+        logger.info("Clearing GPU cache before fine-tuning...")
+        clear_gpu_cache()
+        current_pid = str(os.getpid())
+        kill_gpu_processes(exclude_pids=[current_pid])
+        clear_gpu_cache()
+
+        has_memory, msg = check_gpu_memory(min_free_gb=8.0)
+        if not has_memory:
+            logger.warning(f"GPU memory warning: {msg}")
+            if not ensure_gpu_memory(min_free_gb=8.0, aggressive=True):
+                logger.error("Insufficient GPU memory for fine-tuning.")
+                return {
+                    "success": False,
+                    "error": f"insufficient_gpu_memory: {msg}",
+                    "training_time_minutes": 0,
+                }
+
+        # Skip if this cycle's checkpoint already exists & validates
+        isolated_checkpoint = self.output_dir / f"cycle_{cycle}" / "checkpoint"
+        if isolated_checkpoint.exists():
+            is_valid, msg = StageValidator.validate_finetuning_output(isolated_checkpoint)
+            if is_valid:
+                logger.info(f"✓ Existing checkpoint validated: {isolated_checkpoint}")
+                return {
+                    "success": True,
+                    "checkpoint_dir": str(isolated_checkpoint),
+                    "training_time_minutes": 0.0,
+                    "skipped": True,
+                }
+            logger.warning(f"Existing checkpoint failed validation: {msg} — re-training")
+
+        total, used, free = get_gpu_memory_info()
+        logger.info(f"GPU memory before fine-tuning: {free:.2f}GB free / {total:.2f}GB total")
+
+        ft_output_dir = self.output_dir / f"cycle_{cycle}" / "finetuning_output"
+        ft_output_dir.mkdir(parents=True, exist_ok=True)
+
+        # The KTO file lives inside the data_dir as kto_train.jsonl
+        # (written by KTODataManager.augment_training_data — or by
+        # KTODataManager._build_initial_kto_file for cycle 1).
+        kto_train_file = Path(data_dir) / "kto_train.jsonl"
+        if not kto_train_file.exists():
+            logger.error(f"KTO training file not found: {kto_train_file}")
+            return {
+                "success": False,
+                "error": f"kto_train_file_missing: {kto_train_file}",
+                "training_time_minutes": 0,
+            }
+
+        # Per-run checkpoint dir avoids collision when 1.3B and 7B run concurrently.
+        # kto_output_subdir is e.g. "kto_pipeline_1p3b" or "kto_pipeline_7b".
+        kto_ckpt_dir = out_dir / "qlora-kto" / self.kto_output_subdir / "final"
+
+        # KTO  ←── changed: spawn TuneNNGenKTO, not TuneNNGen
+        cmd = [
+            sys.executable, "-m", "ab.gpt.TuneNNGenKTO",
+            "--llm_conf", self.llm_conf,
+            "--kto_data_file", str(kto_train_file),
+            "--kto_checkpoint_dir", str(kto_ckpt_dir),
+            "--kto_beta", str(self.kto_beta),
+            "--kto_desirable_weight", str(self.kto_desirable_weight),
+            "--kto_undesirable_weight", str(self.kto_undesirable_weight),
+        ]
+
+        # Choose the warm-start adapter (--peft) to merge before attaching the
+        # fresh KTO LoRA:
+        #   cycle 1  → the SFT seed checkpoint (format-teacher; see __init__).
+        #   cycle 2+ → the previous cycle's KTO checkpoint (continual learning).
+        if cycle == 1:
+            if self.kto_seed_checkpoint and Path(self.kto_seed_checkpoint).exists():
+                logger.info(
+                    f"[KTO] Cycle 1 warm-start from SFT seed checkpoint: "
+                    f"{self.kto_seed_checkpoint}"
+                )
+                cmd.extend(["--peft", str(self.kto_seed_checkpoint)])
+            else:
+                logger.warning(
+                    "[KTO] No SFT seed checkpoint found at "
+                    f"{self.kto_seed_checkpoint}. Cycle 1 will KTO-train from RAW "
+                    "BASE, which usually cannot learn the LEMUR Net(in_shape,...) "
+                    "format — expect generated models to crash at evaluation "
+                    "(e.g. Conv2d(1,...) channel mismatches). Run the SFT pipeline "
+                    "first or set KTO_SEED_CHECKPOINT to a format-trained adapter."
+                )
+        else:
+            prev_checkpoint = self.output_dir / f"cycle_{cycle - 1}" / "checkpoint"
+            if prev_checkpoint.exists():
+                logger.info(f"Loading previous cycle checkpoint: {prev_checkpoint}")
+                cmd.extend(["--peft", str(prev_checkpoint)])
+            else:
+                logger.warning(f"Previous cycle checkpoint not found: {prev_checkpoint}")
+
+        if self.use_optimized_training:
+            d = get_pipeline_defaults()
+           
+            kto_learning_rate = 5e-6
+            kto_lora_r = 16
+            kto_lora_alpha = 16
+            kto_max_grad_norm = 0.3
+            cmd.extend([
+                "--per_device_train_batch_size", "2",  # KTO requires actual batch > 1 for KL estimation
+                "--learning_rate", str(kto_learning_rate),
+                "--r", str(kto_lora_r),
+                "--lora_alpha", str(kto_lora_alpha),
+                "--weight_decay", str(d["weight_decay"]),
+                "--warmup_steps", str(d["warmup_steps"]),
+                "--num_train_epochs", str(self.num_train_epochs),
+                "--logging_steps", str(d["logging_steps"]),
+                "--max_grad_norm", str(kto_max_grad_norm),
+                "--target_modules", d["target_modules"],
+                "--max_new_tokens", str(d["max_new_tokens"]),
+                "--temperature", str(d["temperature"]),
+                "--top_k", str(d["top_k"]),
+                "--evaluation_strategy", d["evaluation_strategy"],
+                "--eval_steps", str(d["eval_steps"]),
+                "--per_device_eval_batch_size", str(d["per_device_eval_batch_size"]),
+                "--save_strategy", d["save_strategy"],
+                "--save_steps", str(d["save_steps"]),
+                "--save_total_limit", str(d["save_total_limit"]),
+                "--metric_for_best_model", d["metric_for_best_model"],
+            ])
+            if d["load_best_model_at_end"]:
+                cmd.append("--load_best_model_at_end")
+            logger.info("Using optimized training configuration")
+        else:
+            logger.info("Using default training configuration")
+
+        logger.info(f"Running fine-tuning: {' '.join(cmd)}")
+        start_time = time.time()
+
+        def _run_ft_cmd():
+            clear_gpu_cache()
+            result = subprocess.run(cmd, capture_output=False, text=True, check=False)
+            if result.returncode != 0:
+                logger.error(f"KTO fine-tuning failed with exit code {result.returncode}")
+                clear_gpu_cache()
+                raise subprocess.CalledProcessError(result.returncode, cmd)
+            return result
+
+        try:
+            RetryHandler.retry_with_backoff(
+                _run_ft_cmd,
+                max_retries=self.max_retries,
+                initial_delay=30.0,
+                backoff_factor=2.0,
+                exceptions=(subprocess.CalledProcessError, OSError),
+                operation_name=f"KTO fine-tuning cycle {cycle}",
+            )
+        except subprocess.CalledProcessError as e:
+            training_time = time.time() - start_time
+            logger.error(f"KTO fine-tuning failed after {self.max_retries} retries (exit code {e.returncode})")
+            return {
+                "success": False,
+                "error": f"kto_fine_tuning_failed: exit_code_{e.returncode}",
+                "training_time_minutes": training_time / 60,
+            }
+        except Exception as e:
+            training_time = time.time() - start_time
+            logger.error(f"KTO fine-tuning failed with unexpected error: {e}")
+            return {
+                "success": False,
+                "error": f"kto_fine_tuning_failed: {str(e)}",
+                "training_time_minutes": training_time / 60,
+            }
+
+        training_time = time.time() - start_time
+        logger.info(f"KTO fine-tuning completed in {training_time / 60:.1f} minutes")
+
+        # KTO  ←── changed: TuneNNGenKTO saves to per-run qlora-kto/<subdir>/final
+        source_checkpoint = kto_ckpt_dir
+        if not source_checkpoint.exists():
+            logger.error(f"Checkpoint directory not found: {source_checkpoint}")
+            return {
+                "success": False,
+                "error": "checkpoint_not_found",
+                "training_time_minutes": training_time / 60,
+            }
+
+        isolated_checkpoint = self.output_dir / f"cycle_{cycle}" / "checkpoint"
+        isolated_checkpoint.mkdir(parents=True, exist_ok=True)
+
+        def _copy_checkpoint():
+            logger.info(f"Copying KTO checkpoint to: {isolated_checkpoint}")
+            if isolated_checkpoint.exists():
+                shutil.rmtree(isolated_checkpoint)
+            shutil.copytree(source_checkpoint, isolated_checkpoint)
+            return True
+
+        try:
+            RetryHandler.retry_with_backoff(
+                _copy_checkpoint,
+                max_retries=3,
+                initial_delay=2.0,
+                backoff_factor=1.5,
+                exceptions=(OSError, shutil.Error),
+                operation_name=f"Copy KTO checkpoint cycle {cycle}",
+            )
+        except Exception as e:
+            logger.error(f"Failed to copy KTO checkpoint: {e}")
+            return {
+                "success": False,
+                "error": f"checkpoint_copy_failed: {str(e)}",
+                "training_time_minutes": training_time / 60,
+            }
+
+        is_valid, msg = StageValidator.validate_finetuning_output(isolated_checkpoint)
+        if not is_valid:
+            logger.error(f"KTO checkpoint validation failed: {msg}")
+            return {
+                "success": False,
+                "error": f"checkpoint_validation_failed: {msg}",
+                "training_time_minutes": training_time / 60,
+            }
+
+        logger.info(f"KTO checkpoint validated and saved to: {isolated_checkpoint}")
+
+        return {
+            "success": True,
+            "checkpoint_dir": str(isolated_checkpoint),
+            "source_checkpoint": str(source_checkpoint),
+            "training_time_minutes": training_time / 60,
+        }
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────────
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Iterative KTO Fine-Tuning Pipeline")
+    parser.add_argument("--llm_conf", type=str, required=True,
+                        help="LLM configuration JSON (e.g., ds_coder_1.3b_instruct.json)")
+    parser.add_argument("--cycles", type=int, default=21,
+                        help="Number of fine-tuning cycles (default: 21)")
+    parser.add_argument("--models_per_cycle", type=int, default=150,
+                        help="Number of models to generate per cycle (default: 150)")
+    parser.add_argument("--samples_per_prompt", type=int, default=1)
+    parser.add_argument("--accuracy_threshold", type=float, default=0.40,
+                        help="Min first-epoch accuracy to count as desirable (default: 0.40)")
+    parser.add_argument("--min_selected_k", type=int, default=15)
+    parser.add_argument("--fallback_threshold", type=float, default=0.35)
+    parser.add_argument("--adaptive_threshold", action="store_true", default=False)
+    parser.add_argument("--novelty_check", action="store_true", default=True)
+    parser.add_argument("--no_novelty_check", dest="novelty_check", action="store_false")
+    parser.add_argument("--resume_from_cycle", type=int, default=None)
+    parser.add_argument("--max_retries", type=int, default=3)
+    parser.add_argument("--use_optimized_training", action="store_true", default=True)
+    parser.add_argument("--no_optimized_training", dest="use_optimized_training", action="store_false")
+    parser.add_argument("--num_train_epochs", type=int, default=5)
+
+    # KTO-specific
+    parser.add_argument("--undesirable_floor_accuracy", type=float, default=0.10,
+                        help="Models with success=True but accuracy < this are also undesirables")
+    parser.add_argument("--undesirable_ratio", type=float, default=1.0,
+                        help="Target |undesirable| / |desirable| in the KTO dataset (default: 1.0)")
+    parser.add_argument("--max_undesirable_per_cycle", type=int, default=500)
+    parser.add_argument("--kto_beta", type=float, default=0.1,
+                        help="KTO KL-regularisation strength (default: 0.1)")
+    parser.add_argument("--kto_desirable_weight", type=float, default=1.0)
+    parser.add_argument("--kto_undesirable_weight", type=float, default=1.0)
+    parser.add_argument("--kto_output_subdir", type=str, default="kto_pipeline",
+                        help="Output subdirectory under out_dir (default: kto_pipeline)")
+
+    args = parser.parse_args()
+
+    if args.resume_from_cycle is not None:
+        if args.resume_from_cycle < 1 or args.resume_from_cycle > args.cycles:
+            print(f"[ERROR] Invalid resume_from_cycle {args.resume_from_cycle}; "
+                  f"must be 1..{args.cycles}")
+            sys.exit(1)
+
+    pipeline = KTOIterativeFinetuner(
+        llm_conf=args.llm_conf,
+        cycles=args.cycles,
+        models_per_cycle=args.models_per_cycle,
+        samples_per_prompt=args.samples_per_prompt,
+        accuracy_threshold=args.accuracy_threshold,
+        min_selected_k=args.min_selected_k,
+        fallback_threshold=args.fallback_threshold,
+        adaptive_threshold=args.adaptive_threshold,
+        novelty_check=args.novelty_check,
+        resume_from_cycle=args.resume_from_cycle,
+        max_retries=args.max_retries,
+        use_optimized_training=args.use_optimized_training,
+        num_train_epochs=args.num_train_epochs,
+        undesirable_floor_accuracy=args.undesirable_floor_accuracy,
+        undesirable_ratio=args.undesirable_ratio,
+        max_undesirable_per_cycle=args.max_undesirable_per_cycle,
+        kto_beta=args.kto_beta,
+        kto_desirable_weight=args.kto_desirable_weight,
+        kto_undesirable_weight=args.kto_undesirable_weight,
+        kto_output_subdir=args.kto_output_subdir,
+    )
+
+    pipeline.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/ab/gpt/kto_pipeline/__init__.py
+++ b/ab/gpt/kto_pipeline/__init__.py
@@ -1,0 +1,1 @@
+# KTO pipeline package — data management + balancing for KTO training.

--- a/ab/gpt/kto_pipeline/kto_data_manager.py
+++ b/ab/gpt/kto_pipeline/kto_data_manager.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""
+KTO Training Data Manager for Iterative Fine-Tuning
+
+Extends TrainingDataManager to maintain TWO training corpora in parallel:
+  1. The standard SFT-format JSONL (train.jsonl) — needed for resume
+     and inspection.  Inherited behaviour from TrainingDataManager.
+  2. A KTO-format JSONL (kto_train.jsonl) — what KTOTrainer reads —
+     consisting of all desirable examples (label=True) plus a balanced
+     subset of accumulated undesirable examples (label=False).
+
+Desirable / undesirable split for KTO
+-------------------------------------
+  Desirable   = original LEMUR-curated examples + every cycle's selected
+                (above-threshold, novel) generated architectures.
+  Undesirable = generated architectures that failed validation
+                (compile / NameError / shape mismatch / ...) OR that
+                trained but ended below `undesirable_floor_accuracy`.
+
+Undesirable examples are persisted to `kto_undesirable_cache.jsonl`
+across cycles, exactly the way NoveltyChecker persists seen models
+to `seen_models.json`.
+
+Balancing
+---------
+Default ratio is 1:1.  `balance()` caps undesirable at
+`floor(len(desirable) * undesirable_ratio)`; if more are available we
+keep the most-recent ones (later cycles produce sharper negatives).
+Edge cases (no undesirables yet, extreme imbalance) are handled
+gracefully and reported in the stats dict.
+"""
+
+import json
+import math
+import random
+from pathlib import Path
+from typing import Dict, List, Any, Optional, Tuple
+
+from ab.gpt.iterative_pipeline.training_data_manager import TrainingDataManager
+
+
+class KTODataManager(TrainingDataManager):
+    """KTO-aware data manager: tracks desirables + balanced undesirables."""
+
+    def __init__(
+        self,
+        base_data_dir: str,
+        undesirable_cache_file: Path,
+        undesirable_ratio: float = 1.0,
+        max_undesirable_per_cycle: int = 500,
+        balance_seed: int = 43,
+    ):
+        """
+        Args:
+            base_data_dir: curation_output/chat_data (original SFT JSONL location)
+            undesirable_cache_file: Where to persist the accumulated undesirables JSONL
+            undesirable_ratio: target |undesirable| / |desirable| (default 1.0)
+            max_undesirable_per_cycle: per-cycle cap on accepting new undesirables
+            balance_seed: RNG seed for the shuffle (reproducible runs)
+        """
+        super().__init__(base_data_dir)
+        self.undesirable_cache_file = Path(undesirable_cache_file)
+        self.undesirable_ratio = undesirable_ratio
+        self.max_undesirable_per_cycle = max_undesirable_per_cycle
+        self._balance_seed = balance_seed
+
+        # Accumulated undesirable examples across cycles
+        self._accumulated_undesirable: List[Dict[str, Any]] = []
+        if self.undesirable_cache_file.exists():
+            self._load_undesirable_cache()
+
+        # Build (once) the initial KTO file from the original SFT data so cycle 1
+        # has a kto_train.jsonl to consume.  All original examples → label=True.
+        self._initial_kto_file = self.base_data_dir / "kto_train.jsonl"
+        if not self._initial_kto_file.exists():
+            self._build_initial_kto_file()
+
+    # ── public conversion helpers ────────────────────────────────────────────
+
+    def _sft_to_kto(self, sft_example: Dict[str, Any], label: bool) -> Optional[Dict[str, Any]]:
+        """
+        Split an SFT chat example into KTO {prompt_messages, completion, label}.
+
+        We store `prompt_messages` (list of {role, content}) rather than a
+        pre-rendered prompt string so TuneNNGenKTO can apply the live
+        tokenizer's chat template at training time, ensuring the prompt
+        matches exactly what the generator sees.
+
+        Returns None if the example is malformed (no user/assistant pair).
+        """
+        messages = sft_example.get("messages", [])
+        if not isinstance(messages, list) or len(messages) < 2:
+            return None
+
+        system_msg = next((m for m in messages if m.get("role") == "system"), None)
+        user_msg = next((m for m in messages if m.get("role") == "user"), None)
+        assistant_msg = next((m for m in messages if m.get("role") == "assistant"), None)
+
+        if user_msg is None or assistant_msg is None:
+            return None
+
+        prompt_messages = []
+        if system_msg is not None:
+            prompt_messages.append({"role": "system", "content": system_msg["content"]})
+        prompt_messages.append({"role": "user", "content": user_msg["content"]})
+
+        kto = {
+            "prompt_messages": prompt_messages,
+            "completion": assistant_msg.get("content", ""),
+            "label": bool(label),
+            "_meta": dict(sft_example.get("meta", {})),
+        }
+        return kto
+
+    def convert_code_to_kto(
+        self,
+        code: str,
+        model_id: str,
+        metadata: Dict[str, Any],
+        label: bool,
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Build a KTO example for a generated model.  Re-uses the parent's
+        convert_code_to_chat_example so the prompt matches the SFT path
+        exactly (same system / user template, same enhanced instructions),
+        then splits the resulting chat example into KTO format.
+        """
+        sft = self.convert_code_to_chat_example(code, model_id, metadata)
+        kto = self._sft_to_kto(sft, label=label)
+        if kto is None:
+            return None
+        kto["_meta"]["model_id"] = model_id
+        kto["_meta"]["cycle"] = metadata.get("cycle", 0)
+        kto["_meta"]["first_epoch_accuracy"] = metadata.get("accuracy", None)
+        kto["_meta"]["params"] = metadata.get("params", None)
+        return kto
+
+    # ── undesirable bookkeeping ──────────────────────────────────────────────
+
+    def record_undesirable(
+        self,
+        model_id: str,
+        failure_reason: str,
+        code: Optional[str],
+        metadata: Dict[str, Any],
+    ) -> bool:
+        """
+        Add a failed / low-accuracy model to the accumulated undesirables.
+
+        Returns True if recorded; False if skipped because there was no
+        usable code to form a completion (the most common skip reason is
+        an extraction failure — the LLM produced text we couldn't parse as
+        Python).
+        """
+        if not code or not code.strip():
+            return False
+
+        kto = self.convert_code_to_kto(code, model_id, metadata, label=False)
+        if kto is None:
+            return False
+
+        kto["_meta"]["failure_reason"] = failure_reason
+        kto["_meta"]["accuracy"] = metadata.get("accuracy", None)
+        self._accumulated_undesirable.append(kto)
+        return True
+
+    def _load_undesirable_cache(self):
+        try:
+            self._accumulated_undesirable = self._load_jsonl(self.undesirable_cache_file)
+            print(f"[KTO] Loaded {len(self._accumulated_undesirable)} undesirable examples "
+                  f"from {self.undesirable_cache_file}")
+        except Exception as e:
+            print(f"[KTO][WARN] Failed to load undesirable cache: {e}")
+            self._accumulated_undesirable = []
+
+    def save_undesirable_cache(self):
+        self._save_jsonl(self._accumulated_undesirable, self.undesirable_cache_file)
+
+    # ── balancing ────────────────────────────────────────────────────────────
+
+    def balance(
+        self,
+        desirables: List[Dict[str, Any]],
+        undesirables: List[Dict[str, Any]],
+        ratio: Optional[float] = None,
+    ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+        """
+        Cap undesirables so they don't drown the desirables (or vice versa).
+
+        Returns (combined_list_shuffled, stats).
+        """
+        if ratio is None:
+            ratio = self.undesirable_ratio
+
+        D = len(desirables)
+        Ua = len(undesirables)
+        max_U = math.floor(D * ratio) if D > 0 else Ua
+
+        if D == 0:
+            selected_U: List[Dict[str, Any]] = []
+            note = "no desirable examples — empty training round"
+        elif Ua > max_U:
+            # Cap: keep the most-recent (later cycles' negatives are
+            # typically sharper / more on-distribution).
+            selected_U = undesirables[-max_U:] if max_U > 0 else []
+            note = f"capped from {Ua} to {len(selected_U)} (ratio={ratio})"
+        elif Ua == 0:
+            selected_U = []
+            note = "no undesirables available — KTO falls back to desirables-only (SFT-like)"
+        elif Ua < D * 0.1:
+            selected_U = list(undesirables)
+            note = f"WARNING: severe imbalance {Ua} undesirable << {D} desirable"
+        else:
+            selected_U = list(undesirables)
+            note = "healthy"
+
+        combined = list(desirables) + selected_U
+        random.Random(self._balance_seed).shuffle(combined)
+
+        stats = {
+            "desirable_count": D,
+            "undesirable_available": Ua,
+            "undesirable_used": len(selected_U),
+            "total": len(combined),
+            "target_ratio": ratio,
+            "actual_ratio": (len(selected_U) / D) if D > 0 else 0.0,
+            "balance_note": note,
+        }
+        return combined, stats
+
+    # ── core augmentation override ───────────────────────────────────────────
+
+    def augment_training_data(
+        self,
+        new_examples: List[Dict[str, Any]],
+        cycle: int,
+        output_dir: Path,
+    ) -> Dict[str, Any]:
+        """
+        Write BOTH the SFT-format cumulative JSONL (inherited) AND the
+        balanced KTO-format JSONL that TuneNNGenKTO actually consumes.
+
+        new_examples:  list of SFT chat examples (all label=True).
+        cycle:         current cycle number.
+        output_dir:    KTO pipeline root (e.g. out/kto_pipeline/...).
+        """
+        # 1. Parent writes train.jsonl — cumulative SFT examples, dev/test copies
+        stats = super().augment_training_data(new_examples, cycle, output_dir)
+        cycle_dir = Path(stats["output_dir"])
+
+        # 2. Re-read the cumulative SFT JSONL and convert each entry to KTO desirable.
+        sft_path = cycle_dir / "train.jsonl"
+        all_sft = self._load_jsonl(sft_path)
+        desirables: List[Dict[str, Any]] = []
+        for sft_ex in all_sft:
+            kto = self._sft_to_kto(sft_ex, label=True)
+            if kto is not None:
+                desirables.append(kto)
+
+        # 3. Balance against the rolling undesirable cache.
+        combined, balance_stats = self.balance(
+            desirables, self._accumulated_undesirable, self.undesirable_ratio
+        )
+
+        # 4. Write kto_train.jsonl (with _meta retained for inspection — the
+        #    TuneNNGenKTO loader strips _meta before building the Dataset).
+        kto_file = cycle_dir / "kto_train.jsonl"
+        self._save_jsonl(combined, kto_file)
+
+        # 5. Persist undesirable cache (may have grown this cycle).
+        self.save_undesirable_cache()
+
+        # 6. Report
+        print(f"[KTO] cycle {cycle}: wrote {kto_file}")
+        print(f"[KTO] cycle {cycle}: desirable={balance_stats['desirable_count']}, "
+              f"undesirable_used={balance_stats['undesirable_used']} / "
+              f"available={balance_stats['undesirable_available']} "
+              f"(target ratio={balance_stats['target_ratio']}, "
+              f"actual={balance_stats['actual_ratio']:.2f}) — {balance_stats['balance_note']}")
+
+        stats["kto"] = balance_stats
+        stats["kto_file"] = str(kto_file)
+        return stats
+
+    # ── initial KTO file (cycle-1 input) ─────────────────────────────────────
+
+    def _build_initial_kto_file(self):
+        """
+        On first init, convert every example in the original SFT train.jsonl
+        to a KTO desirable.  This is the file that cycle-1 fine-tuning reads.
+        """
+        desirables: List[Dict[str, Any]] = []
+        for sft_ex in self.original_train_data:
+            kto = self._sft_to_kto(sft_ex, label=True)
+            if kto is not None:
+                desirables.append(kto)
+        self._save_jsonl(desirables, self._initial_kto_file)
+        print(f"[KTO] Initial kto_train.jsonl built at {self._initial_kto_file} "
+              f"({len(desirables)} desirable examples; no undesirables yet)")

--- a/ab/gpt/kto_pipeline/kto_generator.py
+++ b/ab/gpt/kto_pipeline/kto_generator.py
@@ -285,7 +285,7 @@ def _seed_everything(seed: int) -> None:
 
 def load_model_and_tokenizer(base_model: str, adapter: Optional[str], context_length: int):
     """Load the base NNGPT model in 4-bit, optionally with a prior LoRA adapter."""
-    from transformers import AutoModelForCausalLM, AutoTokenizer
+    from ab.gpt.util.LLM import LLM
 
     access_token = (
         os.environ.get("HF_TOKEN")
@@ -293,22 +293,19 @@ def load_model_and_tokenizer(base_model: str, adapter: Optional[str], context_le
         or None
     )
 
-    print(f"[GEN] Loading tokenizer: {base_model}")
-    tokenizer = AutoTokenizer.from_pretrained(
-        base_model, trust_remote_code=True, token=access_token
+    # Reuse the repo's loader (4-bit + bfloat16 + tokenizer caching). Generation
+    # always tokenizes with add_special_tokens=False, so LLM's add_eos_token has
+    # no effect here, and single-sequence generation is unaffected by padding_side.
+    print(f"[GEN] Loading base model in 4-bit via LLM: {base_model}")
+    loader = LLM(
+        base_model,
+        quantization_config_4bit,
+        access_token=access_token,
+        context_length=context_length,
     )
+    model, tokenizer = loader.get_model(), loader.get_tokenizer()
     if tokenizer.pad_token_id is None and tokenizer.eos_token_id is not None:
         tokenizer.pad_token = tokenizer.eos_token
-
-    print(f"[GEN] Loading base model in 4-bit: {base_model}")
-    model = AutoModelForCausalLM.from_pretrained(
-        base_model,
-        quantization_config=quantization_config_4bit,
-        device_map="auto",
-        torch_dtype=torch.bfloat16,
-        trust_remote_code=True,
-        token=access_token,
-    )
 
     if adapter:
         adapter_path = Path(adapter)

--- a/ab/gpt/kto_pipeline/kto_generator.py
+++ b/ab/gpt/kto_pipeline/kto_generator.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import numpy as np
+import torch
+
+# Read-only reuse of existing repo helpers (not modified).
+from ab.gpt.markov.code_extractor import CodeExtractor, validate_code, check_net_class
+from ab.gpt.util.Const import conf_test_dir, new_nn_file
+from ab.gpt.util.LLMUtil import quantization_config_4bit
+
+
+def _salvage_fenceless_code(raw: str) -> Optional[str]:
+    """
+    Recover code from a generation that omitted the ```python fence.
+
+    The model is trained to fence its output, but occasionally emits a bare
+    class.  Rather than throw away a potentially-good architecture, slice from
+    the first plausible code anchor to the end and accept it only if it is
+    syntactically valid and contains a proper Net class.
+    """
+    anchors = ["import torch", "def supported_hyperparameters", "class Net"]
+    starts = [raw.find(a) for a in anchors if raw.find(a) != -1]
+    if not starts:
+        return None
+    candidate = raw[min(starts):].strip()
+    # Drop any trailing prose after the last dedented blank-line block is hard;
+    # rely on the compiler — if the tail is prose it will usually still parse as
+    # long as it's commented or absent.  Require both syntax + Net structure.
+    ok_syntax, _ = validate_code(candidate)
+    if not ok_syntax:
+        return None
+    has_net, _ = check_net_class(candidate)
+    if not has_net:
+        return None
+    return candidate
+
+
+# ── Prompt construction ──────────────────────────────────────────────────────
+
+# Base persona — verbatim from the ABrain/NNGPT-UniqueArch-Rag model card.
+SYSTEM_PERSONA = (
+    "You are an expert PyTorch architecture designer specializing in creating "
+    "UNIQUE, high-performing neural networks optimized for first-epoch accuracy."
+)
+
+# Fallback execution rules (used only if the conf file cannot be read).  Kept
+# deliberately short; the real rules live in
+# conf/prompt/test/unique_rag_test_rules.json and are loaded when present.
+_FALLBACK_RULES = (
+    "\nThe code MUST be directly executable by the evaluation tool.\n"
+    "1. Start with `import torch` and `import torch.nn as nn`.\n"
+    "2. Define `def supported_hyperparameters(): return {'lr', 'momentum'}` "
+    "OUTSIDE all classes.\n"
+    "3. Define a `Net(nn.Module)` whose `__init__(self, in_shape, out_shape, "
+    "prm, device)` derives in_channels from `int(in_shape[0])` and num_classes "
+    "from `int(out_shape[0])` — NEVER hardcode them.\n"
+    "4. Net MUST implement `forward(self, x)`, `train_setup(self, prm)` and "
+    "`learn(self, train_data)`.\n"
+    "5. Complete, executable code only — no placeholders, no `...`.\n"
+)
+
+
+CRITICAL_REINFORCEMENT = (
+    "\n\nCRITICAL — read this carefully, it OVERRIDES any earlier instruction "
+    "about in_shape:\n"
+    "This evaluator instantiates your model as `Net(in_shape, out_shape, prm, "
+    "device)` where **in_shape is (batch, channels, height, width)** — a 4-tuple "
+    "whose FIRST element (in_shape[0]) is the BATCH size (1), NOT the channels. "
+    "The channel count is in_shape[1]. Any earlier rule that says to read input "
+    "channels from in_shape[0] is WRONG here and builds a 1-channel first conv "
+    "that crashes on the 3-channel images.\n"
+    "1. FIRST-LAYER INPUT CHANNELS — derive it robustly with a length check:\n"
+    "       in_channels = in_shape[1] if len(in_shape) == 4 else in_shape[0]\n"
+    "   then `nn.Conv2d(in_channels, ...)` for the first conv. For this RGB "
+    "dataset in_channels is 3. NEVER use in_shape[0] directly as the channel "
+    "count and NEVER hardcode `nn.Conv2d(1, ...)`.\n"
+    "2. OUTPUT MUST BE 2-D LOGITS of shape (batch, {num_classes}): "
+    "num_classes = int(out_shape[0]). Reduce ALL spatial dimensions before the "
+    "classifier — end with global pooling then flatten then Linear, e.g. "
+    "`x = nn.AdaptiveAvgPool2d((1, 1))(x); x = torch.flatten(x, 1); "
+    "x = self.classifier(x)` where `self.classifier = nn.Linear(C, num_classes)`. "
+    "NEVER return a 4-D feature map (N, C, H, W) — the loss only accepts "
+    "(N, num_classes)."
+)
+
+# Rotated through generations to push structural diversity (→ more novel,
+# more desirable models, fewer near-duplicate rejections).  Stays inside the
+# model's training distribution: these are families it was trained on.
+DIVERSITY_HINTS = [
+    "a residual / skip-connection family",
+    "a dense / feature-reuse family",
+    "an inverted-bottleneck / depthwise-separable family",
+    "a multi-branch / inception-style family",
+    "a lightweight attention-augmented family",
+    "a plain VGG-style stacked-convolution family",
+    "a grouped-convolution / channel-shuffle family",
+    "a pyramid / multi-scale pooling family",
+]
+
+
+def load_execution_rules() -> str:
+    """Load the system_prompt_template execution rules the model was SFT'd on."""
+    rules_path = conf_test_dir / "unique_rag_test_rules.json"
+    try:
+        with open(rules_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        rules = data.get("system_prompt_template", "")
+        if rules and rules.strip():
+            return rules
+    except Exception as e:  # noqa: BLE001 — best-effort, fall back gracefully
+        print(f"[GEN][WARN] Could not read {rules_path}: {e}. Using fallback rules.")
+    return _FALLBACK_RULES
+
+
+# Teacher-forcing prefix: the model's answer is seeded with these tokens so it
+# starts from the exact NNEval-required structure (imports + the
+# supported_hyperparameters function) instead of free-forming the preamble.
+# Mirrors how ab/gpt/util/nn_sftcodegen_rag.py uses prefix_code.
+_FALLBACK_PREFIX = (
+    "```python\n"
+    "import torch\n"
+    "import torch.nn as nn\n\n"
+    "def supported_hyperparameters():\n"
+    "    return {'lr', 'momentum'}\n\n"
+)
+
+
+def load_prefix_code() -> str:
+    """Load the prefix_code the model is teacher-forced to start its answer with."""
+    rules_path = conf_test_dir / "unique_rag_test_rules.json"
+    try:
+        with open(rules_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        pfx = data.get("prefix_code", "")
+        if pfx and pfx.strip():
+            return pfx
+    except Exception as e:  # noqa: BLE001
+        print(f"[GEN][WARN] Could not read prefix_code from {rules_path}: {e}")
+    return _FALLBACK_PREFIX
+
+
+def _quick_structural_check(code: str, channels: int = 3, hw: int = 32, num_classes: int = 10):
+    """
+    Pre-flight a generated model EXACTLY the way nn-dataset's evaluator does:
+    instantiate ``Net(in_shape, out_shape, prm, device)`` with the framework's
+    4-tuple ``in_shape = (batch=1, channels, H, W)`` and ``out_shape =
+    (num_classes,)``, then forward a real 3-channel batch.  Using the same
+    4-tuple is essential — a 3-tuple gave false passes because in_shape[0]
+    happened to equal the channel count.
+
+    Catches, before any GPU training is wasted:
+      * channels read from in_shape[0] (the batch=1) → 1-channel conv → forward_error
+      * 4-D output (no global pool/flatten) → bad_output_shape
+      * shape mismatches / missing methods → init_/forward_error
+
+    Returns (ok: bool, message: str).
+    """
+    import torch as _torch
+
+    ns: Dict = {}
+    try:
+        exec("import torch\nimport torch.nn as nn\nimport torch.nn.functional as F\n"
+             "from torch import Tensor\n", ns)
+        exec(code, ns)
+    except Exception as e:  # noqa: BLE001
+        return False, f"exec_error: {type(e).__name__}: {e}"
+
+    Net = ns.get("Net")
+    if Net is None:
+        return False, "no_Net_class"
+
+    device = _torch.device("cpu")
+    prm = {"lr": 0.01, "momentum": 0.9, "dropout": 0.2}
+    # nn-dataset passes in_shape as (batch, channels, H, W); out_shape as (num_classes,).
+    eval_in_shape = (1, channels, hw, hw)
+    try:
+        model = Net(eval_in_shape, (num_classes,), prm, device)
+    except Exception as e:  # noqa: BLE001
+        return False, f"init_error: {type(e).__name__}: {e}"
+
+    try:
+        model.eval()
+        x = _torch.randn(2, channels, hw, hw)  # a real 3-channel batch
+        with _torch.no_grad():
+            y = model(x)
+    except Exception as e:  # noqa: BLE001
+        return False, f"forward_error: {type(e).__name__}: {e}"
+
+    shape = tuple(getattr(y, "shape", ()))
+    if shape != (2, num_classes):
+        return False, f"bad_output_shape: got {shape}, want (2, {num_classes})"
+    return True, "ok"
+
+
+# Used by KTO_PROMPT_MODE=minimal: the ONLY correctness fix (channel index),
+# WITHOUT the diversity hints or output-head guidance that "enhanced" adds.
+MINIMAL_INSHAPE_FIX = (
+    "\n\nIMPORTANT (overrides any earlier in_shape guidance): this evaluator passes "
+    "in_shape as (batch, channels, height, width). Derive the first conv's input "
+    "channels as `in_channels = in_shape[1] if len(in_shape) == 4 else in_shape[0]` "
+    "(it is 3 for this RGB dataset) and use `nn.Conv2d(in_channels, ...)`. Do NOT use "
+    "in_shape[0] as the channel count, and do not hardcode it."
+)
+
+
+def build_prompt_messages(
+    dataset: str = "cifar-10",
+    params_limit: int = 500_000,
+    diversity_hint: Optional[str] = None,
+    execution_rules: Optional[str] = None,
+) -> List[Dict[str, str]]:
+    """
+    Build the [system, user] chat messages used both to GENERATE a model and
+    (later, in the orchestrator) to form the KTO ``prompt_messages`` paired
+    with that model's completion.  Keeping this in one place guarantees the
+    training prompt matches the generation prompt exactly.
+
+    The KTO_PROMPT_MODE env var selects how much of OUR prompt engineering is
+    applied (so an ablation .sh can A/B test it without code changes):
+      * "enhanced" (default): SYSTEM_PERSONA + repo rules + diversity hint +
+        full CRITICAL_REINFORCEMENT (in_shape fix AND output-head guidance).
+      * "minimal":  repo rules + ONLY the one-line in_shape channel correction
+        (no hints, no head guidance) — isolates "do our quality nudges help?".
+      * "original": pure repo prompt, none of our additions. WARNING: the repo
+        rules say in_channels=in_shape[0], which is WRONG for this evaluator
+        (channels are in_shape[1]) → expect Conv2d(1,...) eval failures.
+    """
+    mode = os.environ.get("KTO_PROMPT_MODE", "enhanced").strip().lower()
+    rules = execution_rules if execution_rules is not None else load_execution_rules()
+    system = SYSTEM_PERSONA + "\n\n" + rules
+
+    num_classes = {"cifar-10": 10, "cifar-100": 100}.get(dataset, 10)
+    dataset_label = {
+        "cifar-10": "CIFAR-10 (32x32 RGB, channels-first C x H x W), 10 classes",
+        "cifar-100": "CIFAR-100 (32x32 RGB, channels-first C x H x W), 100 classes",
+    }.get(dataset, f"{dataset} (channels-first C x H x W)")
+
+    user = (
+        "Task: Design a PyTorch CV model for image classification.\n"
+        f"Dataset: {dataset_label}.\n"
+        f"Resource limits: params <= {params_limit}; latency budget: tight "
+        "(edge-friendly).\n"
+        "Constraints: use standard layers only; no pretrained weights."
+    )
+    # Diversity hint is one of OUR additions → enhanced-only.
+    if mode == "enhanced" and diversity_hint:
+        user += (
+            f"\nArchitectural direction for this design: explore {diversity_hint}. "
+            "Produce a distinct, novel architecture (do not repeat a generic CNN)."
+        )
+
+    # Reinforcement goes LAST so it is the most recent context before generation.
+    if mode == "enhanced":
+        user += CRITICAL_REINFORCEMENT.format(num_classes=num_classes)
+    elif mode == "minimal":
+        user += MINIMAL_INSHAPE_FIX
+    # mode == "original": add nothing (pure repo prompt; carries the in_shape[0] bug)
+
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+
+
+# ── Model loading ────────────────────────────────────────────────────────────
+
+def _seed_everything(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def load_model_and_tokenizer(base_model: str, adapter: Optional[str], context_length: int):
+    """Load the base NNGPT model in 4-bit, optionally with a prior LoRA adapter."""
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    access_token = (
+        os.environ.get("HF_TOKEN")
+        or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+        or None
+    )
+
+    print(f"[GEN] Loading tokenizer: {base_model}")
+    tokenizer = AutoTokenizer.from_pretrained(
+        base_model, trust_remote_code=True, token=access_token
+    )
+    if tokenizer.pad_token_id is None and tokenizer.eos_token_id is not None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    print(f"[GEN] Loading base model in 4-bit: {base_model}")
+    model = AutoModelForCausalLM.from_pretrained(
+        base_model,
+        quantization_config=quantization_config_4bit,
+        device_map="auto",
+        torch_dtype=torch.bfloat16,
+        trust_remote_code=True,
+        token=access_token,
+    )
+
+    if adapter:
+        adapter_path = Path(adapter)
+        if adapter_path.exists():
+            from peft import PeftModel
+
+            print(f"[GEN] Attaching previous-cycle LoRA adapter: {adapter_path}")
+            model = PeftModel.from_pretrained(model, str(adapter_path))
+        else:
+            print(f"[GEN][WARN] Adapter path not found, generating from base only: {adapter_path}")
+
+    model.eval()
+    return model, tokenizer
+
+
+# ── Generation ───────────────────────────────────────────────────────────────
+
+def generate_models(
+    *,
+    base_model: str,
+    adapter: Optional[str],
+    out_dir: Path,
+    records_file: Path,
+    num_models: int,
+    start_index: int,
+    temperature: float,
+    top_k: int,
+    top_p: float,
+    max_new_tokens: int,
+    dataset: str,
+    params_limit: int,
+    context_length: int,
+    seed: int,
+    max_rejections: int = 5,
+) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    extractor = CodeExtractor()
+    execution_rules = load_execution_rules()
+    prefix_code = load_prefix_code()
+    num_classes = {"cifar-10": 10, "cifar-100": 100}.get(dataset, 10)
+
+    model, tokenizer = load_model_and_tokenizer(base_model, adapter, context_length)
+
+    # One-time prompt dump so the run is self-verifying: the SLURM log and a file
+    # on disk show the EXACT system+user prompt the model was conditioned on
+    # (proves whether the channel/output reinforcement is actually in effect).
+    _probe_messages = build_prompt_messages(
+        dataset=dataset, params_limit=params_limit,
+        diversity_hint=DIVERSITY_HINTS[start_index % len(DIVERSITY_HINTS)],
+        execution_rules=execution_rules,
+    )
+    _prompt_mode = os.environ.get("KTO_PROMPT_MODE", "enhanced").strip().lower()
+    # flush=True so this appears in the SLURM log immediately (stdout is
+    # block-buffered to a file; without flushing it hides behind tqdm's stderr).
+    print("=" * 80, flush=True)
+    print(f"[GEN] PROMPT IN USE (KTO_PROMPT_MODE={_prompt_mode}):", flush=True)
+    print("---- SYSTEM ----", flush=True)
+    print(_probe_messages[0]["content"], flush=True)
+    print("---- USER ----", flush=True)
+    print(_probe_messages[1]["content"], flush=True)
+    print(f"---- PREFIX (teacher-forced start) ----\n{prefix_code}", flush=True)
+    print(f"[GEN] temperature={temperature}, max_rejections={max_rejections} "
+          f"(retry until model instantiates + forwards on a 3x32x32 batch)", flush=True)
+    print("=" * 80, flush=True)
+    try:
+        (out_dir / "_prompt_used.txt").write_text(
+            "SYSTEM:\n" + _probe_messages[0]["content"]
+            + "\n\nUSER:\n" + _probe_messages[1]["content"]
+            + "\n\nPREFIX:\n" + prefix_code,
+            encoding="utf-8",
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+    records: List[Dict] = []
+    n_ok = 0
+    for i in range(num_models):
+        idx = start_index + i
+        model_id = f"gen_{idx:04d}"
+        model_dir = out_dir / model_id
+        model_dir.mkdir(parents=True, exist_ok=True)
+        hint = DIVERSITY_HINTS[idx % len(DIVERSITY_HINTS)]
+
+        messages = build_prompt_messages(
+            dataset=dataset,
+            params_limit=params_limit,
+            diversity_hint=hint,
+            execution_rules=execution_rules,
+        )
+        text = tokenizer.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
+        base_inputs = tokenizer(text, return_tensors="pt", add_special_tokens=False).to(model.device)
+        # Teacher-force the answer to begin with prefix_code so structure is anchored.
+        if prefix_code:
+            prefix_ids = tokenizer(
+                prefix_code, return_tensors="pt", add_special_tokens=False
+            ).input_ids.to(model.device)
+            input_ids = torch.cat([base_inputs.input_ids, prefix_ids], dim=1)
+        else:
+            input_ids = base_inputs.input_ids
+        attention_mask = torch.ones_like(input_ids)
+
+        # ── Rejection sampling: keep regenerating until the model instantiates
+        #    and forwards correctly (or we exhaust max_rejections attempts). ──
+        accepted_code: Optional[str] = None
+        last_raw = ""
+        last_reason = "no_attempt"
+        attempts_used = 0
+        for attempt in range(max_rejections + 1):
+            attempts_used = attempt + 1
+            _seed_everything(seed + idx + attempt * 7919)
+            try:
+                with torch.no_grad():
+                    generated = model.generate(
+                        input_ids=input_ids,
+                        attention_mask=attention_mask,
+                        max_new_tokens=max_new_tokens,
+                        do_sample=True,
+                        temperature=temperature,
+                        top_k=top_k,
+                        top_p=top_p,
+                        pad_token_id=tokenizer.eos_token_id,
+                    )
+                new_tokens = generated[0][input_ids.shape[1]:]
+                gen_text = tokenizer.decode(new_tokens, skip_special_tokens=True)
+                raw_output = (prefix_code + gen_text) if prefix_code else gen_text
+            except Exception as e:  # noqa: BLE001
+                last_reason = f"generation_crashed: {type(e).__name__}: {e}"
+                torch.cuda.empty_cache()
+                continue
+            last_raw = raw_output
+
+            code, message = extractor.extract(raw_output)
+            if code is None:
+                salvaged = _salvage_fenceless_code(raw_output)
+                if salvaged is not None:
+                    code, message = salvaged, "salvaged_fenceless"
+            if code is None:
+                last_reason = f"extraction_failed: {message}"
+                continue  # reject → retry
+            if "import torch" not in code:
+                code = "import torch\nimport torch.nn as nn\n\n" + code
+
+            ok_struct, check_msg = _quick_structural_check(
+                code, channels=3, hw=32, num_classes=num_classes
+            )
+            if not ok_struct:
+                last_reason = f"structural_check_failed: {check_msg}"
+                last_raw = raw_output  # keep this (real bad arch) as the negative
+                continue  # reject → retry
+            accepted_code = code
+            break
+
+        raw_file = model_dir / "raw_output.txt"
+        raw_file.write_text(last_raw, encoding="utf-8")
+
+        if accepted_code is not None:
+            code_file = model_dir / new_nn_file
+            code_file.write_text(accepted_code, encoding="utf-8")
+            n_ok += 1
+            records.append({
+                "model_id": model_id, "index": idx, "ok": True,
+                "code_file": str(code_file), "raw_file": str(raw_file),
+                "error": None, "diversity_hint": hint, "attempts": attempts_used,
+            })
+            print(f"[GEN] {model_id}: ok ({hint}) [{attempts_used} attempt(s)]", flush=True)
+        else:
+            # All attempts failed validation → still a usable KTO negative (the
+            # last bad generation), but NOT written as new_nn.py so the evaluator
+            # doesn't waste a training run on a model we already know is broken.
+            records.append({
+                "model_id": model_id, "index": idx, "ok": False,
+                "code_file": None, "raw_file": str(raw_file),
+                "error": last_reason, "diversity_hint": hint, "attempts": attempts_used,
+            })
+            print(f"[GEN] {model_id}: rejected after {attempts_used} attempt(s) — "
+                  f"{last_reason}", flush=True)
+
+        torch.cuda.empty_cache()
+
+    records_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(records_file, "w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+
+    print(f"[GEN] Done. {n_ok}/{num_models} passed structural pre-check "
+          f"(will be evaluated). Records → {records_file}", flush=True)
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="KTO pipeline self-contained model generator")
+    parser.add_argument("--base_model", type=str, required=True,
+                        help="HF id or local path of the domain-trained NNGPT model")
+    parser.add_argument("--adapter", type=str, default=None,
+                        help="Optional LoRA adapter dir from the previous KTO cycle")
+    parser.add_argument("--out_dir", type=str, required=True,
+                        help="Output dir (will contain gen_XXXX/new_nn.py for NNEval)")
+    parser.add_argument("--records_file", type=str, required=True,
+                        help="Where to write generation_records.jsonl")
+    parser.add_argument("--num_models", type=int, default=30)
+    parser.add_argument("--start_index", type=int, default=0)
+    parser.add_argument("--temperature", type=float, default=0.4)
+    parser.add_argument("--top_k", type=int, default=50)
+    parser.add_argument("--top_p", type=float, default=0.95)
+    parser.add_argument("--max_new_tokens", type=int, default=2048)
+    parser.add_argument("--max_rejections", type=int, default=5,
+                        help="Regenerate a model up to this many times if it fails "
+                             "the structural pre-check (instantiate + forward)")
+    parser.add_argument("--dataset", type=str, default="cifar-10")
+    parser.add_argument("--params_limit", type=int, default=500_000)
+    parser.add_argument("--context_length", type=int, default=4096)
+    parser.add_argument("--seed", type=int, default=43)
+
+    args = parser.parse_args()
+
+    generate_models(
+        base_model=args.base_model,
+        adapter=args.adapter,
+        out_dir=Path(args.out_dir),
+        records_file=Path(args.records_file),
+        num_models=args.num_models,
+        start_index=args.start_index,
+        temperature=args.temperature,
+        top_k=args.top_k,
+        top_p=args.top_p,
+        max_new_tokens=args.max_new_tokens,
+        dataset=args.dataset,
+        params_limit=args.params_limit,
+        context_length=args.context_length,
+        seed=args.seed,
+        max_rejections=args.max_rejections,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ab/gpt/kto_pipeline/kto_selfcontained_finetune.py
+++ b/ab/gpt/kto_pipeline/kto_selfcontained_finetune.py
@@ -67,6 +67,16 @@ class SelfContainedKTOPipeline:
         undesirable_ratio: float = 1.0,
         max_undesirable_total: int = 1000,
         min_train_examples: int = 10,
+        # curriculum threshold (#1): "fixed" = flat bar; "quantile" = max(floor,
+        # q-percentile of the cycle's accuracies); "linear" = floor + slope*cycle.
+        threshold_mode: str = "fixed",
+        threshold_quantile: float = 0.6,
+        threshold_ceil: float = 0.62,
+        threshold_slope: float = 0.01,
+        # dynamic class weights (#2): "auto" sets undesirable_weight so that
+        # desirable_weight*n_D ~= class_weight_target * undesirable_weight*n_U.
+        class_weight_mode: str = "fixed",
+        class_weight_target: float = 1.0,
         # KTO hyperparameters
         kto_beta: float = 0.1,
         kto_desirable_weight: float = 1.0,
@@ -119,6 +129,13 @@ class SelfContainedKTOPipeline:
         self.undesirable_ratio = undesirable_ratio
         self.max_undesirable_total = max_undesirable_total
         self.min_train_examples = min_train_examples
+
+        self.threshold_mode = threshold_mode
+        self.threshold_quantile = threshold_quantile
+        self.threshold_ceil = threshold_ceil
+        self.threshold_slope = threshold_slope
+        self.class_weight_mode = class_weight_mode
+        self.class_weight_target = class_weight_target
 
         self.kto_beta = kto_beta
         self.kto_desirable_weight = kto_desirable_weight
@@ -184,6 +201,8 @@ class SelfContainedKTOPipeline:
         logger.info(f"Desirable weight     : {self.kto_desirable_weight}")
         logger.info(f"Undesirable weight   : {self.kto_undesirable_weight}")
         logger.info(f"Undesirable ratio    : {self.undesirable_ratio}")
+        logger.info(f"Threshold mode       : {self.threshold_mode}")
+        logger.info(f"Class weight mode    : {self.class_weight_mode}")
         logger.info(f"Starting desirable   : {len(self.desirable)}")
         logger.info(f"Starting undesirable : {len(self.undesirable)}")
         logger.info("=" * 80)
@@ -231,6 +250,39 @@ class SelfContainedKTOPipeline:
                 torch.cuda.empty_cache()
         except Exception:  # noqa: BLE001 — cleanup is best-effort
             pass
+
+    @staticmethod
+    def _percentile(values: List[float], q: float) -> float:
+        if not values:
+            return 0.0
+        s = sorted(values)
+        if len(s) == 1:
+            return s[0]
+        pos = max(0.0, min(1.0, q)) * (len(s) - 1)
+        lo, hi = math.floor(pos), math.ceil(pos)
+        if lo == hi:
+            return s[int(lo)]
+        return s[int(lo)] + (s[int(hi)] - s[int(lo)]) * (pos - lo)
+
+    def _effective_threshold(self, cycle: int, cycle_accs: List[float]) -> float:
+        """Curriculum bar: floor for "fixed"; rising for "quantile"/"linear"."""
+        floor = self.accuracy_threshold
+        if self.threshold_mode == "quantile" and cycle_accs:
+            return min(max(floor, self._percentile(cycle_accs, self.threshold_quantile)),
+                       self.threshold_ceil)
+        if self.threshold_mode == "linear":
+            return min(floor + self.threshold_slope * max(0, cycle - 1), self.threshold_ceil)
+        return floor
+
+    def _class_weights(self, ds_stats: Dict[str, Any]) -> Tuple[float, float]:
+        """KTO imbalance rule: balance desirable_weight*n_D vs undesirable_weight*n_U."""
+        dw, uw = self.kto_desirable_weight, self.kto_undesirable_weight
+        if self.class_weight_mode == "auto":
+            n_d = max(1, int(ds_stats.get("desirable_used", 0)))
+            n_u = max(1, int(ds_stats.get("undesirable_used", 0)))
+            uw = (dw * n_d) / (max(1e-6, self.class_weight_target) * n_u)
+            uw = min(10.0, max(0.1, uw))
+        return dw, uw
 
     def _cycle_dir(self, cycle: int) -> Path:
         d = self.output_dir / f"cycle_{cycle}"
@@ -404,6 +456,15 @@ class SelfContainedKTOPipeline:
                 },
             })
 
+        cycle_accs: List[float] = []
+        for ev in eval_by_id.values():
+            if ev.get("success") and ev.get("accuracy") is not None:
+                try:
+                    cycle_accs.append(float(ev.get("accuracy")))
+                except (TypeError, ValueError):
+                    pass
+        eff_threshold = self._effective_threshold(cycle, cycle_accs)
+
         for rec in generation_records:
             model_id = rec.get("model_id")
             model_dir = nneval_dir / model_id
@@ -455,7 +516,7 @@ class SelfContainedKTOPipeline:
                 accuracy = 0.0
             accuracies.append(accuracy)
 
-            if accuracy < self.accuracy_threshold:
+            if accuracy < eff_threshold:
                 add_undesirable(_fenced(code), model_id, "low_accuracy", accuracy)
                 n_und_lowacc += 1
                 continue
@@ -495,6 +556,7 @@ class SelfContainedKTOPipeline:
             "evaluated_accuracies": len(accuracies),
             "best_accuracy": best_acc,
             "avg_accuracy": avg_acc,
+            "effective_threshold": eff_threshold,
             "desirable_total": len(self.desirable),
             "undesirable_total": len(self.undesirable),
         }
@@ -509,6 +571,7 @@ class SelfContainedKTOPipeline:
         logger.info(f"      unparseable          : {n_und_unparseable}")
         logger.info(f"  skipped (no signal)      : {n_skipped}")
         logger.info(f"  best/avg acc this cycle  : {best_acc*100:.2f}% / {avg_acc*100:.2f}%")
+        logger.info(f"  effective threshold      : {eff_threshold*100:.2f}% ({self.threshold_mode})")
         logger.info(f"  cumulative desirable     : {len(self.desirable)}")
         logger.info(f"  cumulative undesirable   : {len(self.undesirable)}")
         return stats
@@ -567,11 +630,18 @@ class SelfContainedKTOPipeline:
 
     # ── stage 5: KTO fine-tune ──────────────────────────────────────────────────
 
-    def run_kto_training(self, cycle: int, kto_file: Path) -> Dict[str, Any]:
+    def run_kto_training(self, cycle: int, kto_file: Path,
+                         desirable_weight: Optional[float] = None,
+                         undesirable_weight: Optional[float] = None) -> Dict[str, Any]:
         logger.info("")
         logger.info("=" * 80)
         logger.info(f"CYCLE {cycle}: KTO FINE-TUNING")
         logger.info("=" * 80)
+
+        dw = desirable_weight if desirable_weight is not None else self.kto_desirable_weight
+        uw = undesirable_weight if undesirable_weight is not None else self.kto_undesirable_weight
+        logger.info(f"[cycle {cycle}] class weights: desirable={dw:.3f}, undesirable={uw:.3f} "
+                    f"({self.class_weight_mode})")
 
         checkpoint_dir = self._checkpoint_dir(cycle)
         if checkpoint_dir.exists() and (checkpoint_dir / "adapter_config.json").exists():
@@ -586,8 +656,8 @@ class SelfContainedKTOPipeline:
             "--kto_data_file", str(kto_file),
             "--kto_checkpoint_dir", str(checkpoint_dir),
             "--kto_beta", str(self.kto_beta),
-            "--kto_desirable_weight", str(self.kto_desirable_weight),
-            "--kto_undesirable_weight", str(self.kto_undesirable_weight),
+            "--kto_desirable_weight", str(dw),
+            "--kto_undesirable_weight", str(uw),
             "--num_train_epochs", str(self.num_train_epochs),
             "--max_prompt_length", str(self.kto_max_prompt_length),
             "--max_completion_length", str(self.kto_max_completion_length),
@@ -618,7 +688,8 @@ class SelfContainedKTOPipeline:
 
         logger.info(f"[cycle {cycle}] KTO training complete in {minutes:.1f} min → {checkpoint_dir}")
         return {"success": True, "checkpoint_dir": str(checkpoint_dir),
-                "training_time_minutes": minutes}
+                "training_time_minutes": minutes,
+                "desirable_weight": dw, "undesirable_weight": uw}
 
     # ── orchestration ───────────────────────────────────────────────────────────
 
@@ -638,7 +709,8 @@ class SelfContainedKTOPipeline:
         kto_file, ds_stats = self.build_kto_dataset(cycle)
 
         if kto_file is not None:
-            train_stats = self.run_kto_training(cycle, kto_file)
+            dw, uw = self._class_weights(ds_stats)
+            train_stats = self.run_kto_training(cycle, kto_file, dw, uw)
         else:
             train_stats = {"success": False, "skipped": True, "reason": "insufficient_data"}
 
@@ -729,6 +801,17 @@ def main() -> None:
     parser.add_argument("--max_undesirable_total", type=int, default=1000)
     parser.add_argument("--min_train_examples", type=int, default=10)
 
+    # curriculum threshold (#1)
+    parser.add_argument("--threshold_mode", type=str, default="fixed",
+                        choices=["fixed", "quantile", "linear"])
+    parser.add_argument("--threshold_quantile", type=float, default=0.6)
+    parser.add_argument("--threshold_ceil", type=float, default=0.62)
+    parser.add_argument("--threshold_slope", type=float, default=0.01)
+    # dynamic class weights (#2)
+    parser.add_argument("--class_weight_mode", type=str, default="fixed",
+                        choices=["fixed", "auto"])
+    parser.add_argument("--class_weight_target", type=float, default=1.0)
+
     parser.add_argument("--kto_beta", type=float, default=0.1)
     parser.add_argument("--kto_desirable_weight", type=float, default=1.0)
     parser.add_argument("--kto_undesirable_weight", type=float, default=1.0)
@@ -776,6 +859,12 @@ def main() -> None:
         undesirable_ratio=args.undesirable_ratio,
         max_undesirable_total=args.max_undesirable_total,
         min_train_examples=args.min_train_examples,
+        threshold_mode=args.threshold_mode,
+        threshold_quantile=args.threshold_quantile,
+        threshold_ceil=args.threshold_ceil,
+        threshold_slope=args.threshold_slope,
+        class_weight_mode=args.class_weight_mode,
+        class_weight_target=args.class_weight_target,
         kto_beta=args.kto_beta,
         kto_desirable_weight=args.kto_desirable_weight,
         kto_undesirable_weight=args.kto_undesirable_weight,

--- a/ab/gpt/kto_pipeline/kto_selfcontained_finetune.py
+++ b/ab/gpt/kto_pipeline/kto_selfcontained_finetune.py
@@ -1,0 +1,814 @@
+#!/usr/bin/env python3
+
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import math
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from ab.gpt.kto_pipeline.kto_generator import build_prompt_messages
+from ab.gpt.iterative_pipeline.novelty_checker import NoveltyChecker
+from ab.gpt.util.Const import conf_llm_dir, nngpt_dir
+
+logger = logging.getLogger("kto_selfcontained")
+
+
+# ── small helpers ─────────────────────────────────────────────────────────────
+
+def _read_jsonl(path: Path) -> List[Dict[str, Any]]:
+    records: List[Dict[str, Any]] = []
+    if not path.exists():
+        return records
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+    return records
+
+
+def _write_jsonl(records: List[Dict[str, Any]], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+
+
+def _fenced(code: str) -> str:
+    """Wrap raw model code in a python fence — the canonical good completion."""
+    return f"```python\n{code.strip()}\n```"
+
+
+# ── pipeline ──────────────────────────────────────────────────────────────────
+
+class SelfContainedKTOPipeline:
+    """Iterative KTO pipeline that bootstraps its own preference data."""
+
+    def __init__(
+        self,
+        llm_conf: str,
+        cycles: int = 10,
+        models_per_cycle: int = 30,
+        accuracy_threshold: float = 0.50,
+        novelty_check: bool = True,
+        undesirable_ratio: float = 1.0,
+        max_undesirable_total: int = 1000,
+        min_train_examples: int = 10,
+        # KTO hyperparameters
+        kto_beta: float = 0.1,
+        kto_desirable_weight: float = 1.0,
+        kto_undesirable_weight: float = 1.0,
+        num_train_epochs: int = 3,
+        # KTO drift control — conservative defaults.  A single KTO fine-tune at
+        # the SFT-default lr=1e-5 / r=32 was observed (in the older KTO pipeline)
+        # to collapse the generator into a degenerate template, so we halve the
+        # learning rate and LoRA rank and tighten gradient clipping.
+        kto_learning_rate: float = 5e-6,
+        kto_lora_r: int = 16,
+        kto_lora_alpha: int = 16,
+        kto_max_grad_norm: float = 0.3,
+        max_prompt_length: int = 1536,
+        # generation knobs
+        temperature: float = 0.4,
+        top_k: int = 50,
+        top_p: float = 0.95,
+        max_new_tokens: int = 2048,
+        gen_max_rejections: int = 5,
+        # evaluation knobs (CIFAR-10, 1-epoch protocol matching the model card)
+        dataset: str = "cifar-10",
+        # Defaults match the ABrain model-card / ab.nn protocol exactly
+        # (lr 0.01, momentum 0.9, dropout 0.2, batch 10, norm_256_flip, 1 epoch)
+        # so accuracies are directly comparable to the card's 63.98% best / 50.99% avg.
+        eval_transform: str = "norm_256_flip",
+        eval_lr: float = 0.01,
+        eval_momentum: float = 0.9,
+        eval_batch: int = 10,
+        eval_dropout: float = 0.2,
+        eval_train_epochs: int = 1,
+        params_limit: int = 500_000,
+        save_to_db: bool = False,
+        # plumbing
+        output_subdir: str = "kto_selfcontained",
+        resume_from_cycle: Optional[int] = None,
+        max_retries: int = 2,
+        seed: int = 43,
+    ):
+        self.llm_conf = self._resolve_llm_conf(llm_conf)
+        with open(self.llm_conf, "r", encoding="utf-8") as f:
+            self.llm_conf_data = json.load(f)
+        self.base_model = self.llm_conf_data["base_model_name"]
+        self.context_length = int(self.llm_conf_data.get("context_length", 4096))
+
+        self.cycles = cycles
+        self.models_per_cycle = models_per_cycle
+        self.accuracy_threshold = accuracy_threshold
+        self.novelty_check = novelty_check
+        self.undesirable_ratio = undesirable_ratio
+        self.max_undesirable_total = max_undesirable_total
+        self.min_train_examples = min_train_examples
+
+        self.kto_beta = kto_beta
+        self.kto_desirable_weight = kto_desirable_weight
+        self.kto_undesirable_weight = kto_undesirable_weight
+        self.num_train_epochs = num_train_epochs
+        self.kto_learning_rate = kto_learning_rate
+        self.kto_lora_r = kto_lora_r
+        self.kto_lora_alpha = kto_lora_alpha
+        self.kto_max_grad_norm = kto_max_grad_norm
+
+        # KTO concatenates prompt + completion; their token budgets must sum to
+        # ≤ the model context length (else the sequence overflows position
+        # embeddings).  Give the prompt a fixed slice and the rest to the code.
+        self.kto_max_prompt_length = min(max_prompt_length, max(512, self.context_length - 1024))
+        self.kto_max_completion_length = max(1024, self.context_length - self.kto_max_prompt_length)
+
+        self.temperature = temperature
+        self.top_k = top_k
+        self.top_p = top_p
+        self.max_new_tokens = max_new_tokens
+        self.gen_max_rejections = gen_max_rejections
+
+        self.dataset = dataset
+        self.eval_transform = eval_transform
+        self.eval_lr = eval_lr
+        self.eval_momentum = eval_momentum
+        self.eval_batch = eval_batch
+        self.eval_dropout = eval_dropout
+        self.eval_train_epochs = eval_train_epochs
+        self.params_limit = params_limit
+        self.save_to_db = save_to_db
+
+        self.resume_from_cycle = resume_from_cycle
+        self.max_retries = max_retries
+        self.seed = seed
+
+        # Output tree — MUST be under nngpt_dir (NNEval.relative_to(nngpt_dir)).
+        self.output_dir = nngpt_dir / output_subdir
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Persistent preference-data caches (the "dataset" the pipeline grows).
+        self.desirable_cache_file = self.output_dir / "kto_desirable_cache.jsonl"
+        self.undesirable_cache_file = self.output_dir / "kto_undesirable_cache.jsonl"
+        self.desirable: List[Dict[str, Any]] = _read_jsonl(self.desirable_cache_file)
+        self.undesirable: List[Dict[str, Any]] = _read_jsonl(self.undesirable_cache_file)
+
+        # Novelty checker — starts EMPTY (no dataset); grows as we accept models.
+        self.novelty_checker = NoveltyChecker(self.output_dir / "seen_models.json")
+
+        self._setup_logging()
+        self.cycle_results: List[Dict[str, Any]] = []
+
+        logger.info("=" * 80)
+        logger.info("SELF-CONTAINED ITERATIVE KTO PIPELINE")
+        logger.info("=" * 80)
+        logger.info(f"Base model           : {self.base_model}")
+        logger.info(f"Output dir           : {self.output_dir}")
+        logger.info(f"Cycles               : {self.cycles}")
+        logger.info(f"Models per cycle     : {self.models_per_cycle}")
+        logger.info(f"Accuracy threshold   : {self.accuracy_threshold}")
+        logger.info(f"Novelty check        : {self.novelty_check}")
+        logger.info(f"KTO beta             : {self.kto_beta}")
+        logger.info(f"Desirable weight     : {self.kto_desirable_weight}")
+        logger.info(f"Undesirable weight   : {self.kto_undesirable_weight}")
+        logger.info(f"Undesirable ratio    : {self.undesirable_ratio}")
+        logger.info(f"Starting desirable   : {len(self.desirable)}")
+        logger.info(f"Starting undesirable : {len(self.undesirable)}")
+        logger.info("=" * 80)
+
+        # Guard: ABrain's first-epoch CIFAR-10 ceiling is ~0.68 (model card best
+        # 0.6398).  A threshold at/above that makes "desirable" unreachable, so
+        # every cycle collects only negatives and KTO never trains.  Warn loudly.
+        if self.accuracy_threshold >= 0.66:
+            logger.warning(
+                f"accuracy_threshold={self.accuracy_threshold:.2f} is at/above the "
+                "model's realistic first-epoch ceiling (~0.68). Desirable models "
+                "will be near-impossible and KTO will be skipped every cycle. "
+                "Use ~0.45-0.55."
+            )
+
+    # ── setup helpers ─────────────────────────────────────────────────────────
+
+    def _resolve_llm_conf(self, llm_conf: str) -> str:
+        p = Path(llm_conf)
+        if p.exists():
+            return str(p)
+        candidate = conf_llm_dir / p.name
+        if candidate.exists():
+            return str(candidate)
+        raise FileNotFoundError(f"LLM config not found: {llm_conf}")
+
+    def _setup_logging(self) -> None:
+        logger.setLevel(logging.INFO)
+        logger.handlers.clear()
+        fmt = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+        fh = logging.FileHandler(self.output_dir / "kto_pipeline.log")
+        fh.setFormatter(fmt)
+        logger.addHandler(fh)
+        sh = logging.StreamHandler()
+        sh.setFormatter(fmt)
+        logger.addHandler(sh)
+
+    @staticmethod
+    def _free_gpu() -> None:
+        try:
+            import gc
+            import torch
+            gc.collect()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+        except Exception:  # noqa: BLE001 — cleanup is best-effort
+            pass
+
+    def _cycle_dir(self, cycle: int) -> Path:
+        d = self.output_dir / f"cycle_{cycle}"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def _checkpoint_dir(self, cycle: int) -> Path:
+        return self.output_dir / f"cycle_{cycle}" / "checkpoint"
+
+    def _prev_adapter(self, cycle: int) -> Optional[Path]:
+        """Adapter to warm-start from: previous cycle's checkpoint, else None."""
+        if cycle <= 1:
+            return None
+        prev = self._checkpoint_dir(cycle - 1)
+        return prev if prev.exists() else None
+
+    # ── stage 1: generation ────────────────────────────────────────────────────
+
+    def generate_models(self, cycle: int) -> Tuple[Path, List[Dict[str, Any]]]:
+        cycle_dir = self._cycle_dir(cycle)
+        nneval_dir = cycle_dir / "nneval"
+        records_file = cycle_dir / "generation_records.jsonl"
+
+        if records_file.exists() and nneval_dir.exists():
+            logger.info(f"[cycle {cycle}] Reusing existing generations: {records_file}")
+            return nneval_dir, _read_jsonl(records_file)
+
+        adapter = self._prev_adapter(cycle)
+        logger.info("")
+        logger.info("=" * 80)
+        logger.info(f"CYCLE {cycle}: GENERATION ({self.models_per_cycle} models)")
+        logger.info(f"  base={self.base_model}  adapter={adapter}")
+        logger.info("=" * 80)
+
+        cmd = [
+            sys.executable, "-u", "-m", "ab.gpt.kto_pipeline.kto_generator",
+            "--base_model", self.base_model,
+            "--out_dir", str(nneval_dir),
+            "--records_file", str(records_file),
+            "--num_models", str(self.models_per_cycle),
+            "--start_index", "0",
+            "--temperature", str(self.temperature),
+            "--top_k", str(self.top_k),
+            "--top_p", str(self.top_p),
+            "--max_new_tokens", str(self.max_new_tokens),
+            "--max_rejections", str(self.gen_max_rejections),
+            "--dataset", self.dataset,
+            "--params_limit", str(self.params_limit),
+            "--context_length", str(self.context_length),
+            "--seed", str(self.seed + cycle * 1000),
+        ]
+        if adapter is not None:
+            cmd.extend(["--adapter", str(adapter)])
+
+        self._run_subprocess(cmd, f"generation cycle {cycle}")
+
+        records = _read_jsonl(records_file)
+        n_ok = sum(1 for r in records if r.get("ok"))
+        logger.info(f"[cycle {cycle}] generation done: {n_ok}/{len(records)} extractable")
+        return nneval_dir, records
+
+    # ── stage 2: evaluation ────────────────────────────────────────────────────
+
+    def evaluate_models(self, cycle: int, nneval_dir: Path) -> Dict[str, Dict[str, Any]]:
+        """Train+evaluate every gen_XXXX/new_nn.py on CIFAR-10 via NNEval."""
+        logger.info("")
+        logger.info("=" * 80)
+        logger.info(f"CYCLE {cycle}: EVALUATION")
+        logger.info("=" * 80)
+
+        has_models = any(
+            (nneval_dir / d.name / "new_nn.py").exists()
+            for d in nneval_dir.iterdir() if d.is_dir()
+        ) if nneval_dir.exists() else False
+        if not has_models:
+            logger.warning(f"[cycle {cycle}] no extractable models to evaluate")
+            return {}
+
+        # Import here so generation/training subprocess dispatch doesn't pay the
+        # heavy ab.nn import cost, and so a missing optional dep fails loudly only
+        # at eval time.
+        from ab.gpt import NNEval
+
+        eval_by_id: Dict[str, Dict[str, Any]] = {}
+        try:
+            summary = NNEval.main(
+                nn_name_prefix=None,
+                nn_train_epochs=self.eval_train_epochs,
+                only_epoch=0,
+                save_to_db=self.save_to_db,
+                nn_alter_epochs=1,
+                task="img-classification",
+                dataset=self.dataset,
+                metric="acc",
+                lr=self.eval_lr,
+                batch=self.eval_batch,
+                dropout=self.eval_dropout,
+                momentum=self.eval_momentum,
+                transform=self.eval_transform,
+                custom_synth_dir=str(nneval_dir),
+                cycle=cycle,
+                use_sequential=True,
+                use_all_visible_gpus=False,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"[cycle {cycle}] NNEval raised: {type(e).__name__}: {e}")
+            summary = {"epochs": []}
+
+        epochs = summary.get("epochs", []) or []
+        model_results = epochs[0].get("model_results", []) if epochs else []
+        for item in model_results:
+            mid = item.get("model_id")
+            if mid:
+                eval_by_id[mid] = item
+
+        n_succ = sum(1 for v in eval_by_id.values() if v.get("success"))
+        logger.info(f"[cycle {cycle}] evaluation done: {n_succ}/{len(eval_by_id)} trained successfully")
+        return eval_by_id
+
+    # ── stage 3: bucketing into desirable / undesirable ─────────────────────────
+
+    def bucket_models(
+        self,
+        cycle: int,
+        nneval_dir: Path,
+        generation_records: List[Dict[str, Any]],
+        eval_by_id: Dict[str, Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """
+        Sort every generation into a KTO preference class and append to the
+        accumulated caches.  Returns this cycle's bucketing stats.
+        """
+        prompt_messages = build_prompt_messages(
+            dataset=self.dataset, params_limit=self.params_limit, diversity_hint=None
+        )
+
+        # Idempotency: if this cycle was already (partially) bucketed (e.g. on a
+        # resume), drop its prior cache entries so we don't double-count.
+        self.desirable = [r for r in self.desirable if r.get("_meta", {}).get("cycle") != cycle]
+        self.undesirable = [r for r in self.undesirable if r.get("_meta", {}).get("cycle") != cycle]
+
+        n_desirable = 0
+        n_und_compile = 0
+        n_und_runtime = 0
+        n_und_lowacc = 0
+        n_und_notnovel = 0
+        n_und_unparseable = 0
+        n_skipped = 0
+        accuracies: List[float] = []
+
+        def add_desirable(code: str, model_id: str, accuracy: float) -> None:
+            self.desirable.append({
+                "prompt_messages": prompt_messages,
+                "completion": _fenced(code),
+                "label": True,
+                "_meta": {
+                    "model_id": model_id, "cycle": cycle,
+                    "accuracy": accuracy, "reason": "passed",
+                },
+            })
+
+        def add_undesirable(completion: str, model_id: str, reason: str,
+                            accuracy: Optional[float]) -> None:
+            self.undesirable.append({
+                "prompt_messages": prompt_messages,
+                "completion": completion,
+                "label": False,
+                "_meta": {
+                    "model_id": model_id, "cycle": cycle,
+                    "accuracy": accuracy, "reason": reason,
+                },
+            })
+
+        for rec in generation_records:
+            model_id = rec.get("model_id")
+            model_dir = nneval_dir / model_id
+
+            # ── unparseable generation: salvage raw text as a hard negative ──
+            if not rec.get("ok"):
+                raw = ""
+                raw_file = rec.get("raw_file")
+                if raw_file and Path(raw_file).exists():
+                    raw = Path(raw_file).read_text(encoding="utf-8", errors="replace")
+                if not raw.strip() or len(raw.strip()) < 40:
+                    n_skipped += 1
+                    continue
+                add_undesirable(raw.strip(), model_id,
+                                rec.get("error") or "code_extraction_failed", None)
+                n_und_unparseable += 1
+                continue
+
+            code_file = model_dir / "new_nn.py"
+            if not code_file.exists():
+                n_skipped += 1
+                continue
+            code = code_file.read_text(encoding="utf-8", errors="replace")
+
+            ev = eval_by_id.get(model_id)
+            if ev is None:
+                # Generated + extractable but evaluator never returned a verdict
+                # (e.g. evaluator died before reaching it).  Treat as undesirable
+                # — the model could not be shown to clear the bar.
+                add_undesirable(_fenced(code), model_id, "not_evaluated", None)
+                n_und_runtime += 1
+                continue
+
+            if not ev.get("success"):
+                add_undesirable(_fenced(code), model_id,
+                                str(ev.get("error", "evaluation_failed"))[:300], 0.0)
+                # Distinguish compile-ish vs runtime by error text (best-effort).
+                err = str(ev.get("error", "")).lower()
+                if any(k in err for k in ("verification", "compile", "syntax", "import", "missing")):
+                    n_und_compile += 1
+                else:
+                    n_und_runtime += 1
+                continue
+
+            accuracy = ev.get("accuracy")
+            try:
+                accuracy = float(accuracy) if accuracy is not None else 0.0
+            except (TypeError, ValueError):
+                accuracy = 0.0
+            accuracies.append(accuracy)
+
+            if accuracy < self.accuracy_threshold:
+                add_undesirable(_fenced(code), model_id, "low_accuracy", accuracy)
+                n_und_lowacc += 1
+                continue
+
+            # passed the accuracy bar → require novelty
+            is_novel = self.novelty_checker.is_novel(code, model_id) if self.novelty_check else True
+            if not is_novel:
+                add_undesirable(_fenced(code), model_id, "not_novel", accuracy)
+                n_und_notnovel += 1
+                continue
+
+            add_desirable(code, model_id, accuracy)
+            self.novelty_checker.mark_as_seen(code, model_id, source=f"cycle_{cycle}")
+            n_desirable += 1
+
+        # Persist caches + novelty.
+        _write_jsonl(self.desirable, self.desirable_cache_file)
+        _write_jsonl(self.undesirable, self.undesirable_cache_file)
+        self.novelty_checker.save_cache()
+
+        n_und_total = (n_und_compile + n_und_runtime + n_und_lowacc
+                       + n_und_notnovel + n_und_unparseable)
+        best_acc = max(accuracies) if accuracies else 0.0
+        avg_acc = (sum(accuracies) / len(accuracies)) if accuracies else 0.0
+
+        stats = {
+            "new_desirable": n_desirable,
+            "new_undesirable": n_und_total,
+            "undesirable_breakdown": {
+                "non_compiling": n_und_compile,
+                "runtime_error": n_und_runtime,
+                "low_accuracy": n_und_lowacc,
+                "not_novel": n_und_notnovel,
+                "unparseable": n_und_unparseable,
+            },
+            "skipped_no_signal": n_skipped,
+            "evaluated_accuracies": len(accuracies),
+            "best_accuracy": best_acc,
+            "avg_accuracy": avg_acc,
+            "desirable_total": len(self.desirable),
+            "undesirable_total": len(self.undesirable),
+        }
+        logger.info("")
+        logger.info(f"[cycle {cycle}] BUCKETING:")
+        logger.info(f"  + desirable (passed)     : {n_desirable}")
+        logger.info(f"  - undesirable (total)    : {n_und_total}")
+        logger.info(f"      non-compiling        : {n_und_compile}")
+        logger.info(f"      runtime error        : {n_und_runtime}")
+        logger.info(f"      low accuracy         : {n_und_lowacc}")
+        logger.info(f"      not novel            : {n_und_notnovel}")
+        logger.info(f"      unparseable          : {n_und_unparseable}")
+        logger.info(f"  skipped (no signal)      : {n_skipped}")
+        logger.info(f"  best/avg acc this cycle  : {best_acc*100:.2f}% / {avg_acc*100:.2f}%")
+        logger.info(f"  cumulative desirable     : {len(self.desirable)}")
+        logger.info(f"  cumulative undesirable   : {len(self.undesirable)}")
+        return stats
+
+    # ── stage 4: build the balanced KTO dataset ─────────────────────────────────
+
+    def build_kto_dataset(self, cycle: int) -> Tuple[Optional[Path], Dict[str, Any]]:
+        cycle_dir = self._cycle_dir(cycle)
+        kto_file = cycle_dir / "kto_train.jsonl"
+
+        desirables = list(self.desirable)
+        undesirables = list(self.undesirable)
+        D = len(desirables)
+        Ua = len(undesirables)
+
+        # Cap undesirables to keep KTO balanced; keep the most-recent (sharper)
+        # negatives.  Also respect the absolute total cap.
+        max_u = math.floor(D * self.undesirable_ratio) if D > 0 else Ua
+        max_u = min(max_u, self.max_undesirable_total)
+        if Ua > max_u and max_u >= 0:
+            selected_u = undesirables[-max_u:] if max_u > 0 else []
+        else:
+            selected_u = undesirables
+
+        combined = [
+            {"prompt_messages": r["prompt_messages"], "completion": r["completion"],
+             "label": True, "_meta": r.get("_meta", {})}
+            for r in desirables
+        ] + [
+            {"prompt_messages": r["prompt_messages"], "completion": r["completion"],
+             "label": False, "_meta": r.get("_meta", {})}
+            for r in selected_u
+        ]
+        _write_jsonl(combined, kto_file)
+
+        stats = {
+            "desirable_used": D,
+            "undesirable_available": Ua,
+            "undesirable_used": len(selected_u),
+            "total": len(combined),
+            "kto_file": str(kto_file),
+        }
+        logger.info("")
+        logger.info(f"[cycle {cycle}] KTO dataset: {D} desirable + "
+                    f"{len(selected_u)}/{Ua} undesirable = {len(combined)} examples → {kto_file}")
+
+        if D == 0 or len(selected_u) == 0 or len(combined) < self.min_train_examples:
+            logger.warning(
+                f"[cycle {cycle}] insufficient/one-sided data "
+                f"(desirable={D}, undesirable={len(selected_u)}, total={len(combined)}); "
+                f"KTO needs both classes and ≥{self.min_train_examples} examples — "
+                "skipping training this cycle, will accumulate more next cycle."
+            )
+            return None, stats
+        return kto_file, stats
+
+    # ── stage 5: KTO fine-tune ──────────────────────────────────────────────────
+
+    def run_kto_training(self, cycle: int, kto_file: Path) -> Dict[str, Any]:
+        logger.info("")
+        logger.info("=" * 80)
+        logger.info(f"CYCLE {cycle}: KTO FINE-TUNING")
+        logger.info("=" * 80)
+
+        checkpoint_dir = self._checkpoint_dir(cycle)
+        if checkpoint_dir.exists() and (checkpoint_dir / "adapter_config.json").exists():
+            logger.info(f"[cycle {cycle}] checkpoint already exists, skipping: {checkpoint_dir}")
+            return {"success": True, "checkpoint_dir": str(checkpoint_dir), "skipped": True}
+
+        prev_adapter = self._prev_adapter(cycle)
+
+        cmd = [
+            sys.executable, "-u", "-m", "ab.gpt.TuneNNGenKTO",
+            "--llm_conf", self.llm_conf,
+            "--kto_data_file", str(kto_file),
+            "--kto_checkpoint_dir", str(checkpoint_dir),
+            "--kto_beta", str(self.kto_beta),
+            "--kto_desirable_weight", str(self.kto_desirable_weight),
+            "--kto_undesirable_weight", str(self.kto_undesirable_weight),
+            "--num_train_epochs", str(self.num_train_epochs),
+            "--max_prompt_length", str(self.kto_max_prompt_length),
+            "--max_completion_length", str(self.kto_max_completion_length),
+            # KTO drift control (see __init__).
+            "--learning_rate", str(self.kto_learning_rate),
+            "--r", str(self.kto_lora_r),
+            "--lora_alpha", str(self.kto_lora_alpha),
+            "--max_grad_norm", str(self.kto_max_grad_norm),
+        ]
+        if prev_adapter is not None:
+            logger.info(f"[cycle {cycle}] warm-starting from previous adapter: {prev_adapter}")
+            cmd.extend(["--peft", str(prev_adapter)])
+        else:
+            logger.info(f"[cycle {cycle}] training fresh LoRA on base {self.base_model}")
+
+        start = time.time()
+        try:
+            self._run_subprocess(cmd, f"KTO training cycle {cycle}")
+        except subprocess.CalledProcessError as e:
+            return {"success": False, "error": f"kto_training_failed: exit_{e.returncode}",
+                    "training_time_minutes": (time.time() - start) / 60}
+
+        minutes = (time.time() - start) / 60
+        if not (checkpoint_dir / "adapter_config.json").exists():
+            logger.error(f"[cycle {cycle}] training finished but no adapter at {checkpoint_dir}")
+            return {"success": False, "error": "checkpoint_missing",
+                    "training_time_minutes": minutes}
+
+        logger.info(f"[cycle {cycle}] KTO training complete in {minutes:.1f} min → {checkpoint_dir}")
+        return {"success": True, "checkpoint_dir": str(checkpoint_dir),
+                "training_time_minutes": minutes}
+
+    # ── orchestration ───────────────────────────────────────────────────────────
+
+    def run_cycle(self, cycle: int) -> Dict[str, Any]:
+        t0 = time.time()
+        logger.info("")
+        logger.info("#" * 80)
+        logger.info(f"# CYCLE {cycle} / {self.cycles}")
+        logger.info("#" * 80)
+
+        nneval_dir, gen_records = self.generate_models(cycle)
+        eval_by_id = self.evaluate_models(cycle, nneval_dir)
+        # Release any CUDA memory the in-process evaluator held before the KTO
+        # training subprocess loads the 7B model.
+        self._free_gpu()
+        bucket_stats = self.bucket_models(cycle, nneval_dir, gen_records, eval_by_id)
+        kto_file, ds_stats = self.build_kto_dataset(cycle)
+
+        if kto_file is not None:
+            train_stats = self.run_kto_training(cycle, kto_file)
+        else:
+            train_stats = {"success": False, "skipped": True, "reason": "insufficient_data"}
+
+        result = {
+            "cycle": cycle,
+            "timestamp": datetime.now().isoformat(),
+            "generated": len(gen_records),
+            "extractable": sum(1 for r in gen_records if r.get("ok")),
+            "bucketing": bucket_stats,
+            "dataset": ds_stats,
+            "training": train_stats,
+            "cycle_time_minutes": (time.time() - t0) / 60,
+        }
+        (self._cycle_dir(cycle) / "metrics.json").write_text(
+            json.dumps(result, indent=2, default=str), encoding="utf-8"
+        )
+        return result
+
+    def run(self) -> Dict[str, Any]:
+        start_cycle = self.resume_from_cycle or 1
+        for cycle in range(start_cycle, self.cycles + 1):
+            try:
+                result = self.run_cycle(cycle)
+                self.cycle_results.append(result)
+            except Exception as e:  # noqa: BLE001 — keep the experiment alive
+                import traceback
+                logger.error(f"[cycle {cycle}] FAILED: {type(e).__name__}: {e}")
+                logger.error(traceback.format_exc())
+                self.cycle_results.append({"cycle": cycle, "error": str(e)})
+            self._save_aggregate()
+
+        logger.info("")
+        logger.info("=" * 80)
+        logger.info("PIPELINE COMPLETE")
+        logger.info("=" * 80)
+        self._save_aggregate()
+        return {"cycles": self.cycle_results}
+
+    def _save_aggregate(self) -> None:
+        agg = {
+            "base_model": self.base_model,
+            "accuracy_threshold": self.accuracy_threshold,
+            "kto_beta": self.kto_beta,
+            "desirable_total": len(self.desirable),
+            "undesirable_total": len(self.undesirable),
+            "cycles": self.cycle_results,
+        }
+        (self.output_dir / "all_cycles_results.json").write_text(
+            json.dumps(agg, indent=2, default=str), encoding="utf-8"
+        )
+
+    # ── subprocess runner with retry ────────────────────────────────────────────
+
+    def _run_subprocess(self, cmd: List[str], name: str) -> None:
+        logger.info(f"Running {name}: {' '.join(cmd)}")
+        # Force MKL to use GNU OpenMP.  The KTO trainer subprocess's import order
+        # (torch + datasets + trl + peft) otherwise trips:
+        #   "MKL_THREADING_LAYER=INTEL is incompatible with libgomp.so.1"
+        # and exits before training starts.  Harmless for the generator subprocess.
+        env = os.environ.copy()
+        env["MKL_THREADING_LAYER"] = "GNU"
+        last_exc: Optional[Exception] = None
+        for attempt in range(1, self.max_retries + 1):
+            result = subprocess.run(cmd, capture_output=False, text=True, check=False, env=env)
+            if result.returncode == 0:
+                return
+            last_exc = subprocess.CalledProcessError(result.returncode, cmd)
+            logger.error(f"{name} failed (attempt {attempt}/{self.max_retries}, "
+                         f"exit {result.returncode})")
+            if attempt < self.max_retries:
+                time.sleep(15.0 * attempt)
+        assert last_exc is not None
+        raise last_exc
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Self-contained iterative KTO fine-tuning (no initial dataset)"
+    )
+    parser.add_argument("--llm_conf", type=str, default="nngpt_unique_arch_rag.json",
+                        help="LLM config JSON (default: nngpt_unique_arch_rag.json → ABrain model)")
+    parser.add_argument("--cycles", type=int, default=10)
+    parser.add_argument("--models_per_cycle", type=int, default=30)
+    parser.add_argument("--accuracy_threshold", type=float, default=0.50,
+                        help="First-epoch CIFAR-10 accuracy a model must clear to be desirable "
+                             "(ABrain's first-epoch ceiling is ~0.68; keep this well below it)")
+    parser.add_argument("--novelty_check", action="store_true", default=True)
+    parser.add_argument("--no_novelty_check", dest="novelty_check", action="store_false")
+    parser.add_argument("--undesirable_ratio", type=float, default=1.0)
+    parser.add_argument("--max_undesirable_total", type=int, default=1000)
+    parser.add_argument("--min_train_examples", type=int, default=10)
+
+    parser.add_argument("--kto_beta", type=float, default=0.1)
+    parser.add_argument("--kto_desirable_weight", type=float, default=1.0)
+    parser.add_argument("--kto_undesirable_weight", type=float, default=1.0)
+    parser.add_argument("--num_train_epochs", type=int, default=3)
+    parser.add_argument("--kto_learning_rate", type=float, default=5e-6)
+    parser.add_argument("--kto_lora_r", type=int, default=16)
+    parser.add_argument("--kto_lora_alpha", type=int, default=16)
+    parser.add_argument("--kto_max_grad_norm", type=float, default=0.3)
+    parser.add_argument("--max_prompt_length", type=int, default=1536,
+                        help="Prompt token budget; completion gets context_length - this")
+
+    parser.add_argument("--temperature", type=float, default=0.4)
+    parser.add_argument("--top_k", type=int, default=50)
+    parser.add_argument("--top_p", type=float, default=0.95)
+    parser.add_argument("--max_new_tokens", type=int, default=2048)
+    parser.add_argument("--gen_max_rejections", type=int, default=5,
+                        help="Regenerate a model up to N times if it fails the "
+                             "structural pre-check (instantiate + forward on 3x32x32)")
+
+    parser.add_argument("--dataset", type=str, default="cifar-10")
+    parser.add_argument("--eval_transform", type=str, default="norm_256_flip",
+                        help="Card/ab.nn protocol = norm_256_flip (256x256)")
+    parser.add_argument("--eval_lr", type=float, default=0.01)
+    parser.add_argument("--eval_momentum", type=float, default=0.9)
+    parser.add_argument("--eval_batch", type=int, default=10,
+                        help="Card/ab.nn protocol = 10")
+    parser.add_argument("--eval_dropout", type=float, default=0.2)
+    parser.add_argument("--eval_train_epochs", type=int, default=1)
+    parser.add_argument("--params_limit", type=int, default=500_000)
+    parser.add_argument("--save_to_db", action="store_true", default=False)
+
+    parser.add_argument("--output_subdir", type=str, default="kto_selfcontained")
+    parser.add_argument("--resume_from_cycle", type=int, default=None)
+    parser.add_argument("--max_retries", type=int, default=2)
+    parser.add_argument("--seed", type=int, default=43)
+
+    args = parser.parse_args()
+
+    pipeline = SelfContainedKTOPipeline(
+        llm_conf=args.llm_conf,
+        cycles=args.cycles,
+        models_per_cycle=args.models_per_cycle,
+        accuracy_threshold=args.accuracy_threshold,
+        novelty_check=args.novelty_check,
+        undesirable_ratio=args.undesirable_ratio,
+        max_undesirable_total=args.max_undesirable_total,
+        min_train_examples=args.min_train_examples,
+        kto_beta=args.kto_beta,
+        kto_desirable_weight=args.kto_desirable_weight,
+        kto_undesirable_weight=args.kto_undesirable_weight,
+        num_train_epochs=args.num_train_epochs,
+        kto_learning_rate=args.kto_learning_rate,
+        kto_lora_r=args.kto_lora_r,
+        kto_lora_alpha=args.kto_lora_alpha,
+        kto_max_grad_norm=args.kto_max_grad_norm,
+        max_prompt_length=args.max_prompt_length,
+        temperature=args.temperature,
+        top_k=args.top_k,
+        top_p=args.top_p,
+        max_new_tokens=args.max_new_tokens,
+        gen_max_rejections=args.gen_max_rejections,
+        dataset=args.dataset,
+        eval_transform=args.eval_transform,
+        eval_lr=args.eval_lr,
+        eval_momentum=args.eval_momentum,
+        eval_batch=args.eval_batch,
+        eval_dropout=args.eval_dropout,
+        eval_train_epochs=args.eval_train_epochs,
+        params_limit=args.params_limit,
+        save_to_db=args.save_to_db,
+        output_subdir=args.output_subdir,
+        resume_from_cycle=args.resume_from_cycle,
+        max_retries=args.max_retries,
+        seed=args.seed,
+    )
+    pipeline.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/ab/gpt/kto_pipeline/kto_selfcontained_finetune.py
+++ b/ab/gpt/kto_pipeline/kto_selfcontained_finetune.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from ab.gpt.kto_pipeline.kto_generator import build_prompt_messages
 from ab.gpt.iterative_pipeline.novelty_checker import NoveltyChecker
 from ab.gpt.util.Const import conf_llm_dir, nngpt_dir
+from ab.gpt.util.CycleResults import save_cycle_results
 
 logger = logging.getLogger("kto_selfcontained")
 
@@ -651,9 +652,7 @@ class SelfContainedKTOPipeline:
             "training": train_stats,
             "cycle_time_minutes": (time.time() - t0) / 60,
         }
-        (self._cycle_dir(cycle) / "metrics.json").write_text(
-            json.dumps(result, indent=2, default=str), encoding="utf-8"
-        )
+        save_cycle_results(result, self._cycle_dir(cycle) / "metrics.json")
         return result
 
     def run(self) -> Dict[str, Any]:
@@ -685,9 +684,7 @@ class SelfContainedKTOPipeline:
             "undesirable_total": len(self.undesirable),
             "cycles": self.cycle_results,
         }
-        (self.output_dir / "all_cycles_results.json").write_text(
-            json.dumps(agg, indent=2, default=str), encoding="utf-8"
-        )
+        save_cycle_results(agg, self.output_dir / "all_cycles_results.json")
 
     # ── subprocess runner with retry ────────────────────────────────────────────
 

--- a/ab/gpt/kto_pipeline/plot_kto_cycles.py
+++ b/ab/gpt/kto_pipeline/plot_kto_cycles.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import matplotlib
+matplotlib.use("Agg")  # headless / cluster-safe
+import matplotlib.pyplot as plt  # noqa: E402
+
+# Model-card reference (ABrain/NNGPT-UniqueArch-Rag, 1-epoch CIFAR-10).
+CARD_BEST = 0.6398
+CARD_AVG = 0.5099
+
+
+def wilson_ci(k: int, n: int, z: float = 1.96) -> tuple[float, float]:
+    """95% Wilson score interval for a proportion k/n. Returns (lo, hi) in [0,1]."""
+    if n <= 0:
+        return (0.0, 0.0)
+    p = k / n
+    denom = 1.0 + z * z / n
+    center = (p + z * z / (2 * n)) / denom
+    half = (z * math.sqrt(p * (1 - p) / n + z * z / (4 * n * n))) / denom
+    return (max(0.0, center - half), min(1.0, center + half))
+
+
+def _parse_cycle(c: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Flatten one cycle record (from the aggregate OR a per-cycle metrics.json)."""
+    if "bucketing" not in c:
+        return None  # failed cycle with no metrics
+    b = c.get("bucketing", {})
+    bd = b.get("undesirable_breakdown", {})
+    gen = int(c.get("generated", 0)) or 1
+    new_des = int(b.get("new_desirable", 0))
+    not_novel = int(bd.get("not_novel", 0))
+    return {
+        "cycle": int(c.get("cycle", 0)),
+        "generated": gen,
+        "evaluated": int(b.get("evaluated_accuracies", gen)),
+        "best": float(b.get("best_accuracy", 0.0) or 0.0),
+        "avg": float(b.get("avg_accuracy", 0.0) or 0.0),
+        "new_desirable": new_des,
+        "new_undesirable": int(b.get("new_undesirable", 0)),
+        "not_novel": not_novel,
+        "low_accuracy": int(bd.get("low_accuracy", 0)),
+        "non_compiling": int(bd.get("non_compiling", 0)),
+        "runtime_error": int(bd.get("runtime_error", 0)),
+        "unparseable": int(bd.get("unparseable", 0)),
+        "desirable_total": int(b.get("desirable_total", 0)),
+        "undesirable_total": int(b.get("undesirable_total", 0)),
+        "pass_acc": new_des + not_novel,  # cleared the accuracy bar (novel + duplicate)
+        "trained": bool(c.get("training", {}).get("success", False)),
+    }
+
+
+def load_cycles(results_path: Path, cycles_dir: Optional[Path]) -> List[Dict[str, Any]]:
+    """
+    Build the per-cycle list, keyed by cycle number, from:
+      1. the aggregate all_cycles_results.json (current session's cycles), then
+      2. every cycle_<n>/metrics.json found under cycles_dir — these PERSIST across
+         resumes, so they give the FULL history even when the aggregate is partial.
+    """
+    by_cycle: Dict[int, Dict[str, Any]] = {}
+
+    try:
+        data = json.loads(results_path.read_text(encoding="utf-8"))
+        for c in data.get("cycles", []):
+            rec = _parse_cycle(c)
+            if rec is not None:
+                by_cycle[rec["cycle"]] = rec
+    except Exception as e:  # noqa: BLE001
+        print(f"[plot][warn] could not read aggregate {results_path}: {e}")
+
+    if cycles_dir and cycles_dir.exists():
+        for mfile in sorted(cycles_dir.glob("cycle_*/metrics.json")):
+            try:
+                rec = _parse_cycle(json.loads(mfile.read_text(encoding="utf-8")))
+                if rec is not None:
+                    by_cycle[rec["cycle"]] = rec  # authoritative per-cycle metrics
+            except Exception:  # noqa: BLE001
+                continue
+
+    return [by_cycle[k] for k in sorted(by_cycle)]
+
+
+def load_per_model_accuracies(cycles_dir: Optional[Path]) -> Dict[int, List[float]]:
+    """
+    Best-effort: scan cycle_<n>/nneval/*/eval_info.json for per-model accuracies
+    so we can compute median + quality-threshold curves.  Returns {} if not found.
+    """
+    accs: Dict[int, List[float]] = {}
+    if not cycles_dir or not cycles_dir.exists():
+        return accs
+    for cycle_dir in sorted(cycles_dir.glob("cycle_*")):
+        try:
+            n = int(cycle_dir.name.split("_")[1])
+        except (IndexError, ValueError):
+            continue
+        nneval = cycle_dir / "nneval"
+        if not nneval.exists():
+            continue
+        vals: List[float] = []
+        for info in nneval.glob("*/eval_info.json"):
+            try:
+                payload = json.loads(info.read_text(encoding="utf-8"))
+                res = payload.get("eval_results", {})
+                a = res.get("accuracy", res.get("acc"))
+                if a is not None:
+                    vals.append(float(a))
+            except Exception:  # noqa: BLE001
+                continue
+        if vals:
+            accs[n] = vals
+    return accs
+
+
+def plot_overview(cycles: List[Dict[str, Any]], per_model: Dict[int, List[float]],
+                  out_dir: Path, threshold: float) -> Path:
+    xs = [r["cycle"] for r in cycles]
+    fig, ax = plt.subplots(2, 2, figsize=(14, 9))
+    fig.suptitle("Self-Contained KTO — Iterative Cycle Analysis", fontsize=15, fontweight="bold")
+
+    # Panel A: accuracy trends (best, average, +median if available) + card refs
+    a = ax[0][0]
+    a.plot(xs, [r["best"] * 100 for r in cycles], "o-", color="#1f77b4", label="Best")
+    a.plot(xs, [r["avg"] * 100 for r in cycles], "s-", color="#ff7f0e", label="Average")
+    if per_model:
+        med_x, med_y = [], []
+        for r in cycles:
+            v = per_model.get(r["cycle"])
+            if v:
+                s = sorted(v)
+                med = s[len(s) // 2] if len(s) % 2 else (s[len(s) // 2 - 1] + s[len(s) // 2]) / 2
+                med_x.append(r["cycle"]); med_y.append(med * 100)
+        if med_x:
+            a.plot(med_x, med_y, "^-", color="#2ca02c", label="Median")
+    a.axhline(CARD_BEST * 100, ls="--", color="#1f77b4", alpha=0.5, label=f"Card best ({CARD_BEST*100:.1f}%)")
+    a.axhline(CARD_AVG * 100, ls="--", color="#ff7f0e", alpha=0.5, label=f"Card avg ({CARD_AVG*100:.1f}%)")
+    a.axhline(threshold * 100, ls=":", color="gray", alpha=0.7, label=f"Threshold ({threshold*100:.0f}%)")
+    a.set_title("First-Epoch Accuracy Trends"); a.set_xlabel("Cycle"); a.set_ylabel("Accuracy (%)")
+    a.grid(True, alpha=0.3); a.legend(fontsize=8)
+
+    # Panel B: generation outcome rates per cycle
+    b = ax[0][1]
+    b.plot(xs, [100 * r["new_desirable"] / r["generated"] for r in cycles], "o-",
+           color="#2ca02c", label="Desirable (pass+novel)")
+    b.plot(xs, [100 * r["pass_acc"] / r["generated"] for r in cycles], "s-",
+           color="#9467bd", label="Cleared accuracy bar")
+    b.plot(xs, [100 * r["low_accuracy"] / r["generated"] for r in cycles], "v-",
+           color="#d62728", label="Below threshold")
+    b.plot(xs, [100 * r["not_novel"] / r["generated"] for r in cycles], "d-",
+           color="#8c564b", label="Not novel (duplicate)")
+    b.set_title("Generation Outcomes (% of generated)"); b.set_xlabel("Cycle")
+    b.set_ylabel("% of models"); b.grid(True, alpha=0.3); b.legend(fontsize=8)
+
+    # Panel C: per-cycle counts (desirable vs undesirable)
+    c = ax[1][0]
+    width = 0.4
+    c.bar([x - width / 2 for x in xs], [r["new_desirable"] for r in cycles], width,
+          label="New desirable", color="#2ca02c")
+    c.bar([x + width / 2 for x in xs], [r["new_undesirable"] for r in cycles], width,
+          label="New undesirable", color="#d62728", alpha=0.8)
+    c.set_title("Per-Cycle Bucketing Counts"); c.set_xlabel("Cycle"); c.set_ylabel("Count")
+    c.grid(True, alpha=0.3, axis="y"); c.legend(fontsize=9)
+
+    # Panel D: cumulative training-data growth
+    d = ax[1][1]
+    d.plot(xs, [r["desirable_total"] for r in cycles], "o-", color="#2ca02c", label="Desirable total")
+    d.plot(xs, [r["undesirable_total"] for r in cycles], "s-", color="#d62728", label="Undesirable total")
+    d.plot(xs, [r["desirable_total"] + r["undesirable_total"] for r in cycles], "^-",
+           color="#1f77b4", label="Total accumulated")
+    d.set_title("Preference-Data Growth"); d.set_xlabel("Cycle"); d.set_ylabel("Cumulative examples")
+    d.grid(True, alpha=0.3); d.legend(fontsize=9)
+
+    fig.tight_layout(rect=[0, 0, 1, 0.97])
+    path = out_dir / "kto_cycle_overview.png"
+    fig.savefig(path, dpi=130); plt.close(fig)
+    return path
+
+
+def plot_success_ci(cycles: List[Dict[str, Any]], out_dir: Path, threshold: float) -> Path:
+    """≥threshold accuracy rate per cycle with Wilson 95% CI (over evaluated models)."""
+    xs, rate, lo, hi = [], [], [], []
+    for r in cycles:
+        n = r["evaluated"] or r["generated"]
+        k = r["pass_acc"]
+        p = k / n if n else 0.0
+        l, h = wilson_ci(k, n)
+        xs.append(r["cycle"]); rate.append(p * 100)
+        lo.append((p - l) * 100); hi.append((h - p) * 100)
+
+    fig, ax = plt.subplots(figsize=(11, 4.5))
+    ax.errorbar(xs, rate, yerr=[lo, hi], fmt="o-", color="#1f77b4", capsize=3, ecolor="#1f77b4")
+    ax.set_title(f"Accuracy-Pass Rate per Cycle (≥{threshold*100:.0f}%) with 95% CI")
+    ax.set_xlabel("Cycle"); ax.set_ylabel("Models clearing threshold (%)")
+    ax.grid(True, alpha=0.3); ax.set_ylim(0, 100)
+    fig.tight_layout()
+    path = out_dir / "kto_success_rate_ci.png"
+    fig.savefig(path, dpi=130); plt.close(fig)
+    return path
+
+
+def save_csv(cycles: List[Dict[str, Any]], out_dir: Path) -> Path:
+    path = out_dir / "kto_cycle_summary.csv"
+    cols = ["cycle", "generated", "evaluated", "best", "avg", "new_desirable",
+            "new_undesirable", "low_accuracy", "not_novel", "desirable_total",
+            "undesirable_total", "trained"]
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=cols, extrasaction="ignore")
+        w.writeheader()
+        for r in cycles:
+            w.writerow(r)
+    return path
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Plot KTO per-cycle analysis")
+    p.add_argument("--results", type=str, default="all_cycles_results.json",
+                   help="Path to the KTO all_cycles_results.json")
+    p.add_argument("--out_dir", type=str, default="kto_plots")
+    p.add_argument("--threshold", type=float, default=None,
+                   help="Accuracy threshold (default: read from the json's accuracy_threshold)")
+    p.add_argument("--cycles_dir", type=str, default=None,
+                   help="Optional dir with cycle_<n>/nneval/*/eval_info.json for median/quality curves")
+    args = p.parse_args()
+
+    results_path = Path(args.results)
+    if not results_path.exists():
+        raise FileNotFoundError(f"Results file not found: {results_path}")
+    out_dir = Path(args.out_dir); out_dir.mkdir(parents=True, exist_ok=True)
+
+    threshold = args.threshold
+    if threshold is None:
+        try:
+            threshold = float(json.loads(results_path.read_text()).get("accuracy_threshold", 0.40))
+        except Exception:  # noqa: BLE001
+            threshold = 0.40
+
+    # Auto-detect cycles_dir next to the results file if not given (gives full
+    # history via per-cycle metrics.json + per-model accuracies for median curves).
+    cycles_dir = Path(args.cycles_dir) if args.cycles_dir else results_path.parent
+    cycles = load_cycles(results_path, cycles_dir)
+    if not cycles:
+        raise SystemExit("No cycles with metrics found in the results file.")
+    per_model = load_per_model_accuracies(cycles_dir)
+
+    f1 = plot_overview(cycles, per_model, out_dir, threshold)
+    f2 = plot_success_ci(cycles, out_dir, threshold)
+    f3 = save_csv(cycles, out_dir)
+
+    # Console summary (handy for the report).
+    best_overall = max(cycles, key=lambda r: r["best"])
+    print("=" * 64)
+    print(f"KTO run: {len(cycles)} cycles ({cycles[0]['cycle']}..{cycles[-1]['cycle']})")
+    print(f"  best accuracy this run : {best_overall['best']*100:.2f}%  (cycle {best_overall['cycle']})")
+    print(f"  card reference best    : {CARD_BEST*100:.2f}%")
+    print(f"  last-cycle avg accuracy: {cycles[-1]['avg']*100:.2f}%  (card avg {CARD_AVG*100:.2f}%)")
+    print(f"  desirable accumulated  : {cycles[-1]['desirable_total']}")
+    print(f"  per-model eval data    : {'found' if per_model else 'not found (median/quality skipped)'}")
+    print("-" * 64)
+    print(f"  figure : {f1}")
+    print(f"  figure : {f2}")
+    print(f"  csv    : {f3}")
+    print("=" * 64)
+
+
+if __name__ == "__main__":
+    main()

--- a/ab/gpt/util/KTO.py
+++ b/ab/gpt/util/KTO.py
@@ -1,0 +1,339 @@
+"""
+ab/gpt/util/KTO.py - KTO (Kahneman-Tversky Optimization) trainer wrapper.
+
+Analog of ab/gpt/util/LoRA.py for KTO training. Wraps TRL's KTOTrainer so
+the iterative pipeline can swap SFT for KTO with the same LoRA-attachment
+and checkpoint/resume semantics as the existing SFT path.
+
+KTO differs from SFT in three key ways:
+  1. Dataset format: {prompt: str, completion: str, label: bool}
+     instead of {text: str}.  label=True means "desirable" example,
+     label=False means "undesirable" example.
+  2. Loss function: KL-regularised Kahneman-Tversky value function with
+     separate weights for the two classes (desirable_weight,
+     undesirable_weight).
+  3. Reference model: KTO computes per-example log-probs against a frozen
+     reference.  When using PEFT, TRL automatically uses the base model
+     (with adapters disabled) as the reference, so no separate ref_model
+     instance is needed.
+
+Reference: https://huggingface.co/papers/2402.01306 (KTO paper)
+           https://huggingface.co/docs/trl/main/en/kto_trainer (TRL docs)
+"""
+
+from os import makedirs
+import inspect
+from pathlib import Path
+from typing import Optional
+
+import torch
+from ab.nn.util.Util import release_memory
+import ab.gpt.util.training_runtime as TrainingRuntime
+from datasets import Dataset
+from peft import (
+    LoraConfig,
+    get_peft_model,
+    prepare_model_for_kbit_training,
+)
+from transformers import (
+    TrainingArguments,
+    PreTrainedModel,
+    PreTrainedTokenizerBase,
+)
+
+# Import KTO machinery from TRL.  KTOTrainer requires trl >= 0.7.0.
+try:
+    from trl import KTOTrainer, KTOConfig
+except ImportError as e:
+    raise ImportError(
+        "trl.KTOTrainer / KTOConfig not available.  Upgrade trl: "
+        "`pip install -U trl`.  Original error: " + str(e)
+    )
+
+
+def find_all_linear_names(model):
+    cls = torch.nn.modules.linear.Linear
+    lora_module_names = set()
+    for name, module in model.named_modules():
+        if isinstance(module, cls):
+            names = name.split('.')
+            lora_module_names.add(names[0] if len(names) == 1 else names[-1])
+
+    if 'lm_head' in lora_module_names:  # needed for 16-bit
+        lora_module_names.remove('lm_head')
+    return list(lora_module_names)
+
+
+def print_trainable_parameters(model, use_4bit=False):
+    """Print the number of trainable parameters in the model."""
+    trainable_params = 0
+    all_param = 0
+    for _, param in model.named_parameters():
+        num_params = param.numel()
+        # if using DS Zero 3 and the weights are initialized empty
+        if num_params == 0 and hasattr(param, "ds_numel"):
+            num_params = param.ds_numel
+
+        all_param += num_params
+        if param.requires_grad:
+            trainable_params += num_params
+    if use_4bit:
+        trainable_params /= 2
+    print(
+        f"all params: {all_param:,d} || trainable params: {trainable_params:,d} || "
+        f"trainable%: {100 * trainable_params / all_param}"
+    )
+
+
+def create_peft_config(modules):
+    """Create Parameter-Efficient Fine-Tuning config for KTO."""
+    return LoraConfig(
+        r=32,
+        lora_alpha=64,
+        target_modules=modules,
+        lora_dropout=0.1,
+        bias="none",
+        task_type="CAUSAL_LM",
+        use_dora=True,
+    )
+
+
+class KTO:
+    """
+    KTO trainer wrapper.  Mirrors the LoRA class interface so callers
+    (TuneNNGenKTO.py, KTOIterativeFinetuner) can use it as a drop-in
+    replacement for LoRA when training_mode == "kto".
+    """
+
+    def __init__(
+        self,
+        model: PreTrainedModel,
+        tokenizer: PreTrainedTokenizerBase,
+        training_args: TrainingArguments,
+        access_token=None,
+        peft_config=None,
+        use_unsloth=False,
+    ):
+        self.model = model
+        self.tokenizer = tokenizer
+        self.training_args = training_args
+        self.access_token = access_token
+        self._use_unsloth = use_unsloth
+
+        if peft_config is None:
+            modules = find_all_linear_names(self.model)
+            self.peft_config = create_peft_config(modules)
+        else:
+            self.peft_config = peft_config
+
+        if use_unsloth:
+            try:
+                inner_unsloth_available = True
+                try:
+                    from unsloth import FastModel
+                except ImportError:
+                    inner_unsloth_available = False
+
+                if not inner_unsloth_available:
+                    raise ImportError("Unsloth not installed")
+
+                self.peft_model = FastModel.get_peft_model(
+                    self.model,
+                    r=self.peft_config.r,
+                    lora_alpha=self.peft_config.lora_alpha,
+                    lora_dropout=self.peft_config.lora_dropout,
+                    target_modules=list(self.peft_config.target_modules),
+                    bias="none",
+                    use_gradient_checkpointing="unsloth",
+                    random_state=42,
+                )
+                print("[KTO] Using Unsloth's FastModel.get_peft_model() for bfloat16 compatibility")
+            except Exception as e:
+                print(f"[KTO] Unsloth get_peft_model failed: {e}, falling back to standard PEFT")
+                use_unsloth = False
+                self._use_unsloth = False
+
+        if not use_unsloth:
+            # Standard PEFT flow for non-Unsloth models
+            self.model = prepare_model_for_kbit_training(self.model)
+            self.model.gradient_checkpointing_enable()
+            print("[KTO] Gradient checkpointing enabled")
+            self.peft_model = get_peft_model(self.model, self.peft_config)
+
+        self.peft_model._hf_peft_config_loaded = True
+        print(f"[KTO] Adapters attached. Effective target_modules: {self.peft_config.target_modules}")
+        print("[KTO] Trainable parameter summary:")
+        print_trainable_parameters(self.peft_model)
+
+    def train(
+        self,
+        dataset: Dataset,
+        tokenizer,
+        output_dir: str,
+        resume_from_checkpoint: Optional[str] = None,
+        runtime_state_hooks: Optional[TrainingRuntime.RuntimeStateHooks] = None,
+        checkpoint_label: str = "kto_trainer",
+        beta: float = 0.1,
+        desirable_weight: float = 1.0,
+        undesirable_weight: float = 1.0,
+        max_prompt_length: int = 2048,
+        max_completion_length: int = 2048,
+    ):
+        """
+        Train the model using KTOTrainer.
+
+        Args:
+            dataset: HF Dataset with columns {"prompt": str, "completion": str, "label": bool}
+            tokenizer: Tokenizer instance (also stored as self.tokenizer)
+            output_dir: Directory to save the trained adapter
+            resume_from_checkpoint: Optional path to a trainer checkpoint for resume
+            runtime_state_hooks: Optional pipeline-level state-persistence hooks
+            checkpoint_label: Label used in resume error messages
+            beta: KTO KL-regularisation strength (paper recommends 0.1)
+            desirable_weight: per-class loss weight for label=True examples
+            undesirable_weight: per-class loss weight for label=False examples
+            max_prompt_length: max tokens kept from the prompt (truncated from left)
+            max_completion_length: max tokens kept from the completion
+        """
+        self.peft_model.config.use_cache = False
+
+        # KTOTrainer requires the exact three columns: prompt, completion, label.
+        # If the caller passed metadata fields too, strip them now so the trainer
+        # doesn't choke on unexpected columns.
+        required_cols = {"prompt", "completion", "label"}
+        if hasattr(dataset, "column_names"):
+            extra = [c for c in dataset.column_names if c not in required_cols]
+            if extra:
+                print(f"[KTO] Removing non-KTO columns from dataset: {extra}")
+                dataset = dataset.remove_columns(extra)
+            missing = required_cols - set(dataset.column_names)
+            if missing:
+                raise ValueError(
+                    f"KTO dataset missing required columns: {missing}. "
+                    f"Got columns: {dataset.column_names}"
+                )
+
+        # Split dataset for train/eval
+        dataset = dataset.train_test_split(test_size=0.1, seed=43)
+        train_dataset = dataset['train']
+        eval_dataset = dataset['test']
+
+        # Report label balance
+        train_labels = [int(bool(x)) for x in train_dataset["label"]]
+        eval_labels = [int(bool(x)) for x in eval_dataset["label"]]
+        n_train_des = sum(train_labels)
+        n_train_und = len(train_labels) - n_train_des
+        n_eval_des = sum(eval_labels)
+        n_eval_und = len(eval_labels) - n_eval_des
+        print(f"[KTO] Train split: {len(train_dataset)} examples "
+              f"({n_train_des} desirable, {n_train_und} undesirable)")
+        print(f"[KTO] Eval split:  {len(eval_dataset)} examples "
+              f"({n_eval_des} desirable, {n_eval_und} undesirable)")
+
+        # Build KTOConfig from the TrainingArguments instance the caller supplied.
+        # KTOConfig is a subclass of TrainingArguments, so .to_dict() round-tripping
+        # is safe.  We then layer the KTO-specific fields on top.
+        if isinstance(self.training_args, KTOConfig):
+            kto_config = self.training_args
+        else:
+            base_kwargs = self.training_args.to_dict()
+            # Filter to KTOConfig accepted args to be safe across TRL minor versions
+            kto_sig = inspect.signature(KTOConfig.__init__)
+            accepted = set(kto_sig.parameters.keys())
+            filtered = {k: v for k, v in base_kwargs.items() if k in accepted}
+            kto_config = KTOConfig(**filtered)
+
+        # KTO-specific knobs
+        kto_config.beta = beta
+        kto_config.desirable_weight = desirable_weight
+        kto_config.undesirable_weight = undesirable_weight
+        kto_config.max_prompt_length = max_prompt_length
+        kto_config.max_completion_length = max_completion_length
+        kto_config.max_length = max_prompt_length + max_completion_length
+        # KTOTrainer accepts these columns directly; do NOT remove unused columns
+        kto_config.remove_unused_columns = False
+
+        # Tokenizer config — KTOTrainer tokenises prompt + completion separately
+        self.tokenizer.truncation_side = "left"
+        self.tokenizer.padding_side = "right"
+
+        # Build the KTOTrainer.  In TRL >= 0.10 the parameter is "processing_class";
+        # in earlier versions it was "tokenizer".  Detect at runtime.
+        kto_init_sig = inspect.signature(KTOTrainer.__init__)
+        kto_kwargs = dict(
+            model=self.peft_model,
+            args=kto_config,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+        )
+        if "processing_class" in kto_init_sig.parameters:
+            kto_kwargs["processing_class"] = self.tokenizer
+        elif "tokenizer" in kto_init_sig.parameters:
+            kto_kwargs["tokenizer"] = self.tokenizer
+        else:
+            raise RuntimeError(
+                "Installed KTOTrainer accepts neither 'processing_class' nor 'tokenizer' — "
+                "TRL version may be incompatible."
+            )
+
+        # When using PEFT, KTOTrainer can use the base model (adapters disabled)
+        # as the implicit reference, so we don't supply ref_model.  Explicit None.
+        if "ref_model" in kto_init_sig.parameters:
+            kto_kwargs["ref_model"] = None
+
+        trainer = KTOTrainer(**kto_kwargs)
+
+        # Verify dtypes before training
+        dtypes = {}
+        for _, p in self.peft_model.named_parameters():
+            dtype = p.dtype
+            dtypes[dtype] = dtypes.get(dtype, 0) + p.numel()
+        total = sum(dtypes.values())
+        for k, v in dtypes.items():
+            print(k, v, v / total)
+
+        if runtime_state_hooks is not None:
+            TrainingRuntime.restore_or_reset_runtime_state(
+                Path(resume_from_checkpoint).expanduser().resolve() if resume_from_checkpoint else None,
+                runtime_state_hooks,
+            )
+            runtime_callback = TrainingRuntime.build_trainer_checkpoint_callback(runtime_state_hooks)
+            if runtime_callback is not None:
+                trainer.add_callback(runtime_callback)
+
+        # Train
+        print("[KTO] Training...")
+        if resume_from_checkpoint:
+            resolved_resume_checkpoint = Path(resume_from_checkpoint).expanduser().resolve()
+            if not resolved_resume_checkpoint.exists():
+                raise FileNotFoundError(
+                    f"{checkpoint_label.capitalize()} resume checkpoint not found: "
+                    f"{resolved_resume_checkpoint}"
+                )
+            train_signature = inspect.signature(trainer.train)
+            if "resume_from_checkpoint" not in train_signature.parameters:
+                raise RuntimeError(
+                    f"Installed trainer does not support resume_from_checkpoint for "
+                    f"{checkpoint_label} resume."
+                )
+            train_result = trainer.train(resume_from_checkpoint=str(resolved_resume_checkpoint))
+        else:
+            train_result = trainer.train()
+        metrics = train_result.metrics
+        trainer.log_metrics(split="train", metrics=metrics)
+        trainer.save_metrics(split="train", metrics=metrics)
+        trainer.save_state()
+        print(metrics)
+
+        # Re-enable cache for inference
+        self.peft_model.config.use_cache = True
+
+        # Save adapter + tokenizer
+        print(f"[KTO] Saving final adapter to {output_dir}")
+        makedirs(output_dir, exist_ok=True)
+        trainer.model.save_pretrained(output_dir, access_token=self.access_token)
+        self.tokenizer.save_pretrained(output_dir)
+        print(f"[KTO] Tokenizer saved to {output_dir}")
+
+        release_memory()
+        return self.peft_model

--- a/ab/gpt/util/KTO.py
+++ b/ab/gpt/util/KTO.py
@@ -26,8 +26,8 @@ import inspect
 from pathlib import Path
 from typing import Optional
 
-import torch
 from ab.nn.util.Util import release_memory
+from ab.gpt.util.LoRA import find_all_linear_names, print_trainable_parameters
 import ab.gpt.util.training_runtime as TrainingRuntime
 from datasets import Dataset
 from peft import (
@@ -51,51 +51,16 @@ except ImportError as e:
     )
 
 
-def find_all_linear_names(model):
-    cls = torch.nn.modules.linear.Linear
-    lora_module_names = set()
-    for name, module in model.named_modules():
-        if isinstance(module, cls):
-            names = name.split('.')
-            lora_module_names.add(names[0] if len(names) == 1 else names[-1])
-
-    if 'lm_head' in lora_module_names:  # needed for 16-bit
-        lora_module_names.remove('lm_head')
-    return list(lora_module_names)
-
-
-def print_trainable_parameters(model, use_4bit=False):
-    """Print the number of trainable parameters in the model."""
-    trainable_params = 0
-    all_param = 0
-    for _, param in model.named_parameters():
-        num_params = param.numel()
-        # if using DS Zero 3 and the weights are initialized empty
-        if num_params == 0 and hasattr(param, "ds_numel"):
-            num_params = param.ds_numel
-
-        all_param += num_params
-        if param.requires_grad:
-            trainable_params += num_params
-    if use_4bit:
-        trainable_params /= 2
-    print(
-        f"all params: {all_param:,d} || trainable params: {trainable_params:,d} || "
-        f"trainable%: {100 * trainable_params / all_param}"
+def kto_lora_config(target_modules, r=16, lora_alpha=16, lora_dropout=0.05,
+                    bias="none", task_type="CAUSAL_LM", layers_to_transform=None):
+    """LoRA config for KTO — lower-rank defaults than SFT for drift control."""
+    kwargs = dict(
+        r=r, lora_alpha=lora_alpha, target_modules=list(target_modules),
+        lora_dropout=lora_dropout, bias=bias, task_type=task_type,
     )
-
-
-def create_peft_config(modules):
-    """Create Parameter-Efficient Fine-Tuning config for KTO."""
-    return LoraConfig(
-        r=32,
-        lora_alpha=64,
-        target_modules=modules,
-        lora_dropout=0.1,
-        bias="none",
-        task_type="CAUSAL_LM",
-        use_dora=True,
-    )
+    if layers_to_transform is not None:
+        kwargs["layers_to_transform"] = list(layers_to_transform)
+    return LoraConfig(**kwargs)
 
 
 class KTO:
@@ -121,8 +86,7 @@ class KTO:
         self._use_unsloth = use_unsloth
 
         if peft_config is None:
-            modules = find_all_linear_names(self.model)
-            self.peft_config = create_peft_config(modules)
+            self.peft_config = kto_lora_config(find_all_linear_names(self.model))
         else:
             self.peft_config = peft_config
 


### PR DESCRIPTION
Adds a self-contained KTO (Kahneman-Tversky Optimization) pipeline for fine-tuning ABrain/NNGPT-UniqueArch-Rag, as a comparison point to SFT: Each cycle it generates architectures with the model, evaluates them on CIFAR-10, buckets them into desirable/undesirable preference data, and KTO-trains — warm-starting the next cycle from the previous adapter.

Reuses existing repo abstractions (LLM loader, LoRA config helpers, CycleResults, NoveltyChecker, NNEval) rather than re-implementing them.