### PR TITLE
Functionality for RL

### DIFF
--- a/ab/gpt/NNEval.py
+++ b/ab/gpt/NNEval.py
@@ -510,8 +510,11 @@ def main(
     use_all_visible_gpus: Optional[bool] = None,
 ):
     base_nngpt_path = nngpt_dir
+    custom_synth_path = Path(custom_synth_dir) if custom_synth_dir else None
     if nn_alter_epochs is None:
-        if epoch_dir().is_dir():
+        if custom_synth_path is not None:
+            nn_alter_epochs = 1
+        elif epoch_dir().is_dir():
             nn_alter_epochs = len(os.listdir(epoch_dir()))
         else:
             print(f"Directory {epoch_dir()} doesn't exist", file=sys.stderr)
@@ -530,10 +533,14 @@ def main(
                 current_epoch = i
                 cycle_start_time = time.time()
                 # Path to one NNAlter epoch output, e.g. out/nngpt/llm/epoch/A0.
-                current_alter_epoch_path = epoch_dir(i)
-                # Allow callers to point directly at a synth dir instead of
-                # deriving it from epoch_dir().
-                models_base_dir = Path(custom_synth_dir) if custom_synth_dir else synth_dir(current_alter_epoch_path)
+                # If a caller passes a synth dir directly, do not infer anything
+                # from the default epoch root.
+                if custom_synth_path is not None:
+                    models_base_dir = custom_synth_path
+                    current_alter_epoch_path = custom_synth_path.parent
+                else:
+                    current_alter_epoch_path = epoch_dir(i)
+                    models_base_dir = synth_dir(current_alter_epoch_path)
 
                 if not models_base_dir.exists():
                     print(f"Directory {models_base_dir} for NNAlter epoch {i} not found. Skipping.")

--- a/ab/gpt/TuneBackbone.py
+++ b/ab/gpt/TuneBackbone.py
@@ -9,10 +9,21 @@ def main():
     parser = argparse.ArgumentParser(description='Run Backbone Tuning.')
     parser.add_argument('--llm_conf', type=str, default='backbone_sft_config.json', help='LLM config file name')
     parser.add_argument('--test_nn', type=int, default=30, help='Number of NNs to generate')
-    parser.add_argument('--num_train_epochs', type=int, default=5, help='Number of LLM fine-tuning epochs')
+    parser.add_argument('--num_train_epochs', type=int, default=1, help='Number of LLM fine-tuning epochs')
     parser.add_argument('--num_cycles', type=int, default=None, help='Number of generate/eval/SFT cycles; defaults to llm config num_epochs')
     parser.add_argument('--nn_train_epochs', type=int, default=1, help='Number of training epochs for generated NNs')
-    parser.add_argument('--sft_nn_prefixes', type=str, default='rl-bb-test1', help='Comma-separated NN prefixes used as SFT training data')
+    parser.add_argument('--sft_max_length', type=int, default=6144, help='Maximum SFT sequence length')
+    parser.add_argument('--sft_batch_size', type=int, default=2, help='Per-device SFT batch size')
+    parser.add_argument('--sft_gradient_accumulation', type=int, default=4, help='SFT gradient accumulation steps')
+    parser.add_argument('--sft_dataset_limit', type=int, default=None, help='Maximum number of SFT training samples; unset uses all available rows')
+    parser.add_argument('--epoch_root', type=str, default=None, help='Output root for A* cycle directories')
+    parser.add_argument('--sft_dataset', type=str, default='cifar-10', help='Dataset used for SFT seed/query data')
+    parser.add_argument(
+        '--sft_nn_prefixes',
+        type=lambda raw: tuple(item.strip() for item in raw.split(',') if item.strip()),
+        default=('rl-bb-test1',),
+        help='Comma-separated NN prefixes used as SFT training data',
+    )
     parser.add_argument('--gen_nn_prefix', type=str, default='rl-bb-test1', help='NN prefix for generated/evaluated models')
     
     args = parser.parse_args()
@@ -20,8 +31,8 @@ def main():
     # Training Arguments
     training_args = SFTConfig(
         output_dir=str(nngpt_dir / 'outputs'),
-        per_device_train_batch_size=2,
-        gradient_accumulation_steps=4,
+        per_device_train_batch_size=args.sft_batch_size,
+        gradient_accumulation_steps=args.sft_gradient_accumulation,
         learning_rate=1e-5,
         num_train_epochs=args.num_train_epochs,
         logging_steps=5,
@@ -29,6 +40,7 @@ def main():
         save_strategy="no",
         report_to="none",
         remove_unused_columns=False,
+        max_length=args.sft_max_length,
         packing_strategy="wrapped",
         padding_free=False,
         gradient_checkpointing=True
@@ -58,10 +70,12 @@ def main():
         llm_conf=args.llm_conf,
         training_args=training_args,
         peft_config=peft_config,
-        # max_prompts=1000,
+        max_prompts=args.sft_dataset_limit,
         use_backbone=True,
         sft_nn_prefixes=args.sft_nn_prefixes,
+        sft_dataset=args.sft_dataset,
         num_cycles=args.num_cycles,
+        epoch_root=args.epoch_root,
         temperature=0.8
     )
 

--- a/ab/gpt/TuneRL.py
+++ b/ab/gpt/TuneRL.py
@@ -1,9 +1,11 @@
 import ast
 import csv
 from datetime import timedelta
+import hashlib
 import inspect
 import math
 import os
+import random
 import re
 import signal
 import subprocess
@@ -11,6 +13,7 @@ import sys
 import threading
 import time
 import warnings
+from typing import Tuple, Any, List, Dict, Optional, Set
 
 
 _RL_FILTERED_LOG_PATTERNS = (
@@ -64,6 +67,10 @@ def _install_rl_runtime_noise_filters() -> None:
 _install_rl_runtime_noise_filters()
 
 import torch
+try:
+    import numpy as np
+except Exception:
+    np = None
 from peft import prepare_model_for_kbit_training
 from trl.trainer.grpo_trainer import GRPOTrainer
 from trl.trainer.grpo_config import GRPOConfig
@@ -101,7 +108,6 @@ from dataclasses import dataclass, asdict
 
 from ab.gpt.util.simple_logger import SimpleCodeLogger
 import ab.gpt.util.training_runtime as TrainingRuntime
-from typing import Tuple, Any, List, Dict, Optional, Set
 from collections import Counter, deque
 
 # Open-architecture archives are keyed by canonical graph structure, not prompt labels.
@@ -111,7 +117,9 @@ family_hash_archive_counts = Counter()
 descriptor_archive_counts = Counter()
 backbone_signature_archive_counts = Counter()
 cnn_signature_archive_counts = Counter()
+block_signature_archive_counts = Counter()
 backbone_cnn_pair_archive_counts = Counter()
+backbone_block_pair_archive_counts = Counter()
 family_metric_best: Dict[str, float] = {}
 motif_name_counts = Counter()
 saved_graph_counts = Counter()
@@ -119,6 +127,7 @@ saved_family_hash_counts = Counter()
 saved_backbone_signature_counts = Counter()
 saved_cnn_signature_counts = Counter()
 saved_backbone_cnn_pair_counts = Counter()
+saved_backbone_block_pair_counts = Counter()
 goal_graph_archive_counts: Dict[str, Counter] = {}
 goal_family_hash_archive_counts: Dict[str, Counter] = {}
 saved_goal_family_hash_counts: Dict[str, Counter] = {}
@@ -131,10 +140,11 @@ current_group_reward_target_count_by_backbone = Counter()
 prev_closed_group_mean_reward_target_by_backbone: Dict[str, float] = {}
 best_closed_group_mean_reward_target_by_backbone: Dict[str, float] = {}
 saved_best_reward_target_by_backbone_cnn: Dict[str, float] = {}
+best_quality_acc_by_backbone_block: Dict[str, float] = {}
 
 
 # ===== Configuration Options =====
-base_model = "ABrain/NNGPT-Backbone-deepseek-coder-6.7b-instruct" # 使用新的 Backbone 模型
+base_model = "deepseek-ai/deepseek-coder-6.7b-instruct"
 LOAD_EXISTING_MODEL = False  # Model is already merged
 SAVED_MODEL_PATH = "rl_backbone_model" 
 B_index = 0
@@ -144,10 +154,35 @@ BEST_GROUP_REFRESH_DELTA = 0.0015
 GOAL_REFRESH_DELTA = 0.0015
 NON_IMPROVING_REWARD_CAP = 0.04
 FORMAL_REWARD_TRANSFORM = "norm_128_flip"
+
+
+def _formal_reward_resize(default: int = 128) -> int:
+    match = re.search(r"(?:^|_)norm_(\d+)(?:_|$)", FORMAL_REWARD_TRANSFORM)
+    if not match:
+        return int(default)
+    try:
+        value = int(match.group(1))
+    except (TypeError, ValueError):
+        return int(default)
+    return value if value > 0 else int(default)
+
+
+def _formal_reward_input_shape(batch: int = 1) -> Tuple[int, int, int, int]:
+    resize = _formal_reward_resize()
+    return (int(batch), 3, resize, resize)
+
+
+def _formal_reward_out_shape() -> Tuple[int, ...]:
+    dataset = os.getenv("NNGPT_RL_FORMAL_DATASET", "cifar-10").strip().lower().replace("_", "-")
+    if dataset in {"cifar-100", "cifar100"}:
+        return (100,)
+    return (10,)
+
+
 BACKBONE_BASELINE_MIN_ARCHIVE_SAMPLES = 3
 SAVE_DUPLICATE_BACKBONE_CNN_DELTA = 0.002
-BATCH_ELITE_SOFT_BONUSES = (0.10, 0.07, 0.05, 0.03, 0.02)
-BATCH_ELITE_IMPROVING_BONUSES = (0.18, 0.13, 0.09, 0.06, 0.04)
+BATCH_ELITE_SOFT_BONUSES = (0.02, 0.015, 0.01, 0.005, 0.0)
+BATCH_ELITE_IMPROVING_BONUSES = (0.04, 0.03, 0.02, 0.01, 0.0)
 STRUCTURE_MACRO_BONUS = 0.04
 STRUCTURE_MULTI_STAGE_BONUS = 0.03
 STRUCTURE_MOTIF_BONUS = 0.02
@@ -156,10 +191,18 @@ STRUCTURE_NON_DOMINANT_FAMILY_BONUS = 0.02
 STRUCTURE_ARCHIVE_RARITY_STRONG_BONUS = 0.03
 STRUCTURE_ARCHIVE_RARITY_MEDIUM_BONUS = 0.02
 STRUCTURE_ARCHIVE_RARITY_LIGHT_BONUS = 0.01
-REPEAT_FAMILY_PENALTY = -0.10
+REPEAT_FAMILY_PENALTY = -0.05
 PLAIN_FUSE_PENALTY = -0.10
+PLAIN_DUAL_BACKBONE_FUSE_PENALTY = -0.28
+TARGET_STRUCTURE_DEAD_BLOCK_PENALTY = -0.80
+TARGET_STRUCTURE_DUAL_BACKBONE_PENALTY = -0.60
+TARGET_STRUCTURE_PATH_PENALTY = -0.05
+TARGET_STRUCTURE_PARSE_PENALTY = -0.30
+TARGET_STRUCTURE_PATTERN_MISMATCH_PENALTY = -1.00
+TARGET_STRUCTURE_PENALTY_FLOOR = -1.00
+TARGET_STRUCTURE_MATCH_BONUS = 0.20
 NO_PROGRESS_PENALTY = -0.06
-GOAL_REFRESH_BONUS = 0.30
+GOAL_REFRESH_BONUS = 0.08
 GOAL_MATCH_REWARD_SCALE = 0.12
 TRAINSET_NOVEL_FAMILY_BONUS = 0.04
 TRAINSET_NOVEL_GRAPH_BONUS = 0.02
@@ -191,11 +234,17 @@ STAGE_REFERENCE_MIN_GROUPS = {
 STAGE1_GATE_WINDOW_GENERATIONS = 1600
 STAGE2_GATE_WINDOW_GENERATIONS = 4000
 RECOVERY_GATE_WINDOW_GENERATIONS = 2000
+STAGE1_EXECUTABLE_STABLE_WINDOW_GENERATIONS = 320
+STAGE1_EXECUTABLE_STABLE_MIN_GROUPS = 6
+STAGE1_EXECUTABLE_STABLE_MIN_RATE = 0.95
+STAGE1_TRAINABLE_STABLE_MIN_RATE = 0.30
 STAGE1_PROMOTION_MIN_GROUPS = 20
 STAGE1_GATE_EXECUTABLE_MIN = 96
+STAGE1_GATE_TRAINABLE_MIN = 480
 STAGE1_GATE_DISCOVERY_MIN = 8
 STAGE1_GATE_UNIQUE_DISCOVERY_FAMILIES_MIN = 6
 STAGE1_FORCE_PROMOTION_EXECUTABLE_MIN = 800
+STAGE1_FORCE_PROMOTION_TRAINABLE_MIN = 480
 STAGE1_FORCE_PROMOTION_DISCOVERY_MIN = 8
 STAGE1_FORCE_PROMOTION_UNIQUE_DISCOVERY_FAMILIES_MIN = 6
 STAGE2_GATE_MIN_REWARD_TARGET = 0.90
@@ -213,7 +262,7 @@ TRAINING_CONTEXT_WINDOW = 50
 TRAINING_CONTEXT_MIN_POINTS = 8
 STATIC_STAGE_REWARD_TARGET_METRIC = "stage1_static_score"
 FORMAL_STAGE_REWARD_TARGET_METRIC = FORMAL_MULTI_HORIZON_REWARD_TARGET_METRIC
-FORMAL_SUCCESS_SIGNAL_BONUS = 0.02
+FORMAL_SUCCESS_SIGNAL_BONUS = 0.08
 STAGE1_EXECUTABLE_BONUS = 0.10
 STAGE1_DISCOVERY_FAMILY_BONUS = 0.42
 STAGE1_DISCOVERY_GRAPH_BONUS = 0.20
@@ -245,43 +294,74 @@ STAGE1_ZERO_GOAL_HIT_REWARD_CAP = 1.0
 STAGE1_LOW_GOAL_HIT_REWARD_CAP = 1.0
 STAGE1_PLAIN_PARALLEL_REWARD_CAP = 1.0
 STAGE1_OFF_TARGET_PLAIN_PARALLEL_REWARD_CAP = 1.0
+STAGE1_REPEATED_BLOCK_REWARD_CAP = 0.24
 STAGE23_DESCRIPTOR_BATCH_UNIQUE_BONUS = 0.03
 STAGE23_DESCRIPTOR_ARCHIVE_NOVEL_BONUS = 0.02
 STAGE23_NON_DOMINANT_DESCRIPTOR_BONUS = 0.06
-STAGE23_DESCRIPTOR_BATCH_REPEAT_STEP_PENALTY = -0.05
-STAGE23_DESCRIPTOR_BATCH_REPEAT_MAX_PENALTY = -0.20
-STAGE23_DESCRIPTOR_ARCHIVE_REPEAT_STEP_PENALTY = -0.025
-STAGE23_DESCRIPTOR_ARCHIVE_REPEAT_MAX_PENALTY = -0.14
+STAGE23_DESCRIPTOR_BATCH_REPEAT_STEP_PENALTY = -0.015
+STAGE23_DESCRIPTOR_BATCH_REPEAT_MAX_PENALTY = -0.05
+STAGE23_DESCRIPTOR_ARCHIVE_REPEAT_STEP_PENALTY = -0.006
+STAGE23_DESCRIPTOR_ARCHIVE_REPEAT_MAX_PENALTY = -0.03
+STAGE23_GLOBAL_DESCRIPTOR_ARCHIVE_NOVEL_BONUS = 0.08
+STAGE23_GLOBAL_DESCRIPTOR_ARCHIVE_REPEAT_MAX_PENALTY = -0.025
+STAGE23_GLOBAL_DESCRIPTOR_ARCHIVE_REPEAT_WINDOW = 32
 STAGE23_DOMINANT_DESCRIPTOR_SOFT_SHARE = 0.45
 STAGE23_DOMINANT_DESCRIPTOR_STRONG_SHARE = 0.60
-STAGE23_DOMINANT_DESCRIPTOR_REPEAT_PENALTY = -0.12
-STAGE23_DOMINANT_DESCRIPTOR_REPEAT_STRONG_PENALTY = -0.20
+STAGE23_DOMINANT_DESCRIPTOR_REPEAT_PENALTY = -0.03
+STAGE23_DOMINANT_DESCRIPTOR_REPEAT_STRONG_PENALTY = -0.05
 STAGE23_CNN_BATCH_UNIQUE_BONUS = 0.07
 STAGE23_CNN_ARCHIVE_NOVEL_BONUS = 0.05
-STAGE23_CNN_BATCH_REPEAT_STEP_PENALTY = -0.08
-STAGE23_CNN_BATCH_REPEAT_MAX_PENALTY = -0.30
-STAGE23_CNN_ARCHIVE_REPEAT_STEP_PENALTY = -0.03
-STAGE23_CNN_ARCHIVE_REPEAT_MAX_PENALTY = -0.18
+STAGE23_CNN_BATCH_REPEAT_STEP_PENALTY = -0.02
+STAGE23_CNN_BATCH_REPEAT_MAX_PENALTY = -0.07
+STAGE23_CNN_ARCHIVE_REPEAT_STEP_PENALTY = -0.008
+STAGE23_CNN_ARCHIVE_REPEAT_MAX_PENALTY = -0.04
+STAGE23_GLOBAL_CNN_ARCHIVE_NOVEL_BONUS = 0.12
+STAGE23_GLOBAL_CNN_ARCHIVE_REPEAT_MAX_PENALTY = -0.06
+STAGE23_GLOBAL_CNN_ARCHIVE_REPEAT_WINDOW = 32
+STAGE23_BLOCK_BATCH_UNIQUE_BONUS = 0.06
+STAGE23_BLOCK_BATCH_REPEAT_STEP_PENALTY = -0.015
+STAGE23_BLOCK_BATCH_REPEAT_MAX_PENALTY = -0.05
+STAGE23_BLOCK_ARCHIVE_NOVEL_BONUS = 0.08
+STAGE23_BLOCK_ARCHIVE_REPEAT_MAX_PENALTY = -0.08
+STAGE23_BLOCK_ARCHIVE_REPEAT_WINDOW = 16
+STAGE23_REPEATED_BLOCK_REWARD_CAP = 2.0
+STAGE23_POSITIVE_NOVELTY_ACC_THRESHOLD = 0.90
+STAGE23_EARLY_LOCAL_COMPETITION_GENERATIONS = 240
+STAGE23_EARLY_CELL_REPEAT_REWARD_CAP = 0.0
+STAGE23_NEW_CELL_BONUS = 0.04
+STAGE23_CELL_IMPROVEMENT_DELTA = 0.003
+STAGE23_CELL_IMPROVEMENT_BONUS = 0.08
+STAGE23_DUPLICATE_LOW_ACC_THRESHOLD = 0.92
+STAGE23_DUPLICATE_LOW_ACC_REWARD_CAP = 0.03
+STAGE23_HIGH_ACC_BONUS_THRESHOLD = 0.92
+STAGE23_HIGH_ACC_BONUS = 0.08
+STAGE23_HIGH_ACC_STRONG_THRESHOLD = 0.925
+STAGE23_HIGH_ACC_STRONG_BONUS = 0.12
+STAGE23_HIGH_ACC_ELITE_THRESHOLD = 0.93
+STAGE23_HIGH_ACC_ELITE_BONUS = 0.18
 STAGE23_NON_DOMINANT_CNN_BONUS = 0.08
 STAGE23_DOMINANT_CNN_SOFT_SHARE = 0.45
 STAGE23_DOMINANT_CNN_STRONG_SHARE = 0.65
-STAGE23_DOMINANT_CNN_REPEAT_PENALTY = -0.16
-STAGE23_DOMINANT_CNN_REPEAT_STRONG_PENALTY = -0.24
+STAGE23_DOMINANT_CNN_REPEAT_PENALTY = -0.04
+STAGE23_DOMINANT_CNN_REPEAT_STRONG_PENALTY = -0.06
+STAGE23_GLOBAL_CNN_REPEAT_PENALTY = -0.08
+STAGE23_GLOBAL_CNN_REPEAT_STRONG_PENALTY = -0.12
+STAGE23_DEAD_BLOCK_PENALTY = -0.04
 STAGE23_STRUCTURE_ARCHIVE_RARITY_CAP = 0.03
 STAGE2_DENSE_SCALE = 0.50
-STAGE2_PREV_GROUP_SCALE = 0.70
-STAGE2_BEST_GROUP_SCALE = 0.70
+STAGE2_PREV_GROUP_SCALE = 0.20
+STAGE2_BEST_GROUP_SCALE = 0.20
 STAGE2_GLOBAL_BASELINE_BLEND = 0.20
-STAGE2_BACKBONE_PREV_GROUP_SCALE = 0.95
-STAGE2_BACKBONE_BEST_GROUP_SCALE = 0.95
+STAGE2_BACKBONE_PREV_GROUP_SCALE = 0.25
+STAGE2_BACKBONE_BEST_GROUP_SCALE = 0.25
 STAGE2_GOAL_BEST_SCALE = 0.70
 STAGE2_GOAL_MATCH_SCALE = 0.85
 STAGE2_STRUCTURE_SCALE = 1.40
 STAGE2_REPEAT_FAMILY_SCALE = 1.10
 STAGE2_PLAIN_FUSE_SCALE = 1.10
 STAGE2_NO_PROGRESS_SCALE = 0.50
-STAGE2_NON_IMPROVING_CAP = 0.10
-STAGE2_DESCRIPTOR_NON_IMPROVING_CAP = 0.03
+STAGE2_NON_IMPROVING_CAP = 2.0
+STAGE2_DESCRIPTOR_NON_IMPROVING_CAP = 2.0
 STAGE3_DENSE_SCALE = 0.70
 STAGE3_PREV_GROUP_SCALE = 1.10
 STAGE3_BEST_GROUP_SCALE = 1.10
@@ -294,8 +374,8 @@ STAGE3_STRUCTURE_SCALE = 0.85
 STAGE3_REPEAT_FAMILY_SCALE = 1.00
 STAGE3_PLAIN_FUSE_SCALE = 1.00
 STAGE3_NO_PROGRESS_SCALE = 1.15
-STAGE3_NON_IMPROVING_CAP = NON_IMPROVING_REWARD_CAP
-STAGE3_DESCRIPTOR_NON_IMPROVING_CAP = 0.00
+STAGE3_NON_IMPROVING_CAP = 2.0
+STAGE3_DESCRIPTOR_NON_IMPROVING_CAP = 2.0
 RL_STAGE_KL_COEF = 0.005
 reward_batch_index = 0
 current_group_id = 0
@@ -418,6 +498,69 @@ def _backbone_cnn_pair_key(backbone_signature: str, cnn_signature: str) -> str:
     return f"{str(backbone_signature or 'unknown_backbone_pair')}::{str(cnn_signature or 'incomplete_cnn')}"
 
 
+def _backbone_block_pair_key(backbone_signature: str, block_signature: str) -> str:
+    return f"{str(backbone_signature or 'unknown_backbone_pair')}::{str(block_signature or 'incomplete_block')}"
+
+
+def _block_signature_from_code(block_code: str) -> str:
+    source = textwrap.dedent(str(block_code or "")).strip()
+    if not source:
+        return "incomplete_block"
+    try:
+        tree = ast.parse(source)
+        payload = ast.dump(tree, annotate_fields=True, include_attributes=False)
+    except Exception:
+        payload = "\n".join(line.strip() for line in source.splitlines() if line.strip())
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()
+
+
+def _block_contributes_to_forward(init_code: str, forward_code: str) -> bool:
+    init_source = str(init_code or "")
+    forward_source = str(forward_code or "")
+    block_tokens = ("drop_conv3x3_block", "FractalUnit", "FractalBlock")
+    if not any(token in init_source or token in forward_source for token in block_tokens):
+        return False
+    if "drop_conv3x3_block" in forward_source:
+        return True
+    if any(token in init_source for token in block_tokens) and "self.features" in init_source and "self.features" in forward_source:
+        return True
+
+    referenced_attrs = set(re.findall(r"self\.([A-Za-z_][A-Za-z0-9_]*)", forward_source))
+    for line in init_source.splitlines():
+        if not any(token in line for token in block_tokens):
+            continue
+        match = re.search(r"self\.([A-Za-z_][A-Za-z0-9_]*)", line)
+        if match and match.group(1) in referenced_attrs:
+            return True
+    return False
+
+
+def _block_truly_contributes_to_forward(init_code: str, forward_code: str, graph_info) -> bool:
+    if graph_info is not None and getattr(graph_info, "parse_ok", False):
+        return int(getattr(graph_info, "fractal_calls", 0) or 0) > 0
+    return _block_contributes_to_forward(init_code, forward_code)
+
+
+def _is_plain_dual_backbone_concat(forward_code: str) -> bool:
+    source = str(forward_code or "")
+    if not ("self.backbone_a" in source and "self.backbone_b" in source):
+        return False
+    if "torch.cat" not in source or "adaptive_pool_flatten" not in source:
+        return False
+    structural_tokens = (
+        "_feature_to_input_image",
+        "self.features",
+        "self.stem",
+        "self.project",
+        "self.bridge",
+        "self.adapter",
+        "self.fuse",
+        "self.fractal",
+        "drop_conv3x3_block",
+    )
+    return not any(token in source for token in structural_tokens)
+
+
 def _result_backbone_signature(res: Dict[str, Any]) -> str:
     signature = str(res.get("backbone_signature") or "").strip()
     if signature:
@@ -434,6 +577,25 @@ def _result_cnn_signature(res: Dict[str, Any], graph_info) -> str:
         if signature:
             return signature
     return "incomplete_cnn"
+
+
+def _result_block_signature(res: Dict[str, Any], completion: str = "") -> str:
+    if res and res.get("block_contributes_to_forward") is False:
+        return "incomplete_block"
+    signature = str(res.get("block_signature") or "").strip()
+    if signature:
+        return signature
+    block_code, init_code, forward_code = extract_completion_blocks(str(completion or ""))
+    graph_info = res.get("graph_info") if isinstance(res, dict) else None
+    if graph_info is None and block_code and init_code and forward_code:
+        graph_info = extract_graph_info(
+            init_code,
+            forward_code,
+            legacy_patterns=SFTUtil.legacy_patterns,
+        )
+    if not _block_truly_contributes_to_forward(init_code, forward_code, graph_info):
+        return "incomplete_block"
+    return _block_signature_from_code(block_code)
 
 
 def capture_reward_runtime_state() -> Dict[str, Any]:
@@ -612,6 +774,101 @@ def env_float(name: str, default: float) -> float:
     return float(value)
 
 
+def resolve_rl_seed() -> int:
+    return env_int("NNGPT_RL_SEED", 42)
+
+
+def apply_rl_seed(seed: Optional[int] = None, *, log_prefix: str = "[RL]") -> int:
+    resolved_seed = int(resolve_rl_seed() if seed is None else seed)
+    os.environ.setdefault("PYTHONHASHSEED", str(resolved_seed))
+    random.seed(resolved_seed)
+    if np is not None:
+        np.random.seed(resolved_seed)
+    torch.manual_seed(resolved_seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(resolved_seed)
+    try:
+        from transformers import set_seed
+
+        set_seed(resolved_seed)
+    except Exception as exc:
+        print(f"{log_prefix} transformers.set_seed unavailable: {type(exc).__name__}: {exc}")
+    print(f"{log_prefix} Seed: {resolved_seed}")
+    return resolved_seed
+
+
+REWARD_VARIANT_ENV = "NNGPT_RL_REWARD_VARIANT"
+REWARD_VARIANT_FULL = "full"
+REWARD_VARIANT_FULL_REWARD = "full_reward"
+REWARD_VARIANT_NO_DIVERSITY_BONUS = "no_diversity_bonus"
+REWARD_VARIANT_NO_REPEAT_PENALTY = "no_repeat_penalty"
+REWARD_VARIANT_NO_STRUCTURAL_NOVELTY = "no_structural_novelty"
+REWARD_VARIANT_STRONG_REPEAT_PENALTY = "strong_repeat_penalty"
+REWARD_VARIANTS = {
+    REWARD_VARIANT_FULL,
+    REWARD_VARIANT_FULL_REWARD,
+    REWARD_VARIANT_NO_DIVERSITY_BONUS,
+    REWARD_VARIANT_NO_REPEAT_PENALTY,
+    REWARD_VARIANT_NO_STRUCTURAL_NOVELTY,
+    REWARD_VARIANT_STRONG_REPEAT_PENALTY,
+}
+
+
+def resolve_reward_variant() -> str:
+    raw_value = os.getenv(REWARD_VARIANT_ENV, REWARD_VARIANT_FULL).strip().lower().replace("-", "_")
+    if raw_value in {"", "default", "baseline"}:
+        return REWARD_VARIANT_FULL
+    if raw_value not in REWARD_VARIANTS:
+        raise ValueError(
+            f"Invalid {REWARD_VARIANT_ENV}={raw_value!r}; "
+            f"expected one of {sorted(REWARD_VARIANTS)}"
+        )
+    return raw_value
+
+
+def _reward_variant_is_no_structural_novelty() -> bool:
+    return resolve_reward_variant() == REWARD_VARIANT_NO_STRUCTURAL_NOVELTY
+
+
+def _reward_variant_is_full_reward() -> bool:
+    return resolve_reward_variant() in {REWARD_VARIANT_FULL, REWARD_VARIANT_FULL_REWARD}
+
+
+def _reward_variant_is_no_diversity_bonus() -> bool:
+    return resolve_reward_variant() == REWARD_VARIANT_NO_DIVERSITY_BONUS
+
+
+def _reward_variant_is_no_repeat_penalty() -> bool:
+    return resolve_reward_variant() == REWARD_VARIANT_NO_REPEAT_PENALTY
+
+
+def _reward_variant_is_strong_repeat_penalty() -> bool:
+    return resolve_reward_variant() == REWARD_VARIANT_STRONG_REPEAT_PENALTY
+
+
+def _without_positive_bonus(value: float) -> float:
+    return min(float(value or 0.0), 0.0)
+
+
+def _remove_positive_structural_novelty_components(
+    components: Dict[str, float],
+) -> Tuple[Dict[str, float], Dict[str, Any]]:
+    adjusted: Dict[str, float] = {}
+    removed_positive: Dict[str, float] = {}
+    original: Dict[str, float] = {}
+    for key, value in components.items():
+        original_value = float(value or 0.0)
+        adjusted_value = _without_positive_bonus(original_value)
+        original[key] = original_value
+        adjusted[key] = adjusted_value
+        if adjusted_value != original_value:
+            removed_positive[key] = original_value - adjusted_value
+    return adjusted, {
+        "original_components": original,
+        "removed_positive_bonus": removed_positive,
+    }
+
+
 def _stage1_only_enabled() -> bool:
     return env_flag("NNGPT_RL_STAGE1_ONLY", False)
 
@@ -743,6 +1000,11 @@ def _build_rl_grpo_config(
     }
     if "gradient_checkpointing_kwargs" in config_signature.parameters:
         config_kwargs["gradient_checkpointing_kwargs"] = {"use_reentrant": False}
+    seed = resolve_rl_seed()
+    if "seed" in config_signature.parameters:
+        config_kwargs["seed"] = seed
+    if "data_seed" in config_signature.parameters:
+        config_kwargs["data_seed"] = seed
     explicit_kl_coef = env_float("NNGPT_RL_KL_COEF", RL_STAGE_KL_COEF)
     if "beta" in config_signature.parameters:
         config_kwargs["beta"] = explicit_kl_coef
@@ -1732,13 +1994,51 @@ def _stage1_gate_ready() -> bool:
     if current_entry_group_count < STAGE1_PROMOTION_MIN_GROUPS:
         return False
     executable_count = sum(1 for item in recent_generations if bool(item.get("executable_candidate")))
+    trainable_count = sum(
+        1
+        for item in recent_generations
+        if bool(item.get("trained_step_ok") or item.get("backward_ok"))
+    )
     discovery_rows = [item for item in recent_generations if bool(item.get("discovery_candidate"))]
     unique_discovery_families = len(_family_hash_set(discovery_rows, key="family_hash"))
     return bool(
         executable_count >= STAGE1_GATE_EXECUTABLE_MIN
+        and trainable_count >= STAGE1_GATE_TRAINABLE_MIN
         and len(discovery_rows) >= STAGE1_GATE_DISCOVERY_MIN
         and unique_discovery_families >= STAGE1_GATE_UNIQUE_DISCOVERY_FAMILIES_MIN
     )
+
+
+def _stage1_trainable_stable_ready() -> Optional[Dict[str, Any]]:
+    recent_generations = _recent_stage_generation_window(
+        STAGE1_STRUCTURE_EXPLORE,
+        STAGE1_EXECUTABLE_STABLE_WINDOW_GENERATIONS,
+    )
+    current_entry_group_count = len(_recent_stage_group_window(STAGE1_STRUCTURE_EXPLORE, MAX_STAGE_GROUP_HISTORY))
+    if current_entry_group_count < STAGE1_EXECUTABLE_STABLE_MIN_GROUPS:
+        return None
+    if len(recent_generations) < STAGE1_EXECUTABLE_STABLE_WINDOW_GENERATIONS:
+        return None
+    recent_executable_count = sum(1 for item in recent_generations if bool(item.get("executable_candidate")))
+    recent_executable_rate = recent_executable_count / float(len(recent_generations))
+    recent_trainable_count = sum(
+        1
+        for item in recent_generations
+        if bool(item.get("trained_step_ok") or item.get("backward_ok"))
+    )
+    recent_trainable_rate = recent_trainable_count / float(len(recent_generations))
+    if recent_executable_rate < STAGE1_EXECUTABLE_STABLE_MIN_RATE:
+        return None
+    if recent_trainable_rate < STAGE1_TRAINABLE_STABLE_MIN_RATE:
+        return None
+    return {
+        "stage_group_count": current_entry_group_count,
+        "recent_generation_count": len(recent_generations),
+        "recent_executable_count": recent_executable_count,
+        "recent_executable_rate": recent_executable_rate,
+        "recent_trainable_count": recent_trainable_count,
+        "recent_trainable_rate": recent_trainable_rate,
+    }
 
 
 def _stage1_force_promotion_ready() -> Optional[Dict[str, int]]:
@@ -1749,10 +2049,17 @@ def _stage1_force_promotion_ready() -> Optional[Dict[str, int]]:
     if current_entry_group_count < STAGE1_PROMOTION_MIN_GROUPS:
         return None
     recent_executable_count = sum(1 for item in recent_generations if bool(item.get("executable_candidate")))
+    recent_trainable_count = sum(
+        1
+        for item in recent_generations
+        if bool(item.get("trained_step_ok") or item.get("backward_ok"))
+    )
     discovery_rows = [item for item in recent_generations if bool(item.get("discovery_candidate"))]
     recent_discovery_count = len(discovery_rows)
     recent_unique_discovery_families = len(_family_hash_set(discovery_rows, key="family_hash"))
     if recent_executable_count < STAGE1_FORCE_PROMOTION_EXECUTABLE_MIN:
+        return None
+    if recent_trainable_count < STAGE1_FORCE_PROMOTION_TRAINABLE_MIN:
         return None
     if recent_discovery_count < STAGE1_FORCE_PROMOTION_DISCOVERY_MIN:
         return None
@@ -1762,6 +2069,7 @@ def _stage1_force_promotion_ready() -> Optional[Dict[str, int]]:
         "stage_group_count": current_entry_group_count,
         "recent_generation_count": len(recent_generations),
         "recent_executable_count": recent_executable_count,
+        "recent_trainable_count": recent_trainable_count,
         "recent_discovery_count": recent_discovery_count,
         "recent_unique_discovery_families": recent_unique_discovery_families,
     }
@@ -1808,6 +2116,11 @@ def _stage_gate_snapshot() -> Dict[str, Any]:
         "stage_index": RL_STAGE_TO_INDEX.get(stage_name, 0),
         "recent_generation_count": len(recent_generations),
         "recent_executable_count": sum(1 for item in recent_generations if bool(item.get("executable_candidate"))),
+        "recent_trainable_count": sum(
+            1
+            for item in recent_generations
+            if bool(item.get("trained_step_ok") or item.get("backward_ok"))
+        ),
         "recent_discovery_count": len(discovery_rows),
         "recent_unique_discovery_families": len(_family_hash_set(discovery_rows, key="family_hash")),
         "recent_formal_success_count": len(formal_rows),
@@ -1909,6 +2222,23 @@ def _resolve_resume_checkpoint_dir() -> Optional[Path]:
     if resume_stage:
         return _stage_checkpoint_dir(resume_stage)
     return None
+
+
+def apply_resume_stage_override(requested_stage: str, *, log_prefix: str) -> bool:
+    global current_stage_name
+
+    requested_stage = str(requested_stage or "").strip()
+    if not requested_stage:
+        return False
+    current_state_stage = str(current_stage_name)
+    if current_state_stage == requested_stage:
+        return False
+    print(
+        f"{log_prefix} Resume stage override "
+        f"checkpoint_stage={current_state_stage} requested_stage={requested_stage}"
+    )
+    current_stage_name = requested_stage
+    return True
 
 
 def _load_json_if_exists(path: Path) -> Optional[Dict[str, Any]]:
@@ -2384,6 +2714,295 @@ def extract_prompt_goal_tags(prompt_text: str) -> List[str]:
     return [tag.strip() for tag in match.group(1).split(",") if tag.strip()]
 
 
+def extract_prompt_target_pattern(prompt_text: str) -> str:
+    if not prompt_text:
+        return ""
+    match = re.search(
+        r"(?:^|\n)\s*(?:-\s*)?Target pattern:\s*`?([A-Za-z0-9_-]+)`?",
+        prompt_text,
+        flags=re.IGNORECASE,
+    )
+    if not match:
+        return ""
+    return match.group(1).strip()
+
+
+def _compact_graph_expr(graph_expr: str) -> str:
+    return re.sub(r"\s+", "", str(graph_expr or ""))
+
+
+def _graph_has_block_before_backbone(graph_expr: str) -> bool:
+    compact = _compact_graph_expr(graph_expr)
+    return bool(
+        re.search(
+            r"Backbone\[[^\]]+\]\(_feature_to_input_image\((?:Sequential\[Block\]|Block|Fractal)",
+            compact,
+        )
+    )
+
+
+def _graph_has_backbone_before_block(graph_expr: str) -> bool:
+    compact = _compact_graph_expr(graph_expr)
+    return bool(
+        re.search(
+            r"(?:Sequential\[Block\]|Block|Fractal)\(_feature_to_input_image\(Backbone\[[^\]]+\]",
+            compact,
+        )
+    )
+
+
+def build_actual_structure_signature(
+    graph_info,
+    *,
+    block_contributes_to_forward: bool,
+    block_signature: str = "",
+) -> str:
+    if graph_info is None or not getattr(graph_info, "parse_ok", False):
+        return "incomplete|block_unknown|bb0|d0|incomplete"
+    block_state = "block_live" if block_contributes_to_forward else "block_dead"
+    block_key = str(block_signature or "").strip() if block_contributes_to_forward else "incomplete_block"
+    if not block_key:
+        block_key = "unknown_block"
+    return "|".join(
+        [
+            str(getattr(graph_info, "family_id", "") or "UnknownFamily"),
+            str(getattr(graph_info, "descriptor_key", "") or "unknown_descriptor"),
+            f"bb{int(getattr(graph_info, 'backbone_calls', 0) or 0)}",
+            block_state,
+            str(getattr(graph_info, "family_hash", "") or "unknown_family_hash")[:12],
+            str(getattr(graph_info, "cnn_signature", "") or "unknown_cnn")[:12],
+            str(block_key)[:12],
+        ]
+    )
+
+
+def detect_target_structure(
+    *,
+    prompt_target_pattern: str,
+    graph_info,
+    block_contributes_to_forward: bool,
+    block_signature: str = "",
+) -> Dict[str, Any]:
+    prompt_target_pattern = str(prompt_target_pattern or "").strip()
+    normalized_target = normalize_pattern_name(prompt_target_pattern) if prompt_target_pattern else ""
+    declared_pattern = str(getattr(graph_info, "pattern_name", "") or "") if graph_info is not None else ""
+    actual_pattern = str(getattr(graph_info, "suggested_pattern_name", "") or "") if graph_info is not None else ""
+    actual_block_live = bool(block_contributes_to_forward)
+    if graph_info is not None and getattr(graph_info, "parse_ok", False):
+        actual_block_live = int(getattr(graph_info, "fractal_calls", 0) or 0) > 0
+    actual_signature = build_actual_structure_signature(
+        graph_info,
+        block_contributes_to_forward=actual_block_live,
+        block_signature=block_signature,
+    )
+    result = {
+        "prompt_target_pattern": prompt_target_pattern,
+        "normalized_prompt_target_pattern": normalized_target,
+        "declared_pattern": declared_pattern,
+        "actual_pattern": actual_pattern,
+        "declared_pattern_matches_prompt": (
+            bool(normalized_target)
+            and normalize_pattern_name(declared_pattern) == normalized_target
+        ),
+        "actual_structure_signature": actual_signature,
+        "target_structure_key": f"{normalized_target or 'open'}::{actual_signature}",
+        "target_structure_match": True,
+        "target_structure_mismatch_reasons": [],
+        "actual_backbone_calls": int(getattr(graph_info, "backbone_calls", 0) or 0) if graph_info is not None else 0,
+        "actual_block_live": actual_block_live,
+        "actual_block_before_backbone": False,
+        "actual_backbone_before_block": False,
+    }
+    if not normalized_target:
+        return result
+    if graph_info is None or not getattr(graph_info, "parse_ok", False):
+        result["target_structure_match"] = False
+        result["target_structure_mismatch_reasons"] = ["graph_parse_failed"]
+        return result
+
+    graph_expr = str(getattr(graph_info, "graph_expr", "") or "")
+    block_before_backbone = _graph_has_block_before_backbone(graph_expr)
+    backbone_before_block = _graph_has_backbone_before_block(graph_expr)
+    result["actual_block_before_backbone"] = block_before_backbone
+    result["actual_backbone_before_block"] = backbone_before_block
+
+    reasons: List[str] = []
+    declared_matches_prompt = bool(result["declared_pattern_matches_prompt"])
+    if not declared_matches_prompt:
+        reasons.append("declared_pattern_mismatch")
+    target_needs_parallel_triple = normalized_target == "Parallel_Triple"
+    target_needs_block = "Fractal" in normalized_target or target_needs_parallel_triple
+    target_needs_dual_backbone = (
+        "DualBackbone" in normalized_target
+        or "_to_B" in normalized_target
+        or "_plus_B" in normalized_target
+        or normalized_target.endswith("_plus_A")
+        or target_needs_parallel_triple
+    )
+    if target_needs_block and not actual_block_live:
+        if target_needs_parallel_triple:
+            reasons.append("target_parallel_triple_but_block_dead")
+        else:
+            reasons.append("target_fractal_but_block_dead")
+    if target_needs_dual_backbone and int(getattr(graph_info, "backbone_calls", 0) or 0) < 2:
+        if target_needs_parallel_triple:
+            reasons.append("target_parallel_triple_uses_less_than_two_backbones")
+        else:
+            reasons.append("target_dual_but_forward_uses_less_than_two_backbones")
+    result["target_structure_match"] = not reasons
+    result["target_structure_mismatch_reasons"] = reasons
+    return result
+
+
+def _target_structure_penalty(reasons: List[str]) -> float:
+    reason_set = set(str(reason) for reason in (reasons or []))
+    penalty = 0.0
+    if "graph_parse_failed" in reason_set:
+        penalty += TARGET_STRUCTURE_PARSE_PENALTY
+    if "declared_pattern_mismatch" in reason_set:
+        penalty += TARGET_STRUCTURE_PATTERN_MISMATCH_PENALTY
+    if "target_fractal_but_block_dead" in reason_set or "target_parallel_triple_but_block_dead" in reason_set:
+        penalty += TARGET_STRUCTURE_DEAD_BLOCK_PENALTY
+    if (
+        "target_dual_but_forward_uses_less_than_two_backbones" in reason_set
+        or "target_parallel_triple_uses_less_than_two_backbones" in reason_set
+    ):
+        penalty += TARGET_STRUCTURE_DUAL_BACKBONE_PENALTY
+    if any(
+        reason in reason_set
+        for reason in (
+            "fractal_not_before_backbone",
+            "missing_backbone_to_fractal_path",
+            "missing_fractal_to_backbone_path",
+            "missing_backbone_to_fractal_branch",
+        )
+    ):
+        penalty += TARGET_STRUCTURE_PATH_PENALTY
+    return max(TARGET_STRUCTURE_PENALTY_FLOOR, penalty)
+
+
+def _apply_target_structure_reward_adjustment(
+    pattern_detection: Dict[str, Any],
+    r_structure_group: float,
+    r_structure_archive: float,
+) -> Tuple[float, float, float, float]:
+    if bool(pattern_detection.get("target_structure_match", True)):
+        return r_structure_group, r_structure_archive, 0.0, 0.0
+    suppressed_positive = max(0.0, float(r_structure_group or 0.0)) + max(
+        0.0,
+        float(r_structure_archive or 0.0),
+    )
+    return (
+        min(0.0, float(r_structure_group or 0.0)),
+        min(0.0, float(r_structure_archive or 0.0)),
+        _target_structure_penalty(
+            list(pattern_detection.get("target_structure_mismatch_reasons") or [])
+        ),
+        suppressed_positive,
+    )
+
+
+def _apply_target_structure_final_clamp(
+    pattern_detection: Dict[str, Any],
+    reward_value: float,
+    r_target_structure_penalty: float,
+) -> float:
+    if bool(pattern_detection.get("target_structure_match", True)):
+        return reward_value
+    penalty = float(r_target_structure_penalty or 0.0)
+    if penalty == 0.0:
+        penalty = _target_structure_penalty(
+            list(pattern_detection.get("target_structure_mismatch_reasons") or [])
+        )
+    return min(float(reward_value), penalty, 0.0)
+
+
+def _apply_target_structure_reward_gate(res: Dict[str, Any], reward_value: float) -> float:
+    return _apply_target_structure_final_clamp(
+        res,
+        reward_value,
+        float(res.get("r_target_structure_penalty", 0.0) or 0.0),
+    )
+
+
+def _is_target_parallel_triple_block_dead(
+    pattern_detection: Dict[str, Any],
+    block_contributes_to_forward: bool,
+) -> bool:
+    if bool(block_contributes_to_forward):
+        return False
+    if pattern_detection.get("normalized_prompt_target_pattern") != "Parallel_Triple":
+        return False
+    if pattern_detection.get("target_structure_match") is not False:
+        return False
+    return "target_parallel_triple_but_block_dead" in set(
+        str(reason)
+        for reason in list(pattern_detection.get("target_structure_mismatch_reasons") or [])
+    )
+
+
+def _stage23_local_competition_reward(
+    total_reward: float,
+    *,
+    generation_total: int,
+    target_ok: bool,
+    has_formal_epoch: bool,
+    formal_success_candidate: bool,
+    quality_acc_value: Optional[float],
+    cell_archive_freq: int,
+    batch_same_cell_count: int,
+    cell_best_quality_acc: Optional[float],
+    disable_diversity_bonus: bool = False,
+    disable_repeat_penalty: bool = False,
+) -> float:
+    if (
+        not target_ok
+        or not has_formal_epoch
+        or not formal_success_candidate
+        or quality_acc_value is None
+    ):
+        return float(total_reward)
+
+    reward_value = float(total_reward)
+    quality_value = float(quality_acc_value)
+    cell_is_unique_new = bool(cell_archive_freq <= 0 and batch_same_cell_count <= 1)
+    cell_improved = bool(
+        cell_archive_freq > 0
+        and cell_best_quality_acc is not None
+        and quality_value >= float(cell_best_quality_acc) + STAGE23_CELL_IMPROVEMENT_DELTA
+    )
+
+    if cell_is_unique_new and not disable_diversity_bonus:
+        reward_value += STAGE23_NEW_CELL_BONUS
+    elif cell_improved and not disable_diversity_bonus:
+        reward_value += STAGE23_CELL_IMPROVEMENT_BONUS
+    elif (not disable_repeat_penalty) and int(generation_total or 0) < STAGE23_EARLY_LOCAL_COMPETITION_GENERATIONS:
+        reward_value = min(reward_value, STAGE23_EARLY_CELL_REPEAT_REWARD_CAP)
+    elif (not disable_repeat_penalty) and quality_value < STAGE23_DUPLICATE_LOW_ACC_THRESHOLD:
+        reward_value = min(reward_value, STAGE23_DUPLICATE_LOW_ACC_REWARD_CAP)
+
+    if quality_value >= STAGE23_HIGH_ACC_ELITE_THRESHOLD:
+        reward_value += STAGE23_HIGH_ACC_ELITE_BONUS
+    elif quality_value >= STAGE23_HIGH_ACC_STRONG_THRESHOLD:
+        reward_value += STAGE23_HIGH_ACC_STRONG_BONUS
+    elif quality_value >= STAGE23_HIGH_ACC_BONUS_THRESHOLD:
+        reward_value += STAGE23_HIGH_ACC_BONUS
+
+    return _clip(reward_value, -2.0, 2.0)
+
+
+def _stage23_gate_positive_novelty_by_quality(
+    quality_acc_value: Optional[float],
+    components: Dict[str, float],
+) -> Dict[str, float]:
+    if quality_acc_value is not None and float(quality_acc_value) >= STAGE23_POSITIVE_NOVELTY_ACC_THRESHOLD:
+        return dict(components)
+    return {
+        key: min(float(value or 0.0), 0.0)
+        for key, value in components.items()
+    }
+
+
 def prompt_goal_satisfied(graph_info, tag: str) -> bool:
     if not graph_info or not graph_info.parse_ok:
         return False
@@ -2404,8 +3023,12 @@ def prompt_goal_satisfied(graph_info, tag: str) -> bool:
     return False
 
 
-def primary_goal_key(prompt_goal_tags: List[str]) -> str:
-    return "__".join(prompt_goal_tags or ["open"])
+def primary_goal_key(prompt_goal_tags: List[str], prompt_target_pattern: str = "") -> str:
+    tags = [str(tag).strip() for tag in (prompt_goal_tags or []) if str(tag).strip()]
+    if tags:
+        return "__".join(tags)
+    normalized_target = normalize_pattern_name(prompt_target_pattern) if prompt_target_pattern else ""
+    return normalized_target or "open"
 
 
 def goal_family_save_cap(graph_info) -> int:
@@ -2490,6 +3113,23 @@ def _entry_cnn_signature(entry: Dict[str, Any]) -> str:
     return "incomplete_cnn"
 
 
+def _entry_block_signature(entry: Dict[str, Any]) -> str:
+    signature = str(entry.get("block_signature") or "").strip()
+    if signature:
+        return signature
+    block_code, init_code, forward_code = extract_completion_blocks(str(entry.get("completion") or ""))
+    graph_info = entry.get("graph_info")
+    if graph_info is None and block_code and init_code and forward_code:
+        graph_info = extract_graph_info(
+            init_code,
+            forward_code,
+            legacy_patterns=SFTUtil.legacy_patterns,
+        )
+    if not _block_truly_contributes_to_forward(init_code, forward_code, graph_info):
+        return "incomplete_block"
+    return _block_signature_from_code(block_code)
+
+
 def reconstruct_code(
     completion: str,
     *,
@@ -2503,7 +3143,7 @@ def reconstruct_code(
     if pattern_name_override:
         init_code = ensure_pattern_name(init_code, pattern_name_override)
 
-    code = SFTUtil.open_discovery_skeleton_code
+    code = SFTUtil.skeleton_code
     sig_block = "def drop_conv3x3_block(in_channels, out_channels, stride=1, padding=1, bias=False, dropout_prob=0.0):"
     code = code.replace(sig_block, textwrap.dedent(block_code))
 
@@ -2526,7 +3166,7 @@ def _compute_build_partial_reward(res: Dict[str, Any]) -> float:
 
     if error_stage == "cpu_prevalidate":
         if "must call self.infer_dimensions_dynamically" in error_str:
-            build_partial = 0.00
+            return -0.12
         elif "infer_dimensions_dynamically() takes 2 positional arguments but 3 were given" in error_str:
             build_partial = -0.04
         elif "has no attribute '_input_spec'" in error_lower:
@@ -2616,33 +3256,36 @@ def _is_minimal_backbone_classifier_template(init_code: str) -> bool:
 
 
 def _stage1_validity_scale(res: Dict[str, Any]) -> float:
-    if bool(res.get("loss_drop_ok")):
+    if bool(
+        res.get("built_ok")
+        and res.get("forward_shape_ok")
+        and (
+            res.get("backward_ok")
+            or res.get("trained_step_ok")
+            or _has_completed_formal_epoch(res)
+        )
+    ):
         return 1.0
-    if bool(res.get("backward_ok")):
-        return 0.85
+    if bool(res.get("backward_ok") or res.get("trained_step_ok") or _has_completed_formal_epoch(res)):
+        return 0.45
     if bool(res.get("forward_shape_ok")):
-        return 0.55
+        return 0.15
     return 0.0
 
 
 def _stage1_validity_reward(res: Dict[str, Any], graph_info) -> float:
     if not graph_info or not graph_info.parse_ok:
-        return -0.25
+        return -0.85
     if not res.get("built_ok"):
         build_partial = float(res.get("r_build_partial", 0.0) or 0.0)
-        return min(-0.25, -0.50 + build_partial)
+        return min(-0.35, -0.55 + build_partial)
     if not res.get("forward_ok"):
-        return -0.18
+        return -0.40
     if not res.get("forward_shape_ok"):
-        return -0.08
-    if not res.get("backward_ok"):
-        return -0.02
-    if not res.get("loss_drop_ok"):
-        loss_drop = _optional_float(res.get("loss_drop"))
-        if loss_drop is None:
-            return 0.02
-        return _clip(0.01 + 0.25 * float(loss_drop), -0.01, 0.05)
-    return STAGE1_EXECUTABLE_BONUS
+        return -0.30
+    if not _stage1_trainability_ok(res, graph_info):
+        return -0.04
+    return max(STAGE1_EXECUTABLE_BONUS, 0.12)
 
 
 def _template_penalty(
@@ -2760,6 +3403,7 @@ def _discovery_failure_result(
         "r_structure_group": 0.0,
         "r_structure_archive": 0.0,
         "r_descriptor_diversity": 0.0,
+        "r_block_diversity": 0.0,
         "r_batch_elite": 0.0,
         "r_repeat_family": 0.0,
         "r_plain_fuse_penalty": 0.0,
@@ -2787,6 +3431,7 @@ def _discovery_failure_result(
             "r_structure_group": 0.0,
             "r_structure_archive": 0.0,
             "r_descriptor_diversity": 0.0,
+            "r_block_diversity": 0.0,
             "r_batch_elite": 0.0,
             "r_repeat_family": 0.0,
             "r_plain_fuse_penalty": 0.0,
@@ -2815,14 +3460,7 @@ def _discovery_failure_result(
 
 
 def _is_trainable_candidate(res: Dict[str, Any], graph_info) -> bool:
-    return bool(
-        graph_info
-        and graph_info.parse_ok
-        and res.get("built_ok")
-        and res.get("forward_shape_ok")
-        and res.get("backward_ok")
-        and res.get("loss_drop_ok")
-    )
+    return _stage1_trainability_ok(res, graph_info)
 
 
 def _has_completed_formal_epoch(res: Dict[str, Any]) -> bool:
@@ -2855,6 +3493,20 @@ def _stage2_target_qualified_rows(rows: List[Dict[str, Any]]) -> List[Dict[str, 
     return qualified_rows
 
 
+def _stage1_trainability_ok(res: Dict[str, Any], graph_info) -> bool:
+    return bool(
+        graph_info
+        and graph_info.parse_ok
+        and res.get("built_ok")
+        and res.get("forward_shape_ok")
+        and (
+            res.get("backward_ok")
+            or res.get("trained_step_ok")
+            or _has_completed_formal_epoch(res)
+        )
+    )
+
+
 def _apply_trainability_clamp(res: Dict[str, Any], reward_value: float, graph_info) -> float:
     parse_ok = bool(graph_info and graph_info.parse_ok)
     if not parse_ok:
@@ -2870,11 +3522,22 @@ def _apply_trainability_clamp(res: Dict[str, Any], reward_value: float, graph_in
         loss_drop = _optional_float(res.get("loss_drop"))
         partial_progress = _clip(0.25 * float(loss_drop or 0.0), -0.04, 0.04)
         return min(reward_value, -0.12 + partial_progress)
-    if not res.get("loss_drop_ok"):
-        loss_drop = _optional_float(res.get("loss_drop"))
-        if loss_drop is None:
-            return min(reward_value, -0.02)
-        return min(reward_value, _clip(-0.02 + 0.20 * float(loss_drop), -0.08, 0.04))
+    return reward_value
+
+
+def _apply_stage1_trainability_clamp(res: Dict[str, Any], reward_value: float, graph_info) -> float:
+    parse_ok = bool(graph_info and graph_info.parse_ok)
+    if not parse_ok:
+        return min(reward_value, -0.85)
+    if not res.get("built_ok"):
+        build_partial = float(res.get("r_build_partial", 0.0) or 0.0)
+        return min(reward_value, -0.70 + build_partial)
+    if not res.get("forward_ok"):
+        return min(reward_value, -0.40)
+    if not res.get("forward_shape_ok"):
+        return min(reward_value, -0.30)
+    if not _stage1_trainability_ok(res, graph_info):
+        return min(reward_value, -0.04)
     return reward_value
 
 
@@ -3006,19 +3669,30 @@ def _recompute_discovery_reward(
         + float(res.get("r_structure_archive", 0.0) or 0.0)
         + float(res.get("r_descriptor_diversity", 0.0) or 0.0)
         + float(res.get("r_cnn_diversity", 0.0) or 0.0)
+        + float(res.get("r_block_diversity", 0.0) or 0.0)
         + float(res.get("r_batch_elite", 0.0) or 0.0)
         + float(res.get("r_repeat_family", 0.0) or 0.0)
         + float(res.get("r_plain_fuse_penalty", 0.0) or 0.0)
+        + float(res.get("r_target_structure_penalty", 0.0) or 0.0)
         + float(res.get("r_template_penalty", 0.0) or 0.0)
         + float(res.get("r_history_context", 0.0) or 0.0)
         + float(res.get("r_no_progress_penalty", 0.0) or 0.0)
     )
     r_tiebreak = float(res.get("r_goal_match", 0.0) or 0.0)
     total_reward = _clip(r_primary + r_tiebreak, -2.0, 2.0)
-    if stage_name in {STAGE1_STRUCTURE_EXPLORE, STAGE2_FORMAL_EXPLORE}:
+    if stage_name == STAGE1_STRUCTURE_EXPLORE:
+        total_reward = _apply_stage1_trainability_clamp(res, total_reward, graph_info)
+    elif stage_name == STAGE2_FORMAL_EXPLORE:
+        if _reward_variant_is_strong_repeat_penalty() and _is_strong_repeat_without_refresh(res):
+            total_reward = min(total_reward, 0.0)
+            res["strong_repeat_penalty_applied"] = True
         total_reward = _apply_executability_clamp(res, total_reward, graph_info)
     else:
+        if _reward_variant_is_strong_repeat_penalty() and _is_strong_repeat_without_refresh(res):
+            total_reward = min(total_reward, 0.0)
+            res["strong_repeat_penalty_applied"] = True
         total_reward = _apply_trainability_clamp(res, total_reward, graph_info)
+    total_reward = _apply_target_structure_reward_gate(res, total_reward)
     return total_reward, r_primary, r_tiebreak
 
 
@@ -3105,12 +3779,19 @@ def base_discovery_reward_fn(
     batch_descriptor_keys: List[str] = None,
     batch_backbone_signatures: List[str] = None,
     batch_cnn_signatures: List[str] = None,
+    batch_block_signatures: List[str] = None,
+    batch_backbone_block_signatures: List[str] = None,
     prompt_goal_tags: List[str] = None,
+    prompt_target_pattern: str = "",
     archive_snapshot_family_counts: Optional[Dict[str, int]] = None,
     archive_snapshot_descriptor_counts: Optional[Dict[str, int]] = None,
     archive_snapshot_backbone_signature_counts: Optional[Dict[str, int]] = None,
     archive_snapshot_cnn_signature_counts: Optional[Dict[str, int]] = None,
+    archive_snapshot_graph_counts: Optional[Dict[str, int]] = None,
+    archive_snapshot_block_signature_counts: Optional[Dict[str, int]] = None,
     archive_snapshot_backbone_cnn_pair_counts: Optional[Dict[str, int]] = None,
+    archive_snapshot_backbone_block_pair_counts: Optional[Dict[str, int]] = None,
+    archive_snapshot_backbone_block_best_quality: Optional[Dict[str, float]] = None,
     group_baseline_train_acc: Optional[float] = None,
     group_baseline_reward_target_acc: Optional[float] = None,
     reward_batch_index: Optional[int] = None,
@@ -3119,6 +3800,7 @@ def base_discovery_reward_fn(
     completion_index: Optional[int] = None,
     batch_last_item: bool = False,
 ) -> Dict[str, Any]:
+    reward_variant = resolve_reward_variant()
     stage_name = str(current_stage_name)
     stage_profile = _stage_reward_profile(stage_name)
     stage_reward_metric = _stage_reward_target_metric(stage_name)
@@ -3131,6 +3813,7 @@ def base_discovery_reward_fn(
         'epoch': 1,
     }
     block_code, init_code, forward_code = extract_completion_blocks(completion)
+    plain_dual_backbone_concat = _is_plain_dual_backbone_concat(forward_code)
     backbone_model_names = _extract_backbone_model_names(init_code)
     if not block_code or not init_code or not forward_code:
         return _discovery_failure_result(
@@ -3153,9 +3836,24 @@ def base_discovery_reward_fn(
         forward_code,
         legacy_patterns=SFTUtil.legacy_patterns,
     )
-    effective_pattern_name = (
-        graph_info.pattern_name if graph_info.has_custom_pattern_name else graph_info.suggested_pattern_name
+    block_contributes_to_forward = _block_truly_contributes_to_forward(
+        init_code,
+        forward_code,
+        graph_info,
     )
+    block_signature = (
+        _block_signature_from_code(block_code)
+        if block_contributes_to_forward
+        else "incomplete_block"
+    )
+    prompt_target_pattern = str(prompt_target_pattern or "").strip()
+    pattern_detection = detect_target_structure(
+        prompt_target_pattern=prompt_target_pattern,
+        graph_info=graph_info,
+        block_contributes_to_forward=block_contributes_to_forward,
+        block_signature=block_signature,
+    )
+    effective_pattern_name = graph_info.suggested_pattern_name
     pattern_override = graph_info.suggested_pattern_name if not graph_info.has_custom_pattern_name else ""
 
     final_code = reconstruct_code(completion, pattern_name_override=pattern_override)
@@ -3170,17 +3868,19 @@ def base_discovery_reward_fn(
     if precomputed_eval_result is not None:
         res = dict(precomputed_eval_result)
     else:
+        formal_input_shape = _formal_reward_input_shape()
+        formal_out_shape = _formal_reward_out_shape()
         res = evaluate_code_and_reward(
             final_code,
-            in_shape=(1, 3, 224, 224),
-            out_shape=(10,),
+            in_shape=formal_input_shape,
+            out_shape=formal_out_shape,
             prm=prm,
             device="cuda" if torch.cuda.is_available() else "cpu",
             seed_accuracy_baseline=seed_accuracy_baseline,
             cfg=build_stage_eval_cfg(
                 stage_name=stage_name,
-                in_shape=(1, 3, 224, 224),
-                out_shape=(10,),
+                in_shape=formal_input_shape,
+                out_shape=formal_out_shape,
                 prm=prm,
                 device="cuda" if torch.cuda.is_available() else "cpu",
             ),
@@ -3196,6 +3896,7 @@ def base_discovery_reward_fn(
     cnn_signature = str(getattr(graph_info, "cnn_signature", "") or "incomplete_cnn")
     cnn_expr = str(getattr(graph_info, "cnn_expr", "") or "IncompleteCNN")
     backbone_cnn_pair_key = _backbone_cnn_pair_key(backbone_signature, cnn_signature)
+    backbone_block_pair_key = _backbone_block_pair_key(backbone_signature, block_signature)
 
     training_context = summarize_stage_training_context(stage_name)
     shallow_one_shot = is_shallow_one_shot_fuse(graph_info)
@@ -3221,6 +3922,19 @@ def base_discovery_reward_fn(
         if graph_info.parse_ok
         else 0
     )
+    batch_same_block_count = (
+        batch_block_signatures.count(block_signature)
+        if batch_block_signatures and block_signature and block_signature != "incomplete_block"
+        else 0
+    )
+    batch_same_backbone_block_count = (
+        batch_backbone_block_signatures.count(backbone_block_pair_key)
+        if batch_backbone_block_signatures
+        and graph_info.parse_ok
+        and block_signature
+        and block_signature != "incomplete_block"
+        else 0
+    )
     archive_snapshot_family_freq = int((archive_snapshot_family_counts or {}).get(graph_info.family_hash, 0)) if graph_info.parse_ok else 0
     archive_snapshot_descriptor_freq = (
         int((archive_snapshot_descriptor_counts or {}).get(graph_info.descriptor_key, 0))
@@ -3237,10 +3951,28 @@ def base_discovery_reward_fn(
         if graph_info.parse_ok
         else 0
     )
+    archive_snapshot_graph_freq = (
+        int((archive_snapshot_graph_counts or {}).get(graph_info.graph_hash, 0))
+        if graph_info.parse_ok
+        else 0
+    )
+    archive_snapshot_block_freq = (
+        int((archive_snapshot_block_signature_counts or {}).get(block_signature, 0))
+        if graph_info.parse_ok and block_signature and block_signature != "incomplete_block"
+        else 0
+    )
     archive_snapshot_backbone_cnn_freq = (
         int((archive_snapshot_backbone_cnn_pair_counts or {}).get(backbone_cnn_pair_key, 0))
         if graph_info.parse_ok
         else 0
+    )
+    archive_snapshot_backbone_block_freq = (
+        int((archive_snapshot_backbone_block_pair_counts or {}).get(backbone_block_pair_key, 0))
+        if graph_info.parse_ok and block_signature and block_signature != "incomplete_block"
+        else 0
+    )
+    cell_best_quality_acc = _optional_float(
+        (archive_snapshot_backbone_block_best_quality or {}).get(backbone_block_pair_key)
     )
     global_group_baseline_reward_target_acc = (
         group_baseline_reward_target_acc
@@ -3291,7 +4023,10 @@ def base_discovery_reward_fn(
     reward_target_value = _result_reward_target_value(res)
     if reward_target_value is None and stage_name != STAGE1_STRUCTURE_EXPLORE:
         reward_target_value = frozen_test_acc
-    goal_key = primary_goal_key(prompt_goal_tags or [])
+    quality_acc_value = _optional_float(frozen_test_acc)
+    if quality_acc_value is None:
+        quality_acc_value = _optional_float(reward_target_value)
+    goal_key = primary_goal_key(prompt_goal_tags or [], prompt_target_pattern)
     best_reward_target_for_goal = best_reward_target_by_goal.get(goal_key)
     group_train_acc_gain = None
     group_train_acc_improved = False
@@ -3313,11 +4048,19 @@ def base_discovery_reward_fn(
     r_batch_elite = 0.0
     r_repeat_family = 0.0
     r_plain_fuse_penalty = 0.0
+    r_target_structure_penalty = 0.0
+    target_structure_positive_suppressed = 0.0
+    target_block_dead_accuracy_components_suppressed = False
+    target_block_dead_accuracy_suppressed_total = 0.0
     r_template_penalty = 0.0
     r_history_context = 0.0
     r_no_progress_penalty = 0.0
     r_descriptor_diversity = 0.0
     r_cnn_diversity = 0.0
+    r_block_diversity = 0.0
+    global_descriptor_archive_reward = 0.0
+    global_cnn_archive_reward = 0.0
+    block_archive_reward = 0.0
     r_formal_success_signal = 0.0
     stage1_validity_scale = 0.0
     dominant_family_repeat = False
@@ -3326,6 +4069,13 @@ def base_discovery_reward_fn(
     plain_parallel_repeat = False
     descriptor_reward_cap_applied = False
     cnn_reward_cap_applied = False
+    block_reward_cap_applied = False
+    strong_repeat_penalty_applied = False
+    repeated_graph_without_refresh = False
+    strong_repeat_reasons: List[str] = []
+    reward_variant_adjustment: Dict[str, Any] = {}
+    no_diversity_bonus_variant = reward_variant == REWARD_VARIANT_NO_DIVERSITY_BONUS
+    no_repeat_penalty_variant = reward_variant == REWARD_VARIANT_NO_REPEAT_PENALTY
     executable_candidate = _is_executable_candidate(res, graph_info)
     formal_success_candidate = _is_trainable_candidate(res, graph_info)
     has_formal_epoch = _has_completed_formal_epoch(res)
@@ -3371,8 +4121,9 @@ def base_discovery_reward_fn(
             and not discovery_candidate
         ):
             dominant_family_repeat = True
-            r_repeat_family = REPEAT_FAMILY_PENALTY
-        if graph_info.is_plain_parallel_triple:
+            if not no_repeat_penalty_variant:
+                r_repeat_family = REPEAT_FAMILY_PENALTY
+        if graph_info.is_plain_parallel_triple or plain_dual_backbone_concat:
             plain_parallel_repeat = True
             if stage_name == STAGE1_STRUCTURE_EXPLORE:
                 if goal_tag_hit_rate < STAGE1_DISCOVERY_MIN_GOAL_HIT_RATE:
@@ -3380,8 +4131,10 @@ def base_discovery_reward_fn(
                 else:
                     r_plain_fuse_penalty = min(r_plain_fuse_penalty, STAGE1_PLAIN_PARALLEL_WARMUP_PENALTY)
             elif (not group_warmup) and not discovery_candidate:
-                r_plain_fuse_penalty = PLAIN_FUSE_PENALTY
-
+                r_plain_fuse_penalty = min(
+                    r_plain_fuse_penalty,
+                    PLAIN_DUAL_BACKBONE_FUSE_PENALTY if plain_dual_backbone_concat else PLAIN_FUSE_PENALTY,
+                )
     if stage_name == STAGE1_STRUCTURE_EXPLORE:
         reward_target_value = None
         stage1_validity_scale = _stage1_validity_scale(res)
@@ -3391,7 +4144,7 @@ def base_discovery_reward_fn(
             shallow_one_shot=shallow_one_shot,
             minimal_init_template=minimal_init_template,
         )
-        if executable_candidate:
+        if formal_success_candidate:
             novelty_scale = max(0.35, float(stage1_validity_scale))
             goal_alignment_scale = float(goal_tag_hit_rate or 0.0)
             r_structure_group *= (
@@ -3402,7 +4155,7 @@ def base_discovery_reward_fn(
                 STAGE1_STRUCTURE_ARCHIVE_SCALE
                 * float(stage1_validity_scale)
             )
-            if batch_same_descriptor_count == 1:
+            if batch_same_descriptor_count == 1 and not no_diversity_bonus_variant:
                 r_structure_group += (
                     STAGE1_DESCRIPTOR_BATCH_UNIQUE_BONUS
                     * novelty_scale
@@ -3414,21 +4167,24 @@ def base_discovery_reward_fn(
                     STAGE1_DESCRIPTOR_BATCH_REPEAT_MAX_PENALTY,
                     STAGE1_DESCRIPTOR_BATCH_REPEAT_STEP_PENALTY * float(batch_same_descriptor_count - 2),
                 )
-                r_no_progress_penalty += descriptor_batch_repeat_penalty
+                if not no_repeat_penalty_variant:
+                    r_no_progress_penalty += descriptor_batch_repeat_penalty
                 if batch_same_graph_count > 2:
                     graph_batch_repeat_penalty = max(
                         STAGE1_GRAPH_BATCH_REPEAT_MAX_PENALTY,
                         STAGE1_GRAPH_BATCH_REPEAT_STEP_PENALTY * float(batch_same_graph_count - 2),
                     )
-                    r_no_progress_penalty += graph_batch_repeat_penalty
-            if archive_snapshot_descriptor_freq <= 0:
+                    if not no_repeat_penalty_variant:
+                        r_no_progress_penalty += graph_batch_repeat_penalty
+            if archive_snapshot_descriptor_freq <= 0 and not no_diversity_bonus_variant:
                 r_structure_archive += STAGE1_DESCRIPTOR_ARCHIVE_NOVEL_BONUS * novelty_scale
             elif archive_snapshot_descriptor_freq > 3:
                 descriptor_archive_repeat_penalty = max(
                     STAGE1_DESCRIPTOR_ARCHIVE_REPEAT_MAX_PENALTY,
                     STAGE1_DESCRIPTOR_ARCHIVE_REPEAT_STEP_PENALTY * float(archive_snapshot_descriptor_freq - 3),
                 )
-                r_no_progress_penalty += descriptor_archive_repeat_penalty
+                if not no_repeat_penalty_variant:
+                    r_no_progress_penalty += descriptor_archive_repeat_penalty
             if discovery_candidate and goal_alignment_scale >= STAGE1_DISCOVERY_MIN_GOAL_HIT_RATE:
                 r_goal_best = (
                     STAGE1_DISCOVERY_FAMILY_BONUS
@@ -3453,13 +4209,15 @@ def base_discovery_reward_fn(
                     STAGE1_ARCHIVE_REPEAT_MAX_PENALTY,
                     STAGE1_ARCHIVE_REPEAT_STEP_PENALTY * float(archive_snapshot_family_freq),
                 )
-                r_no_progress_penalty += archive_repeat_penalty
+                if not no_repeat_penalty_variant:
+                    r_no_progress_penalty += archive_repeat_penalty
             if batch_same_family_count >= 3:
                 batch_repeat_penalty = max(
                     STAGE1_BATCH_REPEAT_MAX_PENALTY,
                     STAGE1_BATCH_REPEAT_STEP_PENALTY * float(batch_same_family_count - 2),
                 )
-                r_no_progress_penalty += batch_repeat_penalty
+                if not no_repeat_penalty_variant:
+                    r_no_progress_penalty += batch_repeat_penalty
             r_goal_match = STAGE1_GOAL_MATCH_SCALE * goal_tag_hit_rate * novelty_scale
             r_repeat_family = _clip(r_repeat_family, STAGE1_DOMINANT_FAMILY_PENALTY, 0.0)
             r_plain_fuse_penalty = _clip(r_plain_fuse_penalty, STAGE1_PLAIN_PARALLEL_PENALTY, 0.0)
@@ -3477,7 +4235,7 @@ def base_discovery_reward_fn(
                     reward_target_value = min(float(reward_target_value), STAGE1_ZERO_GOAL_HIT_REWARD_CAP)
                 elif goal_alignment_scale < 0.5:
                     reward_target_value = min(float(reward_target_value), STAGE1_LOW_GOAL_HIT_REWARD_CAP)
-            if graph_info.is_plain_parallel_triple:
+            if graph_info.is_plain_parallel_triple or plain_dual_backbone_concat:
                 reward_target_value = min(float(reward_target_value), STAGE1_PLAIN_PARALLEL_REWARD_CAP)
                 if goal_alignment_scale < STAGE1_DISCOVERY_MIN_GOAL_HIT_RATE:
                     reward_target_value = min(float(reward_target_value), STAGE1_OFF_TARGET_PLAIN_PARALLEL_REWARD_CAP)
@@ -3489,12 +4247,22 @@ def base_discovery_reward_fn(
             if (
                 (not discovery_candidate and archive_snapshot_family_freq > 5)
                 or shallow_pattern_repeat
-                or dominant_family_repeat
+                or (dominant_family_repeat and not no_repeat_penalty_variant)
                 or minimal_init_template
             ):
                 reward_target_value = min(float(reward_target_value), 0.26)
                 if minimal_init_template:
                     reward_target_value = min(float(reward_target_value), 0.18)
+            stage1_repeated_block = bool(
+                executable_candidate
+                and block_signature
+                and block_signature != "incomplete_block"
+                and not discovery_candidate
+                and (archive_snapshot_block_freq > 0 or batch_same_block_count >= 3)
+            )
+            if stage1_repeated_block and not no_repeat_penalty_variant:
+                reward_target_value = min(float(reward_target_value), STAGE1_REPEATED_BLOCK_REWARD_CAP)
+                block_reward_cap_applied = True
         r_history_context = _history_context_reward(
             stage_name=stage_name,
             training_context=training_context,
@@ -3503,7 +4271,7 @@ def base_discovery_reward_fn(
             discovery_candidate=discovery_candidate,
             novel_vs_trainset_family=novel_vs_trainset_family,
             novel_vs_trainset_graph=novel_vs_trainset_graph,
-            dominant_family_repeat=dominant_family_repeat,
+            dominant_family_repeat=dominant_family_repeat and not no_repeat_penalty_variant,
             dominant_descriptor_repeat=False,
             shallow_one_shot=shallow_one_shot,
             plain_parallel_repeat=plain_parallel_repeat,
@@ -3514,6 +4282,27 @@ def base_discovery_reward_fn(
         if (reward_target_value is not None) and (effective_group_baseline_reward_target_acc is not None) and (not group_warmup):
             group_reward_target_gain = float(reward_target_value - effective_group_baseline_reward_target_acc)
             group_reward_target_improved = bool(group_reward_target_gain >= GROUP_IMPROVEMENT_DELTA)
+        if reward_variant == REWARD_VARIANT_NO_STRUCTURAL_NOVELTY:
+            adjusted_components, reward_variant_adjustment = _remove_positive_structural_novelty_components(
+                {
+                    "r_trainset_novelty": r_trainset_novelty,
+                    "r_structure_group": r_structure_group,
+                    "r_structure_archive": r_structure_archive,
+                }
+            )
+            r_trainset_novelty = adjusted_components["r_trainset_novelty"]
+            r_structure_group = adjusted_components["r_structure_group"]
+            r_structure_archive = adjusted_components["r_structure_archive"]
+        (
+            r_structure_group,
+            r_structure_archive,
+            r_target_structure_penalty,
+            target_structure_positive_suppressed,
+        ) = _apply_target_structure_reward_adjustment(
+            pattern_detection,
+            r_structure_group,
+            r_structure_archive,
+        )
         r_primary = (
             r_dense
             + r_goal_best
@@ -3521,13 +4310,16 @@ def base_discovery_reward_fn(
             + r_structure_archive
             + r_repeat_family
             + r_plain_fuse_penalty
+            + r_target_structure_penalty
             + r_template_penalty
             + r_history_context
             + r_no_progress_penalty
         )
         r_tiebreak = r_goal_match
         total_reward = _clip(r_primary + r_tiebreak, -2.0, 2.0)
-        total_reward = _apply_executability_clamp(res, total_reward, graph_info)
+        if block_reward_cap_applied:
+            total_reward = min(total_reward, STAGE1_REPEATED_BLOCK_REWARD_CAP)
+        total_reward = _apply_stage1_trainability_clamp(res, total_reward, graph_info)
     else:
         if (train_acc is not None) and (group_baseline_train_acc is not None) and (not group_warmup):
             group_train_acc_gain = float(train_acc - group_baseline_train_acc)
@@ -3542,14 +4334,19 @@ def base_discovery_reward_fn(
         if has_formal_epoch and reward_target_value is not None:
             train_acc_value = float(train_acc or 0.0)
             reward_target_float = float(reward_target_value)
-            quality_diversity_eligible = bool(formal_success_candidate)
+            quality_diversity_eligible = bool(
+                formal_success_candidate
+                and pattern_detection.get("target_structure_match") is not False
+            )
             r_dense = stage_profile["dense_scale"] * _clip(
-                0.03 + 0.20 * reward_target_float + 0.04 * max(0.0, train_acc_value - 0.50),
+                0.03 + 0.28 * reward_target_float + 0.04 * max(0.0, train_acc_value - 0.50),
                 0.02,
-                0.22,
+                0.35,
             )
             if formal_success_candidate:
                 r_formal_success_signal = FORMAL_SUCCESS_SIGNAL_BONUS
+                if pattern_detection.get("target_structure_match") is not False:
+                    r_formal_success_signal += TARGET_STRUCTURE_MATCH_BONUS
             if (not group_warmup) and (group_baseline_train_acc is not None):
                 prev_target_train_acc = float(group_baseline_train_acc) + GROUP_IMPROVEMENT_DELTA
             if (not group_warmup) and (best_closed_group_mean_train_acc is not None):
@@ -3638,25 +4435,42 @@ def base_discovery_reward_fn(
             )
         descriptor_progress_refresh = formal_progress_refresh
         if executable_candidate and graph_info.parse_ok and graph_info.descriptor_key:
-            if quality_diversity_eligible and batch_same_descriptor_count == 1:
+            if quality_diversity_eligible and batch_same_descriptor_count == 1 and not no_diversity_bonus_variant:
                 r_descriptor_diversity += STAGE23_DESCRIPTOR_BATCH_UNIQUE_BONUS
             elif batch_same_descriptor_count > 1:
-                r_descriptor_diversity += max(
-                    STAGE23_DESCRIPTOR_BATCH_REPEAT_MAX_PENALTY,
-                    STAGE23_DESCRIPTOR_BATCH_REPEAT_STEP_PENALTY * float(batch_same_descriptor_count - 1),
-                )
+                if not no_repeat_penalty_variant:
+                    r_descriptor_diversity += max(
+                        STAGE23_DESCRIPTOR_BATCH_REPEAT_MAX_PENALTY,
+                        STAGE23_DESCRIPTOR_BATCH_REPEAT_STEP_PENALTY * float(batch_same_descriptor_count - 1),
+                    )
 
-            if quality_diversity_eligible and archive_snapshot_descriptor_freq <= 0:
+            if quality_diversity_eligible and archive_snapshot_descriptor_freq <= 0 and not no_diversity_bonus_variant:
                 r_descriptor_diversity += STAGE23_DESCRIPTOR_ARCHIVE_NOVEL_BONUS
             elif archive_snapshot_descriptor_freq > 1:
-                r_descriptor_diversity += max(
-                    STAGE23_DESCRIPTOR_ARCHIVE_REPEAT_MAX_PENALTY,
-                    STAGE23_DESCRIPTOR_ARCHIVE_REPEAT_STEP_PENALTY * float(archive_snapshot_descriptor_freq - 1),
-                )
+                if not no_repeat_penalty_variant:
+                    r_descriptor_diversity += max(
+                        STAGE23_DESCRIPTOR_ARCHIVE_REPEAT_MAX_PENALTY,
+                        STAGE23_DESCRIPTOR_ARCHIVE_REPEAT_STEP_PENALTY * float(archive_snapshot_descriptor_freq - 1),
+                    )
+            if quality_diversity_eligible and not no_diversity_bonus_variant:
+                if archive_snapshot_descriptor_freq <= 0:
+                    global_descriptor_archive_reward = STAGE23_GLOBAL_DESCRIPTOR_ARCHIVE_NOVEL_BONUS
+                elif not no_repeat_penalty_variant:
+                    global_descriptor_archive_reward = max(
+                        STAGE23_GLOBAL_DESCRIPTOR_ARCHIVE_REPEAT_MAX_PENALTY,
+                        STAGE23_GLOBAL_DESCRIPTOR_ARCHIVE_REPEAT_MAX_PENALTY
+                        * min(
+                            1.0,
+                            float(archive_snapshot_descriptor_freq)
+                            / float(STAGE23_GLOBAL_DESCRIPTOR_ARCHIVE_REPEAT_WINDOW),
+                        ),
+                    )
+                r_descriptor_diversity += global_descriptor_archive_reward
 
             if (
                 (not group_warmup)
                 and quality_diversity_eligible
+                and not no_diversity_bonus_variant
                 and dominant_descriptor_key
                 and graph_info.descriptor_key != dominant_descriptor_key
                 and float(dominant_descriptor_share or 0.0) >= STAGE23_DOMINANT_DESCRIPTOR_SOFT_SHARE
@@ -3670,31 +4484,64 @@ def base_discovery_reward_fn(
                 and not descriptor_progress_refresh
             ):
                 dominant_descriptor_repeat = True
-                if float(dominant_descriptor_share or 0.0) >= STAGE23_DOMINANT_DESCRIPTOR_STRONG_SHARE:
-                    r_descriptor_diversity += STAGE23_DOMINANT_DESCRIPTOR_REPEAT_STRONG_PENALTY
-                else:
-                    r_descriptor_diversity += STAGE23_DOMINANT_DESCRIPTOR_REPEAT_PENALTY
+                if not no_repeat_penalty_variant:
+                    if float(dominant_descriptor_share or 0.0) >= STAGE23_DOMINANT_DESCRIPTOR_STRONG_SHARE:
+                        r_descriptor_diversity += STAGE23_DOMINANT_DESCRIPTOR_REPEAT_STRONG_PENALTY
+                    else:
+                        r_descriptor_diversity += STAGE23_DOMINANT_DESCRIPTOR_REPEAT_PENALTY
 
         if executable_candidate and graph_info.parse_ok and cnn_signature:
-            if quality_diversity_eligible and batch_same_backbone_cnn_count == 1:
+            if quality_diversity_eligible and batch_same_backbone_cnn_count == 1 and not no_diversity_bonus_variant:
                 r_cnn_diversity += STAGE23_CNN_BATCH_UNIQUE_BONUS
             elif batch_same_backbone_cnn_count > 1:
-                r_cnn_diversity += max(
-                    STAGE23_CNN_BATCH_REPEAT_MAX_PENALTY,
-                    STAGE23_CNN_BATCH_REPEAT_STEP_PENALTY * float(batch_same_backbone_cnn_count - 1),
-                )
+                if not no_repeat_penalty_variant:
+                    r_cnn_diversity += max(
+                        STAGE23_CNN_BATCH_REPEAT_MAX_PENALTY,
+                        STAGE23_CNN_BATCH_REPEAT_STEP_PENALTY * float(batch_same_backbone_cnn_count - 1),
+                    )
 
-            if quality_diversity_eligible and archive_snapshot_backbone_cnn_freq <= 0:
+            if quality_diversity_eligible and archive_snapshot_backbone_cnn_freq <= 0 and not no_diversity_bonus_variant:
                 r_cnn_diversity += STAGE23_CNN_ARCHIVE_NOVEL_BONUS
             elif archive_snapshot_backbone_cnn_freq > 1:
-                r_cnn_diversity += max(
-                    STAGE23_CNN_ARCHIVE_REPEAT_MAX_PENALTY,
-                    STAGE23_CNN_ARCHIVE_REPEAT_STEP_PENALTY * float(archive_snapshot_backbone_cnn_freq - 1),
-                )
+                if not no_repeat_penalty_variant:
+                    r_cnn_diversity += max(
+                        STAGE23_CNN_ARCHIVE_REPEAT_MAX_PENALTY,
+                        STAGE23_CNN_ARCHIVE_REPEAT_STEP_PENALTY * float(archive_snapshot_backbone_cnn_freq - 1),
+                    )
+            if quality_diversity_eligible and not no_diversity_bonus_variant:
+                if archive_snapshot_cnn_freq <= 0:
+                    global_cnn_archive_reward = STAGE23_GLOBAL_CNN_ARCHIVE_NOVEL_BONUS
+                elif not no_repeat_penalty_variant:
+                    global_cnn_archive_reward = max(
+                        STAGE23_GLOBAL_CNN_ARCHIVE_REPEAT_MAX_PENALTY,
+                        STAGE23_GLOBAL_CNN_ARCHIVE_REPEAT_MAX_PENALTY
+                        * min(
+                            1.0,
+                            float(archive_snapshot_cnn_freq)
+                            / float(STAGE23_GLOBAL_CNN_ARCHIVE_REPEAT_WINDOW),
+                        ),
+                    )
+                r_cnn_diversity += global_cnn_archive_reward
 
             if (
                 (not group_warmup)
                 and quality_diversity_eligible
+                and dominant_cnn_signature
+                and cnn_signature == dominant_cnn_signature
+                and float(dominant_cnn_share or 0.0) >= STAGE23_DOMINANT_CNN_SOFT_SHARE
+                and not descriptor_progress_refresh
+            ):
+                dominant_cnn_repeat = True
+                if not no_repeat_penalty_variant:
+                    if float(dominant_cnn_share or 0.0) >= STAGE23_DOMINANT_CNN_STRONG_SHARE:
+                        r_cnn_diversity += STAGE23_GLOBAL_CNN_REPEAT_STRONG_PENALTY
+                    else:
+                        r_cnn_diversity += STAGE23_GLOBAL_CNN_REPEAT_PENALTY
+
+            if (
+                (not group_warmup)
+                and quality_diversity_eligible
+                and not no_diversity_bonus_variant
                 and archive_snapshot_backbone_freq >= BACKBONE_BASELINE_MIN_ARCHIVE_SAMPLES
                 and dominant_backbone_cnn_signature
                 and cnn_signature != dominant_backbone_cnn_signature
@@ -3710,10 +4557,49 @@ def base_discovery_reward_fn(
                 and not descriptor_progress_refresh
             ):
                 dominant_cnn_repeat = True
-                if float(dominant_backbone_cnn_share or 0.0) >= STAGE23_DOMINANT_CNN_STRONG_SHARE:
-                    r_cnn_diversity += STAGE23_DOMINANT_CNN_REPEAT_STRONG_PENALTY
-                else:
-                    r_cnn_diversity += STAGE23_DOMINANT_CNN_REPEAT_PENALTY
+                if not no_repeat_penalty_variant:
+                    if float(dominant_backbone_cnn_share or 0.0) >= STAGE23_DOMINANT_CNN_STRONG_SHARE:
+                        r_cnn_diversity += STAGE23_DOMINANT_CNN_REPEAT_STRONG_PENALTY
+                    else:
+                        r_cnn_diversity += STAGE23_DOMINANT_CNN_REPEAT_PENALTY
+
+        if (
+            executable_candidate
+            and graph_info.parse_ok
+            and quality_diversity_eligible
+            and block_code
+            and not block_contributes_to_forward
+        ):
+            r_block_diversity += STAGE23_DEAD_BLOCK_PENALTY
+
+        if (
+            executable_candidate
+            and graph_info.parse_ok
+            and quality_diversity_eligible
+            and block_signature
+            and block_signature != "incomplete_block"
+        ):
+            if batch_same_block_count == 1 and not no_diversity_bonus_variant:
+                r_block_diversity += STAGE23_BLOCK_BATCH_UNIQUE_BONUS
+            elif batch_same_block_count > 1:
+                if not no_repeat_penalty_variant:
+                    r_block_diversity += max(
+                        STAGE23_BLOCK_BATCH_REPEAT_MAX_PENALTY,
+                        STAGE23_BLOCK_BATCH_REPEAT_STEP_PENALTY * float(batch_same_block_count - 1),
+                    )
+            if archive_snapshot_block_freq <= 0 and not no_diversity_bonus_variant:
+                block_archive_reward = STAGE23_BLOCK_ARCHIVE_NOVEL_BONUS
+            elif not no_repeat_penalty_variant:
+                block_archive_reward = max(
+                    STAGE23_BLOCK_ARCHIVE_REPEAT_MAX_PENALTY,
+                    STAGE23_BLOCK_ARCHIVE_REPEAT_MAX_PENALTY
+                    * min(
+                        1.0,
+                        float(archive_snapshot_block_freq)
+                        / float(STAGE23_BLOCK_ARCHIVE_REPEAT_WINDOW),
+                    ),
+                )
+            r_block_diversity += block_archive_reward
 
         r_goal_match = stage_profile["goal_match_scale"] * GOAL_MATCH_REWARD_SCALE * goal_tag_hit_rate
         r_template_penalty = _template_penalty(
@@ -3741,6 +4627,84 @@ def base_discovery_reward_fn(
         r_repeat_family *= stage_profile["repeat_family_scale"]
         r_plain_fuse_penalty *= stage_profile["plain_fuse_scale"]
 
+        if reward_variant == REWARD_VARIANT_NO_STRUCTURAL_NOVELTY:
+            adjusted_components, reward_variant_adjustment = _remove_positive_structural_novelty_components(
+                {
+                    "r_trainset_novelty": r_trainset_novelty,
+                    "r_structure_group": r_structure_group,
+                    "r_structure_archive": r_structure_archive,
+                    "r_descriptor_diversity": r_descriptor_diversity,
+                    "r_cnn_diversity": r_cnn_diversity,
+                    "r_block_diversity": r_block_diversity,
+                    "global_descriptor_archive_reward": global_descriptor_archive_reward,
+                    "global_cnn_archive_reward": global_cnn_archive_reward,
+                    "block_archive_reward": block_archive_reward,
+                }
+            )
+            r_trainset_novelty = adjusted_components["r_trainset_novelty"]
+            r_structure_group = adjusted_components["r_structure_group"]
+            r_structure_archive = adjusted_components["r_structure_archive"]
+            r_descriptor_diversity = adjusted_components["r_descriptor_diversity"]
+            r_cnn_diversity = adjusted_components["r_cnn_diversity"]
+            r_block_diversity = adjusted_components["r_block_diversity"]
+            global_descriptor_archive_reward = adjusted_components["global_descriptor_archive_reward"]
+            global_cnn_archive_reward = adjusted_components["global_cnn_archive_reward"]
+            block_archive_reward = adjusted_components["block_archive_reward"]
+
+        (
+            r_structure_group,
+            r_structure_archive,
+            r_target_structure_penalty,
+            target_structure_positive_suppressed,
+        ) = _apply_target_structure_reward_adjustment(
+            pattern_detection,
+            r_structure_group,
+            r_structure_archive,
+        )
+        gated_novelty_components = _stage23_gate_positive_novelty_by_quality(
+            quality_acc_value,
+            {
+                "r_structure_group": r_structure_group,
+                "r_structure_archive": r_structure_archive,
+                "r_descriptor_diversity": r_descriptor_diversity,
+                "r_cnn_diversity": r_cnn_diversity,
+                "r_block_diversity": r_block_diversity,
+            },
+        )
+        r_structure_group = gated_novelty_components["r_structure_group"]
+        r_structure_archive = gated_novelty_components["r_structure_archive"]
+        r_descriptor_diversity = gated_novelty_components["r_descriptor_diversity"]
+        r_cnn_diversity = gated_novelty_components["r_cnn_diversity"]
+        r_block_diversity = gated_novelty_components["r_block_diversity"]
+        if _is_target_parallel_triple_block_dead(pattern_detection, block_contributes_to_forward):
+            target_block_dead_accuracy_components_suppressed = True
+            target_block_dead_accuracy_suppressed_total = sum(
+                max(0.0, float(component or 0.0))
+                for component in (
+                    r_dense,
+                    r_formal_success_signal,
+                    r_prev_group,
+                    r_best_group,
+                    r_prev_backbone_group,
+                    r_best_backbone_group,
+                    r_goal_best,
+                    r_generalization,
+                    r_batch_elite,
+                )
+            )
+            r_dense = 0.0
+            r_formal_success_signal = 0.0
+            r_prev_group = 0.0
+            r_best_group = 0.0
+            r_prev_backbone_group = 0.0
+            r_best_backbone_group = 0.0
+            r_goal_best = 0.0
+            r_generalization = 0.0
+            r_batch_elite = 0.0
+            beat_prev_target = False
+            beat_best_target = False
+            beat_prev_backbone_target = False
+            beat_best_backbone_target = False
         r_primary = (
             r_dense
             + r_formal_success_signal
@@ -3754,9 +4718,11 @@ def base_discovery_reward_fn(
             + r_structure_archive
             + r_descriptor_diversity
             + r_cnn_diversity
+            + r_block_diversity
             + r_batch_elite
             + r_repeat_family
             + r_plain_fuse_penalty
+            + r_target_structure_penalty
             + r_template_penalty
             + r_history_context
             + r_no_progress_penalty
@@ -3775,12 +4741,56 @@ def base_discovery_reward_fn(
         )
         if has_formal_epoch and effective_prev_target_reward_target_acc is not None and not effective_beat_prev_target:
             total_reward = min(total_reward, stage_profile["non_improving_cap"])
-        if has_formal_epoch and dominant_descriptor_repeat:
+        if has_formal_epoch and dominant_descriptor_repeat and not no_repeat_penalty_variant:
             total_reward = min(total_reward, stage_profile["descriptor_non_improving_cap"])
             descriptor_reward_cap_applied = True
-        if has_formal_epoch and dominant_cnn_repeat:
+        if has_formal_epoch and dominant_cnn_repeat and not no_repeat_penalty_variant:
             total_reward = min(total_reward, stage_profile["descriptor_non_improving_cap"])
             cnn_reward_cap_applied = True
+        block_repeat_quality_refresh = bool(r_goal_best > 0.0 or beat_best_backbone_target or beat_best_target)
+        repeated_block_without_refresh = bool(
+            has_formal_epoch
+            and formal_success_candidate
+            and block_signature
+            and block_signature != "incomplete_block"
+            and (archive_snapshot_block_freq > 0 or batch_same_block_count > 1)
+            and not block_repeat_quality_refresh
+        )
+        repeated_graph_without_refresh = bool(
+            has_formal_epoch
+            and formal_success_candidate
+            and graph_info.parse_ok
+            and graph_info.graph_hash
+            and (archive_snapshot_graph_freq > 0 or batch_same_graph_count > 1)
+            and not block_repeat_quality_refresh
+        )
+        if repeated_block_without_refresh and not no_repeat_penalty_variant:
+            total_reward = min(total_reward, STAGE23_REPEATED_BLOCK_REWARD_CAP)
+            block_reward_cap_applied = True
+        if dominant_descriptor_repeat:
+            strong_repeat_reasons.append("descriptor")
+        if dominant_cnn_repeat:
+            strong_repeat_reasons.append("backbone_cnn")
+        if repeated_block_without_refresh:
+            strong_repeat_reasons.append("block")
+        if repeated_graph_without_refresh:
+            strong_repeat_reasons.append("graph")
+        if reward_variant == REWARD_VARIANT_STRONG_REPEAT_PENALTY and strong_repeat_reasons:
+            total_reward = min(total_reward, 0.0)
+            strong_repeat_penalty_applied = True
+        total_reward = _stage23_local_competition_reward(
+            total_reward,
+            generation_total=_current_generation_total(),
+            target_ok=pattern_detection.get("target_structure_match") is not False,
+            has_formal_epoch=has_formal_epoch,
+            formal_success_candidate=formal_success_candidate,
+            quality_acc_value=quality_acc_value,
+            cell_archive_freq=archive_snapshot_backbone_block_freq,
+            batch_same_cell_count=batch_same_backbone_block_count,
+            cell_best_quality_acc=cell_best_quality_acc,
+            disable_diversity_bonus=no_diversity_bonus_variant,
+            disable_repeat_penalty=no_repeat_penalty_variant,
+        )
         total_reward = _apply_executability_clamp(res, total_reward, graph_info)
 
     reward_target_value_for_payload = reward_target_value
@@ -3791,6 +4801,11 @@ def base_discovery_reward_fn(
         warmup_dense_reward = _compute_warmup_dense_reward(reward_target_value)
         total_reward = float(warmup_dense_reward or 0.0)
         total_reward = _apply_executability_clamp(res, total_reward, graph_info)
+    total_reward = _apply_target_structure_final_clamp(
+        pattern_detection,
+        total_reward,
+        r_target_structure_penalty,
+    )
 
     res['reward'] = total_reward
     res['test_acc'] = test_acc
@@ -3839,10 +4854,15 @@ def base_discovery_reward_fn(
     res['r_structure_archive'] = r_structure_archive
     res['r_descriptor_diversity'] = r_descriptor_diversity
     res['r_cnn_diversity'] = r_cnn_diversity
+    res['r_block_diversity'] = r_block_diversity
     res['r_formal_success_signal'] = r_formal_success_signal
     res['r_batch_elite'] = r_batch_elite
     res['r_repeat_family'] = r_repeat_family
     res['r_plain_fuse_penalty'] = r_plain_fuse_penalty
+    res['r_target_structure_penalty'] = r_target_structure_penalty
+    res['target_structure_positive_suppressed'] = target_structure_positive_suppressed
+    res['target_block_dead_accuracy_components_suppressed'] = target_block_dead_accuracy_components_suppressed
+    res['target_block_dead_accuracy_suppressed_total'] = target_block_dead_accuracy_suppressed_total
     res['r_template_penalty'] = r_template_penalty
     res['r_history_context'] = r_history_context
     res['r_no_progress_penalty'] = r_no_progress_penalty
@@ -3869,11 +4889,22 @@ def base_discovery_reward_fn(
     res['backbone_signature'] = backbone_signature
     res['cnn_signature'] = cnn_signature
     res['cnn_expr'] = cnn_expr
+    res['block_signature'] = block_signature
+    res['block_contributes_to_forward'] = block_contributes_to_forward
+    res['backbone_block_pair_key'] = backbone_block_pair_key
+    res['plain_dual_backbone_concat'] = plain_dual_backbone_concat
     res['archive_snapshot_backbone_freq'] = archive_snapshot_backbone_freq
     res['archive_snapshot_cnn_freq'] = archive_snapshot_cnn_freq
+    res['archive_snapshot_graph_freq'] = archive_snapshot_graph_freq
+    res['archive_snapshot_block_freq'] = archive_snapshot_block_freq
     res['archive_snapshot_backbone_cnn_freq'] = archive_snapshot_backbone_cnn_freq
+    res['archive_snapshot_backbone_block_freq'] = archive_snapshot_backbone_block_freq
+    res['cell_best_quality_acc'] = cell_best_quality_acc
+    res['batch_same_graph_count'] = batch_same_graph_count
     res['batch_same_backbone_count'] = batch_same_backbone_count
     res['batch_same_backbone_cnn_count'] = batch_same_backbone_cnn_count
+    res['batch_same_block_count'] = batch_same_block_count
+    res['batch_same_backbone_block_count'] = batch_same_backbone_block_count
     res['descriptor_key'] = graph_info.descriptor_key
     res['dominant_descriptor_key'] = dominant_descriptor_key
     res['dominant_descriptor_share'] = dominant_descriptor_share
@@ -3882,10 +4913,23 @@ def base_discovery_reward_fn(
     res['unique_descriptor_count'] = len(descriptor_archive_counts)
     res['dominant_descriptor_repeat'] = dominant_descriptor_repeat
     res['dominant_cnn_repeat'] = dominant_cnn_repeat
+    res['global_descriptor_archive_reward'] = global_descriptor_archive_reward
+    res['global_cnn_archive_reward'] = global_cnn_archive_reward
+    res['block_archive_reward'] = block_archive_reward
     res['descriptor_reward_cap_applied'] = descriptor_reward_cap_applied
     res['cnn_reward_cap_applied'] = cnn_reward_cap_applied
+    res['block_reward_cap_applied'] = block_reward_cap_applied
+    res['reward_variant'] = reward_variant
+    res['reward_variant_adjustment'] = reward_variant_adjustment
+    res['repeated_graph_without_refresh'] = repeated_graph_without_refresh
+    res['strong_repeat_penalty_applied'] = strong_repeat_penalty_applied
+    res['strong_repeat_penalty_reasons'] = list(dict.fromkeys(strong_repeat_reasons))
     res['history_exploration_pressure'] = float(training_context.get('exploration_pressure') or 0.0)
     res['minimal_init_template'] = minimal_init_template
+    res.update(pattern_detection)
+    res['declared_pattern_name'] = pattern_detection["declared_pattern"]
+    res['actual_pattern_name'] = pattern_detection["actual_pattern"]
+    res['target_pattern_match'] = pattern_detection["target_structure_match"]
     res['graph_expr'] = graph_info.graph_expr
     res['pattern_name'] = effective_pattern_name
     res['suggested_pattern_name'] = graph_info.suggested_pattern_name
@@ -3906,9 +4950,14 @@ def base_discovery_reward_fn(
         'r_structure_archive': r_structure_archive,
         'r_descriptor_diversity': r_descriptor_diversity,
         'r_cnn_diversity': r_cnn_diversity,
+        'r_block_diversity': r_block_diversity,
         'r_batch_elite': r_batch_elite,
         'r_repeat_family': r_repeat_family,
         'r_plain_fuse_penalty': r_plain_fuse_penalty,
+        'r_target_structure_penalty': r_target_structure_penalty,
+        'target_structure_positive_suppressed': target_structure_positive_suppressed,
+        'target_block_dead_accuracy_components_suppressed': target_block_dead_accuracy_components_suppressed,
+        'target_block_dead_accuracy_suppressed_total': target_block_dead_accuracy_suppressed_total,
         'r_template_penalty': r_template_penalty,
         'r_history_context': r_history_context,
         'r_no_progress_penalty': r_no_progress_penalty,
@@ -3950,11 +4999,17 @@ def base_discovery_reward_fn(
         'batch_same_descriptor_count': batch_same_descriptor_count,
         'batch_same_backbone_count': batch_same_backbone_count,
         'batch_same_backbone_cnn_count': batch_same_backbone_cnn_count,
+        'batch_same_block_count': batch_same_block_count,
+        'batch_same_backbone_block_count': batch_same_backbone_block_count,
         'archive_snapshot_family_freq': archive_snapshot_family_freq,
         'archive_snapshot_descriptor_freq': archive_snapshot_descriptor_freq,
         'archive_snapshot_backbone_freq': archive_snapshot_backbone_freq,
         'archive_snapshot_cnn_freq': archive_snapshot_cnn_freq,
+        'archive_snapshot_graph_freq': archive_snapshot_graph_freq,
+        'archive_snapshot_block_freq': archive_snapshot_block_freq,
         'archive_snapshot_backbone_cnn_freq': archive_snapshot_backbone_cnn_freq,
+        'archive_snapshot_backbone_block_freq': archive_snapshot_backbone_block_freq,
+        'cell_best_quality_acc': cell_best_quality_acc,
         'macro_structure_ok': passes_macro_structure_gate(graph_info),
         'is_multi_stage_architecture': is_multi_stage_architecture(graph_info),
         'is_shallow_one_shot_fuse': shallow_one_shot,
@@ -3963,6 +5018,10 @@ def base_discovery_reward_fn(
         'backbone_signature': backbone_signature,
         'cnn_signature': cnn_signature,
         'cnn_expr': cnn_expr,
+        'block_signature': block_signature,
+        'block_contributes_to_forward': block_contributes_to_forward,
+        'backbone_block_pair_key': backbone_block_pair_key,
+        'plain_dual_backbone_concat': plain_dual_backbone_concat,
         'descriptor_key': graph_info.descriptor_key,
         'dominant_descriptor_key': dominant_descriptor_key,
         'dominant_descriptor_share': dominant_descriptor_share,
@@ -3971,8 +5030,17 @@ def base_discovery_reward_fn(
         'unique_descriptor_count': len(descriptor_archive_counts),
         'dominant_descriptor_repeat': dominant_descriptor_repeat,
         'dominant_cnn_repeat': dominant_cnn_repeat,
+        'global_descriptor_archive_reward': global_descriptor_archive_reward,
+        'global_cnn_archive_reward': global_cnn_archive_reward,
+        'block_archive_reward': block_archive_reward,
         'descriptor_reward_cap_applied': descriptor_reward_cap_applied,
         'cnn_reward_cap_applied': cnn_reward_cap_applied,
+        'block_reward_cap_applied': block_reward_cap_applied,
+        'reward_variant': reward_variant,
+        'reward_variant_adjustment': reward_variant_adjustment,
+        'repeated_graph_without_refresh': repeated_graph_without_refresh,
+        'strong_repeat_penalty_applied': strong_repeat_penalty_applied,
+        'strong_repeat_penalty_reasons': list(dict.fromkeys(strong_repeat_reasons)),
         'history_exploration_pressure': float(training_context.get('exploration_pressure') or 0.0),
         'minimal_init_template': minimal_init_template,
         'depth': graph_info.depth,
@@ -4012,12 +5080,19 @@ def reward_fn(
     batch_descriptor_keys: List[str] = None,
     batch_backbone_signatures: List[str] = None,
     batch_cnn_signatures: List[str] = None,
+    batch_block_signatures: List[str] = None,
+    batch_backbone_block_signatures: List[str] = None,
     prompt_goal_tags: List[str] = None,
+    prompt_target_pattern: str = "",
     archive_snapshot_family_counts: Optional[Dict[str, int]] = None,
     archive_snapshot_descriptor_counts: Optional[Dict[str, int]] = None,
     archive_snapshot_backbone_signature_counts: Optional[Dict[str, int]] = None,
     archive_snapshot_cnn_signature_counts: Optional[Dict[str, int]] = None,
+    archive_snapshot_graph_counts: Optional[Dict[str, int]] = None,
+    archive_snapshot_block_signature_counts: Optional[Dict[str, int]] = None,
     archive_snapshot_backbone_cnn_pair_counts: Optional[Dict[str, int]] = None,
+    archive_snapshot_backbone_block_pair_counts: Optional[Dict[str, int]] = None,
+    archive_snapshot_backbone_block_best_quality: Optional[Dict[str, float]] = None,
     group_baseline_train_acc: Optional[float] = None,
     group_baseline_reward_target_acc: Optional[float] = None,
     reward_batch_index: Optional[int] = None,
@@ -4037,12 +5112,19 @@ def reward_fn(
         batch_descriptor_keys=batch_descriptor_keys,
         batch_backbone_signatures=batch_backbone_signatures,
         batch_cnn_signatures=batch_cnn_signatures,
+        batch_block_signatures=batch_block_signatures,
+        batch_backbone_block_signatures=batch_backbone_block_signatures,
         prompt_goal_tags=prompt_goal_tags,
+        prompt_target_pattern=prompt_target_pattern,
         archive_snapshot_family_counts=archive_snapshot_family_counts,
         archive_snapshot_descriptor_counts=archive_snapshot_descriptor_counts,
         archive_snapshot_backbone_signature_counts=archive_snapshot_backbone_signature_counts,
         archive_snapshot_cnn_signature_counts=archive_snapshot_cnn_signature_counts,
+        archive_snapshot_graph_counts=archive_snapshot_graph_counts,
+        archive_snapshot_block_signature_counts=archive_snapshot_block_signature_counts,
         archive_snapshot_backbone_cnn_pair_counts=archive_snapshot_backbone_cnn_pair_counts,
+        archive_snapshot_backbone_block_pair_counts=archive_snapshot_backbone_block_pair_counts,
+        archive_snapshot_backbone_block_best_quality=archive_snapshot_backbone_block_best_quality,
         group_baseline_train_acc=group_baseline_train_acc,
         group_baseline_reward_target_acc=group_baseline_reward_target_acc,
         reward_batch_index=reward_batch_index,
@@ -4058,6 +5140,7 @@ def _apply_batch_elite_bonuses(scored_results: List[Dict[str, Any]], group_conte
         return
 
     eligible: List[Tuple[float, Dict[str, Any]]] = []
+    no_repeat_penalty_variant = _reward_variant_is_no_repeat_penalty()
 
     for item in scored_results:
         res = item["result"]
@@ -4068,6 +5151,21 @@ def _apply_batch_elite_bonuses(scored_results: List[Dict[str, Any]], group_conte
         if not _has_completed_formal_epoch(res):
             continue
         if reward_target_value is None:
+            continue
+        if res.get("target_structure_match") is False:
+            continue
+        if (not no_repeat_penalty_variant) and _is_repeated_block_without_refresh(res):
+            continue
+        improved = bool(res.get("group_reward_target_improved") or res.get("backbone_reward_target_improved"))
+        if (
+            (not no_repeat_penalty_variant)
+            and (res.get("dominant_descriptor_repeat") or res.get("dominant_cnn_repeat"))
+            and not improved
+        ):
+            continue
+        if res.get("plain_dual_backbone_concat") and not improved:
+            continue
+        if _reward_variant_is_strong_repeat_penalty() and _is_strong_repeat_without_refresh(res):
             continue
         eligible.append((float(reward_target_value), item))
 
@@ -4092,14 +5190,21 @@ def _apply_batch_elite_bonuses(scored_results: List[Dict[str, Any]], group_conte
         )
         res = item["result"]
         graph_info = item["graph_info"]
-        if float(res.get("r_no_progress_penalty", 0.0) or 0.0) < 0.0:
+        old_reward = float(res.get("reward", -2.0))
+        old_discovery_reward, _, _ = _recompute_discovery_reward(res, graph_info)
+        postprocess_delta = old_reward - float(old_discovery_reward)
+        if (
+            (no_repeat_penalty_variant or not _is_repeated_block_without_refresh(res))
+            and not (_reward_variant_is_strong_repeat_penalty() and _is_strong_repeat_without_refresh(res))
+            and float(res.get("r_no_progress_penalty", 0.0) or 0.0) < 0.0
+        ):
             res["r_no_progress_penalty"] = 0.0
         res["r_batch_elite"] = bonus
         res["batch_elite_rank"] = rank + 1
         res["batch_elite_tier"] = tier
         res["batch_elite_threshold_passed"] = threshold_passed
         total_reward, r_primary, r_tiebreak = _recompute_discovery_reward(res, graph_info)
-        res["reward"] = total_reward
+        res["reward"] = _clip(float(total_reward) + postprocess_delta, -2.0, 2.0)
         open_discovery = res.setdefault("open_discovery", {})
         open_discovery["r_batch_elite"] = bonus
         open_discovery["r_primary"] = r_primary
@@ -4107,7 +5212,7 @@ def _apply_batch_elite_bonuses(scored_results: List[Dict[str, Any]], group_conte
         open_discovery["batch_elite_rank"] = rank + 1
         open_discovery["batch_elite_tier"] = tier
         open_discovery["batch_elite_threshold_passed"] = threshold_passed
-        item["score"] = float(total_reward)
+        item["score"] = float(res["reward"])
         elite_summaries.append(
             f"#{rank + 1} target={reward_target_float:.4f} tier={tier} bonus={bonus:.3f} "
             f"struct={float(res.get('r_structure_group', 0.0) or 0.0) + float(res.get('r_structure_archive', 0.0) or 0.0):.3f}"
@@ -4117,6 +5222,58 @@ def _apply_batch_elite_bonuses(scored_results: List[Dict[str, Any]], group_conte
             f"[Reward Batch Elite] reward_batch_index={group_context['reward_batch_index']} "
             + "; ".join(elite_summaries)
         )
+
+
+def _is_repeated_block_without_refresh(res: Dict[str, Any]) -> bool:
+    block_signature = str(res.get("block_signature") or "")
+    if not block_signature or block_signature == "incomplete_block":
+        return False
+    if _has_block_repeat_quality_refresh(res):
+        return False
+    archive_freq = int(res.get("archive_snapshot_block_freq", 0) or 0)
+    batch_count = int(res.get("batch_same_block_count", 0) or 0)
+    return archive_freq > 0 or batch_count > 1
+
+
+def _is_repeated_graph_without_refresh(res: Dict[str, Any]) -> bool:
+    if bool(res.get("repeated_graph_without_refresh")):
+        return True
+    graph_hash = str(res.get("graph_hash") or "")
+    if not graph_hash:
+        return False
+    if _has_block_repeat_quality_refresh(res):
+        return False
+    archive_freq = int(res.get("archive_snapshot_graph_freq", 0) or 0)
+    batch_count = int(res.get("batch_same_graph_count", 0) or 0)
+    return archive_freq > 0 or batch_count > 1
+
+
+def _is_strong_repeat_without_refresh(res: Dict[str, Any]) -> bool:
+    if not _has_completed_formal_epoch(res):
+        return False
+    if not bool(res.get("formal_success_candidate")):
+        return False
+    if _has_block_repeat_quality_refresh(res):
+        return False
+    return bool(
+        res.get("dominant_descriptor_repeat")
+        or res.get("dominant_cnn_repeat")
+        or _is_repeated_block_without_refresh(res)
+        or _is_repeated_graph_without_refresh(res)
+    )
+
+
+def _has_block_repeat_quality_refresh(res: Dict[str, Any]) -> bool:
+    if float(res.get("r_goal_best", 0.0) or 0.0) > 0.0:
+        return True
+    reward_target_value = _optional_float(res.get("reward_target_value"))
+    if reward_target_value is None:
+        return False
+    best_targets = (
+        _optional_float(res.get("backbone_best_target_reward_target_acc")),
+        _optional_float(res.get("best_target_reward_target_acc")),
+    )
+    return any(target is not None and reward_target_value >= target for target in best_targets)
 
 def _reward_failure_result(
     *,
@@ -4159,6 +5316,7 @@ def _prepare_local_reward_entries(
     batch_graph_infos: List[Any] = []
     batch_backbone_model_names: List[List[str]] = []
     batch_prompt_goal_tags = [extract_prompt_goal_tags(prompt) for prompt in prompts]
+    batch_prompt_target_patterns = [extract_prompt_target_pattern(prompt) for prompt in prompts]
 
     for i, completion in enumerate(completions):
         _, init_code, forward_code = extract_completion_blocks(completion)
@@ -4192,7 +5350,8 @@ def _prepare_local_reward_entries(
                     else "incomplete_cnn"
                 ),
                 "prompt_goal_tags": batch_prompt_goal_tags[i],
-                "goal_key": primary_goal_key(batch_prompt_goal_tags[i]),
+                "prompt_target_pattern": batch_prompt_target_patterns[i],
+                "goal_key": primary_goal_key(batch_prompt_goal_tags[i], batch_prompt_target_patterns[i]),
                 "seed_accuracy_baseline": seed_accuracy_baselines[i],
                 "precomputed_eval_result": None,
             }
@@ -4271,10 +5430,12 @@ def _build_batched_eval_specs(
         if not final_code:
             continue
 
+        formal_input_shape = _formal_reward_input_shape()
+        formal_out_shape = _formal_reward_out_shape()
         spec = {
             "code": final_code,
-            "in_shape": (1, 3, 224, 224),
-            "out_shape": (10,),
+            "in_shape": formal_input_shape,
+            "out_shape": formal_out_shape,
             "prm": {
                 "lr": 0.01,
                 "batch": 64,
@@ -4290,15 +5451,17 @@ def _build_batched_eval_specs(
             "batch_last_item": False,
         }
         if callable(eval_cfg_builder):
-            spec["cfg"] = _invoke_eval_cfg_builder(
+            spec_cfg = _invoke_eval_cfg_builder(
                 eval_cfg_builder,
                 stage_name=str(group_context.get("current_stage_name") or current_stage_name),
-                in_shape=(1, 3, 224, 224),
-                out_shape=(10,),
+                in_shape=formal_input_shape,
+                out_shape=formal_out_shape,
                 prm=spec["prm"],
                 cfg=None,
                 device=spec["device"],
             )
+            spec["cfg"] = spec_cfg
+            spec["out_shape"] = (int(getattr(spec_cfg, "n_classes", spec["out_shape"][0])),)
 
         batched_eval_entries.append(entry)
         batched_eval_specs.append(spec)
@@ -4433,7 +5596,11 @@ def _score_reward_entries(
     archive_snapshot_descriptor_counts = dict(descriptor_archive_counts)
     archive_snapshot_backbone_signature_counts = dict(backbone_signature_archive_counts)
     archive_snapshot_cnn_signature_counts = dict(cnn_signature_archive_counts)
+    archive_snapshot_graph_counts = dict(graph_archive_counts)
+    archive_snapshot_block_signature_counts = dict(block_signature_archive_counts)
     archive_snapshot_backbone_cnn_pair_counts = dict(backbone_cnn_pair_archive_counts)
+    archive_snapshot_backbone_block_pair_counts = dict(backbone_block_pair_archive_counts)
+    archive_snapshot_backbone_block_best_quality = dict(best_quality_acc_by_backbone_block)
     batch_graph_hashes = [
         entry["graph_info"].graph_hash if entry.get("graph_info") and entry["graph_info"].parse_ok else "incomplete"
         for entry in entries
@@ -4454,6 +5621,14 @@ def _score_reward_entries(
         _entry_cnn_signature(entry)
         for entry in entries
     ]
+    batch_block_signatures = [
+        _entry_block_signature(entry)
+        for entry in entries
+    ]
+    batch_backbone_block_signatures = [
+        _backbone_block_pair_key(backbone_signature, block_signature)
+        for backbone_signature, block_signature in zip(batch_backbone_signatures, batch_block_signatures)
+    ]
     scored_results: List[Dict[str, Any]] = []
 
     for position, entry in enumerate(entries):
@@ -4471,12 +5646,19 @@ def _score_reward_entries(
                 batch_descriptor_keys=batch_descriptor_keys,
                 batch_backbone_signatures=batch_backbone_signatures,
                 batch_cnn_signatures=batch_cnn_signatures,
+                batch_block_signatures=batch_block_signatures,
+                batch_backbone_block_signatures=batch_backbone_block_signatures,
                 prompt_goal_tags=entry.get("prompt_goal_tags"),
+                prompt_target_pattern=entry.get("prompt_target_pattern", ""),
                 archive_snapshot_family_counts=archive_snapshot_family_counts,
                 archive_snapshot_descriptor_counts=archive_snapshot_descriptor_counts,
                 archive_snapshot_backbone_signature_counts=archive_snapshot_backbone_signature_counts,
                 archive_snapshot_cnn_signature_counts=archive_snapshot_cnn_signature_counts,
+                archive_snapshot_graph_counts=archive_snapshot_graph_counts,
+                archive_snapshot_block_signature_counts=archive_snapshot_block_signature_counts,
                 archive_snapshot_backbone_cnn_pair_counts=archive_snapshot_backbone_cnn_pair_counts,
+                archive_snapshot_backbone_block_pair_counts=archive_snapshot_backbone_block_pair_counts,
+                archive_snapshot_backbone_block_best_quality=archive_snapshot_backbone_block_best_quality,
                 group_baseline_train_acc=group_context["group_baseline_train_acc"],
                 group_baseline_reward_target_acc=group_context["group_baseline_reward_target_acc"],
                 reward_batch_index=group_context["reward_batch_index"],
@@ -4543,11 +5725,16 @@ def _finalize_scored_results(scored_results: List[Dict[str, Any]]) -> None:
         sig = res.get("signature", "unknown")
         backbone_signature = _result_backbone_signature(res)
         cnn_signature = _result_cnn_signature(res, graph_info)
+        block_signature = _result_block_signature(res, completion)
         backbone_cnn_pair_key = _backbone_cnn_pair_key(backbone_signature, cnn_signature)
+        backbone_block_pair_key = _backbone_block_pair_key(backbone_signature, block_signature)
 
         is_executable = _is_executable_candidate(res, graph_info)
         is_trainable = _is_trainable_candidate(res, graph_info)
         reward_target_value = _result_reward_target_value(res)
+        quality_acc_value = _optional_float(res.get("frozen_test_acc"))
+        if quality_acc_value is None:
+            quality_acc_value = _optional_float(reward_target_value)
         if reward_target_value is not None:
             current_batch_results.append(res)
         if is_executable:
@@ -4563,8 +5750,17 @@ def _finalize_scored_results(scored_results: List[Dict[str, Any]]) -> None:
                 backbone_signature_archive_counts[backbone_signature] += 1
             if cnn_signature:
                 cnn_signature_archive_counts[cnn_signature] += 1
+            if block_signature and block_signature != "incomplete_block":
+                block_signature_archive_counts[block_signature] += 1
             if backbone_signature and cnn_signature:
                 backbone_cnn_pair_archive_counts[backbone_cnn_pair_key] += 1
+            if backbone_signature and block_signature and block_signature != "incomplete_block":
+                backbone_block_pair_archive_counts[backbone_block_pair_key] += 1
+                if is_trainable and quality_acc_value is not None:
+                    best_quality_acc_by_backbone_block[backbone_block_pair_key] = max(
+                        float(best_quality_acc_by_backbone_block.get(backbone_block_pair_key, float("-inf"))),
+                        float(quality_acc_value),
+                    )
             motif_name_counts[res.get("pattern_name", graph_info.suggested_pattern_name)] += 1
             get_goal_counter(goal_graph_archive_counts, goal_key)[graph_info.graph_hash] += 1
             get_goal_counter(goal_family_hash_archive_counts, goal_key)[graph_info.family_hash] += 1
@@ -4634,6 +5830,8 @@ def _finalize_scored_results(scored_results: List[Dict[str, Any]]) -> None:
                     float(saved_best_reward_target_by_backbone_cnn.get(backbone_cnn_pair_key, float("-inf"))),
                     float(reward_target_value if reward_target_value is not None else float("-inf")),
                 )
+            if backbone_signature and block_signature and block_signature != "incomplete_block":
+                saved_backbone_block_pair_counts[backbone_block_pair_key] += 1
             get_goal_counter(saved_goal_family_hash_counts, goal_key)[graph_info.family_hash] += 1
             B_index += 1
         elif (
@@ -4662,7 +5860,9 @@ def _finalize_scored_results(scored_results: List[Dict[str, Any]]) -> None:
                 "descriptor_key": str(res.get("descriptor_key") or getattr(graph_info, "descriptor_key", "") or ""),
                 "backbone_signature": backbone_signature,
                 "cnn_signature": cnn_signature,
+                "block_signature": block_signature,
                 "backbone_cnn_pair_key": backbone_cnn_pair_key,
+                "backbone_block_pair_key": backbone_block_pair_key,
                 "reward": score,
                 "reward_target_metric": str(res.get("reward_target_metric") or ""),
                 "reward_target_value": reward_target_value,
@@ -4709,7 +5909,9 @@ def _print_discovery_metrics() -> None:
     unique_descriptors = len(descriptor_archive_counts)
     unique_backbones = len(backbone_signature_archive_counts)
     unique_cnns = len(cnn_signature_archive_counts)
+    unique_blocks = len(block_signature_archive_counts)
     unique_backbone_cnn_pairs = len(backbone_cnn_pair_archive_counts)
+    unique_backbone_block_pairs = len(backbone_block_pair_archive_counts)
 
     if total_valid > 0:
         most_common_count = family_hash_archive_counts.most_common(1)[0][1]
@@ -4727,7 +5929,8 @@ def _print_discovery_metrics() -> None:
     print(
         f"\n[Discovery Metrics] Unique Graphs: {unique_count}, "
         f"Families: {unique_families}, Skeletons: {unique_skeletons}, Descriptors: {unique_descriptors}, "
-        f"Backbone Buckets: {unique_backbones}, CNN Signatures: {unique_cnns}, Backbone+CNN Pairs: {unique_backbone_cnn_pairs}, "
+        f"Backbone Buckets: {unique_backbones}, CNN Signatures: {unique_cnns}, Block Signatures: {unique_blocks}, "
+        f"Backbone+CNN Pairs: {unique_backbone_cnn_pairs}, Backbone+Block Cells: {unique_backbone_block_pairs}, "
         f"Dominant Family Share: {dominant_share:.2%}, Entropy: {entropy:.2f}"
     )
     print(f"[Graph Archive] Top 5 Exact Graphs: {dict(graph_archive_counts.most_common(5))}")
@@ -4736,7 +5939,9 @@ def _print_discovery_metrics() -> None:
     print(f"[Descriptor Archive] Top 5: {dict(descriptor_archive_counts.most_common(5))}")
     print(f"[Backbone Archive] Top 5: {dict(backbone_signature_archive_counts.most_common(5))}")
     print(f"[CNN Archive] Top 5: {dict(cnn_signature_archive_counts.most_common(5))}")
+    print(f"[Block Archive] Top 5: {dict(block_signature_archive_counts.most_common(5))}")
     print(f"[Backbone+CNN Archive] Top 5: {dict(backbone_cnn_pair_archive_counts.most_common(5))}")
+    print(f"[Backbone+Block Archive] Top 5: {dict(backbone_block_pair_archive_counts.most_common(5))}")
     print(f"[Motif Names] Top 5: {dict(motif_name_counts.most_common(5))}")
     goal_summary = {
         goal_key: len(counter)
@@ -4947,13 +6152,14 @@ def load_rl_dataset(tokenizer):
             })
 
     rl_dataset = Dataset.from_list(prompts)
-    return rl_dataset.shuffle(seed=42)
+    return rl_dataset.shuffle(seed=resolve_rl_seed())
 
 def main():
     global active_rl_model
     global active_rl_tokenizer
     global current_stage_name
 
+    apply_rl_seed()
     torch.cuda.empty_cache()
     resume_checkpoint_dir = _resolve_resume_checkpoint_dir()
     resume_manifest = None
@@ -4970,13 +6176,7 @@ def main():
             legacy_state_filenames=("reward_state.json",),
         )
         if resume_stage_override:
-            current_state_stage = str(current_stage_name)
-            if current_state_stage != resume_stage_override:
-                print(
-                    "[RL] Resume stage override "
-                    f"checkpoint_stage={current_state_stage} requested_stage={resume_stage_override}"
-                )
-                current_stage_name = resume_stage_override
+            apply_resume_stage_override(resume_stage_override, log_prefix="[RL]")
         print(
             "[RL] Resuming from checkpoint "
             f"dir={resume_checkpoint_dir} stage={current_stage_name} "
@@ -4990,6 +6190,8 @@ def main():
             _reward_runtime_hooks(),
             legacy_state_filenames=("reward_state.json",),
         )
+        if resume_stage_override:
+            apply_resume_stage_override(resume_stage_override, log_prefix="[RL]")
     precision = best_mixed_precision()
     runtime = get_distributed_runtime_info()
     runtime_settings = resolve_rl_runtime_settings(runtime)

--- a/ab/gpt/TuneRLSft.py
+++ b/ab/gpt/TuneRLSft.py
@@ -1,46 +1,79 @@
 import json
 import os
+import re
 import shutil
 import random
 import inspect
+import subprocess
 import sys
 import tempfile
 import time
+import traceback
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 from torch.utils.data import Dataset as TorchDataset
 from ab.gpt.util.Const import conf_dir
 
+try:
+    import faulthandler
+
+    faulthandler.enable(all_threads=True)
+except Exception:
+    pass
+
 
 # ── SFT runtime configuration ─────────────────────────────────────────────
-SFT_BASE_MODEL_ID = "ABrain/NNGPT-Backbone-deepseek-coder-6.7b-instruct"
+SFT_BASE_MODEL_ID = "deepseek-ai/deepseek-coder-6.7b-instruct"
 SFT_INIT_ADAPTER = ""
 SFT_LOAD_INITIAL_ADAPTER = False
+SFT_INITIAL_ADAPTER_MODE = "trainable"
+SFT_INITIAL_ADAPTER_DTYPE = "fp32"
 SFT_SAVE_RL_MODEL = False
 SFT_MODEL_OUT = "rl_backbone_model_sft"
 SFT_LOG_DIR = "rl_output/sft"
 SFT_EPOCH_ROOT = "out/nngpt/llm/epoch_sft"
 SFT_TRAINER_OUT = "grpo_backbone_outputs/sft"
-SFT_TEMPERATURE = 1.1
+SFT_TEMPERATURE = 0.8
+SFT_TOP_P = 0.95
+SFT_TOP_K = 50
 SFT_NUM_GENERATIONS = 8
 SFT_GRAD_ACCUM = 8
-SFT_MAX_COMPLETION_LENGTH = 1536
+SFT_MAX_PROMPT_LENGTH = 3500
+SFT_MAX_COMPLETION_LENGTH = 1200
+SFT_GENERATION_BATCH_SIZE = 8
+SFT_MAX_STEPS = 125
 SFT_DATASET_LIMIT = 500
-SFT_FEEDBACK_CHAR_BUDGET = 1200
+SFT_FEEDBACK_CHAR_BUDGET = 0
 SFT_LR = 5e-5
 SFT_NUM_EPOCHS = 5
-SFT_KL_COEF = 5e-4
+SFT_SAVE_STEPS = 25
+SFT_KL_COEF = 0.04
 SFT_LORA_R = 16
 SFT_LORA_ALPHA = 32
 SFT_LORA_DROPOUT = 0.05
+SFT_RL_NN_PREFIXES = ("rl-bb-test1",)
+SFT_RL_PROMPT_MODE = "sft_aligned"
+SFT_RL_RESUME_STAGE = "stage2_formal_explore"
+SFT_FORMAL_REWARD_EPOCHS = "1"
 SFT_DEEPSPEED_DEFAULT_CONFIG = str(conf_dir / "DeepSpeedSftGrpo.json")
 SFT_MODE_DEFAULT = "auto"
+SFT_REWARD_EXCLUDE_TRAIN_GPU = False
+SFT_COMPACT_AFTER_MODEL_LOAD = False
+SFT_COMPACT_FLOAT_PARAMS = False
+SFT_LENGTH_SOFT_TOKEN_LIMIT = 850
+SFT_LENGTH_HARD_TOKEN_LIMIT = 1000
+SFT_LENGTH_FAILURE_TOKEN_LIMIT = 1200
+SFT_LENGTH_SOFT_PENALTY = 0.05
+SFT_LENGTH_HARD_EXTRA_PENALTY = 0.20
+SFT_REPEAT_LINE_PENALTY = 0.03
+SFT_REPEAT_LINE_MAX_PENALTY = 0.15
+SFT_RUNTIME_SOURCE_INFO: Dict[str, str] = {}
 
 # CIFAR-10 reward evaluation via nn-dataset / NNEval-aligned formal acc.
 SFT_EVAL_IMAGE_SIZE = 128
 SFT_EVAL_BATCH_SIZE = 64
-SFT_EVAL_TRAIN_SUBSET = 256
-SFT_EVAL_VAL_SUBSET = 128
+SFT_EVAL_TRAIN_SUBSET = 0
+SFT_EVAL_VAL_SUBSET = 0
 SFT_EVAL_TRAIN_EPOCHS = 1
 SFT_EVAL_VAL_BATCHES = 2
 SFT_EVAL_FULL_TEST_ACC = True
@@ -49,21 +82,22 @@ SFT_EVAL_LIMIT_SECONDS = 900
 SFT_EVAL_FORMAL_EPOCH_LIMIT_MINUTES = 30
 SFT_EVAL_DATA_ROOT = "data_v2"
 SFT_EVAL_DOWNLOAD = True
+SFT_EVAL_SPLIT_PROTOCOL = "trainvaltest"
+SFT_EVAL_SPLIT_SEED = 42
+SFT_EVAL_SPLIT_ROLE = "reward_eval"
 SFT_VAL_METRIC_BASELINE = 0.10
-
-# Local desktop cache roots.
-# Keep this block on the local machine if you want Hugging Face downloads/cache on
-# the mounted disk. On the server, if the model is already placed under
-# `out/llm/ABrain/NNGPT-Backbone-deepseek-coder-6.7b-instruct`, you can comment
-# out this whole block and the script will still load from `out/llm` first.
-# SFT_HF_HOME = "/media/xi/Data/hf-cache"
-# SFT_HF_HUB_CACHE = "/media/xi/Data/hf-cache/hub"
-# SFT_TRANSFORMERS_CACHE = "/media/xi/Data/hf-cache/transformers"
-
-# os.environ["HF_HOME"] = SFT_HF_HOME
-# os.environ["HF_HUB_CACHE"] = SFT_HF_HUB_CACHE
-# os.environ["HUGGINGFACE_HUB_CACHE"] = SFT_HF_HUB_CACHE
-# os.environ["TRANSFORMERS_CACHE"] = SFT_TRANSFORMERS_CACHE
+SFT_FORMAL_DATASET_CLASS_COUNTS = {
+    "cifar-10": 10,
+    "cifar-100": 100,
+    "imagenette": 10,
+}
+SFT_FORMAL_DATASET_ALIASES = {
+    "cifar10": "cifar-10",
+    "cifar-10": "cifar-10",
+    "cifar100": "cifar-100",
+    "cifar-100": "cifar-100",
+    "imagenette": "imagenette",
+}
 
 import ab.gpt.TuneRL as TuneRL
 from ab.gpt.rl_pipeline.completion import (
@@ -86,6 +120,140 @@ _TRAIN_GPU_TOKENS_ENV = "NNGPT_TRAIN_GPU_TOKENS"
 _AUX_GPU_TOKENS_ENV = "NNGPT_AUX_GPU_TOKENS"
 _REWARD_GPU_TOKENS_ENV = "NNGPT_REWARD_GPU_TOKENS"
 
+
+def normalize_sft_formal_dataset(dataset: str | None = None) -> str:
+    raw = str(dataset or os.getenv("NNGPT_RL_FORMAL_DATASET", "cifar-10")).strip().lower()
+    if raw not in SFT_FORMAL_DATASET_ALIASES:
+        allowed = ", ".join(sorted(SFT_FORMAL_DATASET_CLASS_COUNTS))
+        raise ValueError(f"Unsupported NNGPT_RL_FORMAL_DATASET={raw!r}; expected one of: {allowed}")
+    return SFT_FORMAL_DATASET_ALIASES[raw]
+
+
+def resolve_sft_formal_dataset() -> str:
+    return normalize_sft_formal_dataset()
+
+
+def resolve_sft_formal_n_classes(dataset: str | None = None) -> int:
+    return int(SFT_FORMAL_DATASET_CLASS_COUNTS[normalize_sft_formal_dataset(dataset)])
+
+
+def resolve_sft_formal_out_shape(dataset: str | None = None) -> tuple[int, ...]:
+    return (resolve_sft_formal_n_classes(dataset),)
+
+
+def _normalize_sft_eval_split_protocol(split_protocol: str | None) -> str:
+    normalized = str(split_protocol or "").strip().lower().replace("-", "").replace("_", "").replace(" ", "")
+    if normalized in {
+        "721",
+        "7/2/1",
+        "702010",
+        "70/20/10",
+        "trainval",
+        "trainvaltest",
+        "trainvaltestsplit",
+    }:
+        return "trainvaltest"
+    return "official"
+
+
+def _describe_sft_eval_split(formal_dataset: str, split_protocol: str) -> tuple[str, str, str]:
+    dataset = normalize_sft_formal_dataset(formal_dataset)
+    if _normalize_sft_eval_split_protocol(split_protocol) == "trainvaltest":
+        if dataset == "cifar-10":
+            return "cifar10-train[45k]", "cifar10-train[5k]", "cifar10-test[10k]"
+        if dataset == "cifar-100":
+            return "cifar100-train[45k]", "cifar100-train[5k]", "cifar100-test[10k]"
+        if dataset == "imagenette":
+            return "imagenette-train[7500]", "imagenette-train[1969]", "imagenette-test[3925]"
+    return "official-train", "official-test", "none"
+
+
+def _stage1_fixed_failure_reward(res: Dict[str, Any], meta: Dict[str, Any], graph_info) -> Optional[float]:
+    if str(res.get("current_stage_name") or "") != TuneRL.STAGE1_STRUCTURE_EXPLORE:
+        return None
+    if TuneRL._is_trainable_candidate(res, graph_info):
+        return None
+
+    if (
+        not meta.get("xml_tag_exact")
+        or int(meta.get("xml_tag_count", 0) or 0) < 3
+        or int(meta.get("class_count", 0) or 0) > 0
+        or int(meta.get("import_count", 0) or 0) > 0
+        or int(meta.get("bad_signature_count", 0) or 0) > 0
+        or not meta.get("dual_backbone_ok")
+        or not res.get("built_ok")
+    ):
+        return -3.0
+    if not res.get("forward_ok") or not res.get("forward_shape_ok"):
+        return -1.0
+    return -0.25
+
+
+def _estimate_completion_tokens(completion: str) -> tuple[int, str]:
+    tokenizer = getattr(TuneRL, "active_rl_tokenizer", None)
+    if tokenizer is not None:
+        try:
+            tokenized = tokenizer(completion, add_special_tokens=False)
+            return int(len(tokenized.input_ids)), "tokenizer"
+        except Exception:
+            pass
+    return int(max(1, round(len(completion) / 2.4))), "char_estimate"
+
+
+def _count_repeated_code_lines(completion: str) -> tuple[int, int]:
+    counts: Dict[str, int] = {}
+    for raw_line in completion.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("<") or len(line) < 12:
+            continue
+        line = re.sub(r"\s+", " ", line)
+        counts[line] = counts.get(line, 0) + 1
+    repeated_groups = sum(1 for value in counts.values() if value >= 3)
+    repeated_excess = sum(value - 2 for value in counts.values() if value >= 3)
+    return repeated_groups, repeated_excess
+
+
+def _completion_compactness_penalty(completion: str, meta: Dict[str, Any]) -> Dict[str, Any]:
+    token_count, token_count_source = _estimate_completion_tokens(completion)
+    soft_limit = max(1, _env_int("NNGPT_SFT_LENGTH_SOFT_TOKEN_LIMIT", SFT_LENGTH_SOFT_TOKEN_LIMIT))
+    hard_limit = max(soft_limit + 1, _env_int("NNGPT_SFT_LENGTH_HARD_TOKEN_LIMIT", SFT_LENGTH_HARD_TOKEN_LIMIT))
+    failure_limit = max(hard_limit + 1, _env_int("NNGPT_SFT_LENGTH_FAILURE_TOKEN_LIMIT", SFT_LENGTH_FAILURE_TOKEN_LIMIT))
+    soft_penalty = max(0.0, _env_float("NNGPT_SFT_LENGTH_SOFT_PENALTY", SFT_LENGTH_SOFT_PENALTY))
+    hard_extra_penalty = max(
+        0.0,
+        _env_float("NNGPT_SFT_LENGTH_HARD_EXTRA_PENALTY", SFT_LENGTH_HARD_EXTRA_PENALTY),
+    )
+    repeat_unit = max(0.0, _env_float("NNGPT_SFT_REPEAT_LINE_PENALTY", SFT_REPEAT_LINE_PENALTY))
+    repeat_cap = max(0.0, _env_float("NNGPT_SFT_REPEAT_LINE_MAX_PENALTY", SFT_REPEAT_LINE_MAX_PENALTY))
+
+    length_penalty = 0.0
+    if token_count > soft_limit:
+        if token_count <= hard_limit:
+            length_penalty = -soft_penalty * ((token_count - soft_limit) / float(hard_limit - soft_limit))
+        else:
+            hard_span = max(1, failure_limit - hard_limit)
+            length_penalty = -soft_penalty - hard_extra_penalty * min(
+                1.0,
+                (token_count - hard_limit) / float(hard_span),
+            )
+
+    repeated_groups, repeated_excess = _count_repeated_code_lines(completion)
+    repeated_line_penalty = -min(repeat_cap, repeat_unit * repeated_excess)
+    xml_incomplete_length_cap = bool(token_count > failure_limit and not meta.get("xml_tag_exact"))
+    return {
+        "completion_token_count": token_count,
+        "completion_token_count_source": token_count_source,
+        "completion_length_soft_limit": soft_limit,
+        "completion_length_hard_limit": hard_limit,
+        "completion_length_failure_limit": failure_limit,
+        "repeated_line_groups": repeated_groups,
+        "repeated_line_excess": repeated_excess,
+        "r_length_compactness": length_penalty,
+        "r_repeated_line_penalty": repeated_line_penalty,
+        "xml_incomplete_length_cap": xml_incomplete_length_cap,
+    }
+
+
 def raw_reward_fn(
     completion: str,
     *,
@@ -97,12 +265,19 @@ def raw_reward_fn(
     batch_descriptor_keys: List[str] = None,
     batch_backbone_signatures: List[str] = None,
     batch_cnn_signatures: List[str] = None,
+    batch_block_signatures: List[str] = None,
+    batch_backbone_block_signatures: List[str] = None,
     prompt_goal_tags: List[str] = None,
+    prompt_target_pattern: str = "",
     archive_snapshot_family_counts: Dict[str, int] = None,
     archive_snapshot_descriptor_counts: Dict[str, int] = None,
     archive_snapshot_backbone_signature_counts: Dict[str, int] = None,
     archive_snapshot_cnn_signature_counts: Dict[str, int] = None,
+    archive_snapshot_graph_counts: Dict[str, int] = None,
+    archive_snapshot_block_signature_counts: Dict[str, int] = None,
     archive_snapshot_backbone_cnn_pair_counts: Dict[str, int] = None,
+    archive_snapshot_backbone_block_pair_counts: Dict[str, int] = None,
+    archive_snapshot_backbone_block_best_quality: Dict[str, float] = None,
     group_baseline_train_acc: float | None = None,
     group_baseline_reward_target_acc: float | None = None,
     reward_batch_index: int | None = None,
@@ -121,12 +296,19 @@ def raw_reward_fn(
         batch_descriptor_keys=batch_descriptor_keys,
         batch_backbone_signatures=batch_backbone_signatures,
         batch_cnn_signatures=batch_cnn_signatures,
+        batch_block_signatures=batch_block_signatures,
+        batch_backbone_block_signatures=batch_backbone_block_signatures,
         prompt_goal_tags=prompt_goal_tags,
+        prompt_target_pattern=prompt_target_pattern,
         archive_snapshot_family_counts=archive_snapshot_family_counts,
         archive_snapshot_descriptor_counts=archive_snapshot_descriptor_counts,
         archive_snapshot_backbone_signature_counts=archive_snapshot_backbone_signature_counts,
         archive_snapshot_cnn_signature_counts=archive_snapshot_cnn_signature_counts,
+        archive_snapshot_graph_counts=archive_snapshot_graph_counts,
+        archive_snapshot_block_signature_counts=archive_snapshot_block_signature_counts,
         archive_snapshot_backbone_cnn_pair_counts=archive_snapshot_backbone_cnn_pair_counts,
+        archive_snapshot_backbone_block_pair_counts=archive_snapshot_backbone_block_pair_counts,
+        archive_snapshot_backbone_block_best_quality=archive_snapshot_backbone_block_best_quality,
         group_baseline_train_acc=group_baseline_train_acc,
         group_baseline_reward_target_acc=group_baseline_reward_target_acc,
         reward_batch_index=reward_batch_index,
@@ -154,6 +336,16 @@ def raw_reward_fn(
     if not meta.get("exact_forward_signature"):
         raw_delta -= 0.60
 
+    terminal_penalty = 0.0
+    if meta.get("trailing_after_forward"):
+        terminal_penalty -= 0.20
+        if int(meta.get("trailing_after_forward_chars", 0) or 0) > 300:
+            terminal_penalty -= 0.10
+    jupyter_artifact_count = int(meta.get("jupyter_artifact_count", 0) or 0)
+    if jupyter_artifact_count:
+        terminal_penalty -= 0.25 * min(jupyter_artifact_count, 2)
+    raw_delta += terminal_penalty
+
     if meta.get("dual_backbone_ok"):
         raw_delta += 0.45
     else:
@@ -161,6 +353,16 @@ def raw_reward_fn(
             raw_delta -= 1.75
         if not meta.get("dual_backbone_forward_ok"):
             raw_delta -= 1.75
+
+    shape_contract_delta = 0.0
+    if str(res.get("current_stage_name") or TuneRL.current_stage_name) != TuneRL.STAGE1_STRUCTURE_EXPLORE:
+        if res.get("built_ok") and res.get("forward_ok") and res.get("forward_shape_ok"):
+            shape_contract_delta = 0.12
+        elif res.get("built_ok") and res.get("forward_ok"):
+            shape_contract_delta = -0.12
+        elif res.get("built_ok"):
+            shape_contract_delta = -0.08
+    raw_delta += shape_contract_delta
 
     res["reward"] = TuneRL._apply_trainability_clamp(
         res,
@@ -188,12 +390,43 @@ def raw_reward_fn(
 
     if not meta.get("dual_backbone_ok"):
         res["reward"] = min(float(res["reward"]), -3.5)
-    elif group_warmup and TuneRL._is_trainable_candidate(res, graph_info):
-        res["reward"] = float(res.get("warmup_dense_reward") or 0.0)
+    elif group_warmup:
+        if TuneRL._is_trainable_candidate(res, graph_info):
+            res["reward"] = float(res.get("warmup_dense_reward") or 0.0)
+        else:
+            res["reward"] = -float(res.get("warmup_dense_reward") or 0.18)
+
+    fixed_failure_reward = _stage1_fixed_failure_reward(res, meta, graph_info)
+    if fixed_failure_reward is not None:
+        res["reward"] = fixed_failure_reward
+        res["stage1_fixed_failure_reward"] = True
+    elif str(res.get("current_stage_name") or "") == TuneRL.STAGE1_STRUCTURE_EXPLORE:
+        if TuneRL._is_trainable_candidate(res, graph_info):
+            trainability_bonus = 0.10
+            res["reward"] = float(res["reward"]) + trainability_bonus
+            res["stage1_trainability_bonus"] = trainability_bonus
+
+    compactness = _completion_compactness_penalty(completion, meta)
+    res.update(compactness)
+    res["reward"] = (
+        float(res.get("reward", -2.0))
+        + float(compactness["r_length_compactness"])
+        + float(compactness["r_repeated_line_penalty"])
+    )
+    if compactness["xml_incomplete_length_cap"]:
+        res["reward"] = min(float(res["reward"]), -0.8)
+    if TuneRL._reward_variant_is_strong_repeat_penalty() and bool(res.get("strong_repeat_penalty_applied")):
+        res["reward"] = min(float(res["reward"]), 0.0)
+    res["reward"] = TuneRL._apply_target_structure_reward_gate(
+        res,
+        float(res.get("reward", -2.0)),
+    )
 
     res["raw_extraction"] = {
         **meta,
         "raw_delta": raw_delta,
+        "shape_contract_delta": shape_contract_delta,
+        "terminal_penalty": terminal_penalty,
     }
     res.setdefault("backbone_model_names", list(meta.get("backbone_model_names", [])))
     return res
@@ -214,6 +447,14 @@ def _repo_model_dir(model_id: str) -> Path:
 
 def _repo_tokenizer_dir(model_id: str) -> Path:
     return Path("out/tokenizer") / model_id
+
+
+def resolve_sft_base_model_id() -> str:
+    return _env_str("NNGPT_SFT_BASE_MODEL_ID", SFT_BASE_MODEL_ID)
+
+
+def resolve_sft_tokenizer_id() -> str:
+    return _env_str("NNGPT_SFT_TOKENIZER_ID", "")
 
 
 def _has_model_files(model_dir: Path) -> bool:
@@ -247,20 +488,46 @@ def _has_tokenizer_files(tokenizer_dir: Path) -> bool:
 
 
 def resolve_sft_model_sources() -> tuple[str, str, str]:
-    repo_model_dir = _repo_model_dir(SFT_BASE_MODEL_ID)
-    repo_tokenizer_dir = _repo_tokenizer_dir(SFT_BASE_MODEL_ID)
+    base_model_id = resolve_sft_base_model_id()
+    tokenizer_id = resolve_sft_tokenizer_id()
+    base_model_path = Path(base_model_id).expanduser()
+    if base_model_path.is_dir():
+        if not _has_model_files(base_model_path):
+            raise RuntimeError(f"Configured SFT base model path has no model files: {base_model_path}")
+        if tokenizer_id:
+            tokenizer_path = Path(tokenizer_id).expanduser()
+            if tokenizer_path.is_dir():
+                if not _has_tokenizer_files(tokenizer_path):
+                    raise RuntimeError(f"Configured SFT tokenizer path has no tokenizer files: {tokenizer_path}")
+                return str(base_model_path), str(tokenizer_path), "explicit-path+explicit-tokenizer-path"
+            return str(base_model_path), tokenizer_id, "explicit-path+explicit-tokenizer-id"
+        if _has_tokenizer_files(base_model_path):
+            return str(base_model_path), str(base_model_path), "explicit-path"
+        out_llm_root = Path("out/llm").resolve()
+        try:
+            relative_model_id = str(base_model_path.resolve().relative_to(out_llm_root))
+        except ValueError:
+            relative_model_id = ""
+        if relative_model_id:
+            repo_tokenizer_dir = _repo_tokenizer_dir(relative_model_id)
+            if _has_tokenizer_files(repo_tokenizer_dir):
+                return str(base_model_path), str(repo_tokenizer_dir), "explicit-path+out/tokenizer"
+        raise RuntimeError(f"Configured SFT base model path has no tokenizer files: {base_model_path}")
+
+    repo_model_dir = _repo_model_dir(base_model_id)
+    repo_tokenizer_dir = _repo_tokenizer_dir(base_model_id)
 
     if _has_model_files(repo_model_dir):
         if _has_tokenizer_files(repo_model_dir):
             return str(repo_model_dir), str(repo_model_dir), "out/llm"
         if _has_tokenizer_files(repo_tokenizer_dir):
             return str(repo_model_dir), str(repo_tokenizer_dir), "out/llm+out/tokenizer"
-        return str(repo_model_dir), SFT_BASE_MODEL_ID, "out/llm+model-id-tokenizer"
+        return str(repo_model_dir), base_model_id, "out/llm+model-id-tokenizer"
 
     if _has_tokenizer_files(repo_tokenizer_dir):
-        return SFT_BASE_MODEL_ID, str(repo_tokenizer_dir), "model-id+out/tokenizer"
+        return base_model_id, str(repo_tokenizer_dir), "model-id+out/tokenizer"
 
-    return SFT_BASE_MODEL_ID, SFT_BASE_MODEL_ID, "model-id-download"
+    return base_model_id, base_model_id, "model-id-download"
 
 
 def _env_flag(name: str, default: bool = False) -> bool:
@@ -284,6 +551,13 @@ def _env_int(name: str, default: int) -> int:
     return int(raw)
 
 
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return float(default)
+    return float(raw)
+
+
 def _env_optional_int(name: str) -> int | None:
     raw = os.getenv(name)
     if raw is None or raw == "":
@@ -296,6 +570,10 @@ def _env_optional_json(name: str) -> Any | None:
     if raw is None or raw == "":
         return None
     return json.loads(raw)
+
+
+def resolve_sft_rl_seed() -> int:
+    return TuneRL.resolve_rl_seed()
 
 
 def _set_optional_grpo_config(
@@ -316,11 +594,108 @@ def resolve_sft_init_adapter() -> str:
 
 
 def resolve_sft_load_initial_adapter() -> bool:
-    return _env_flag("NNGPT_SFT_LOAD_INITIAL_ADAPTER", SFT_LOAD_INITIAL_ADAPTER)
+    raw = os.getenv("NNGPT_SFT_LOAD_INITIAL_ADAPTER")
+    if raw is not None and raw != "":
+        return _env_flag("NNGPT_SFT_LOAD_INITIAL_ADAPTER", SFT_LOAD_INITIAL_ADAPTER)
+    return bool(SFT_LOAD_INITIAL_ADAPTER or resolve_sft_init_adapter().strip())
+
+
+def resolve_sft_initial_adapter_mode() -> str:
+    mode = _env_str("NNGPT_SFT_INITIAL_ADAPTER_MODE", SFT_INITIAL_ADAPTER_MODE).strip().lower()
+    aliases = {
+        "train": "trainable",
+        "trainable": "trainable",
+        "peft": "trainable",
+        "peft_unmerged": "trainable",
+        "unmerged": "trainable",
+        "merge": "merge",
+        "merged": "merge",
+        "merge_and_unload": "merge",
+    }
+    if mode not in aliases:
+        raise ValueError("NNGPT_SFT_INITIAL_ADAPTER_MODE must be one of: trainable, merge")
+    return aliases[mode]
+
+
+def resolve_sft_initial_adapter_dtype_label() -> str:
+    raw = _env_str("NNGPT_SFT_INITIAL_ADAPTER_DTYPE", SFT_INITIAL_ADAPTER_DTYPE).strip().lower()
+    aliases = {
+        "": "fp32",
+        "float32": "fp32",
+        "fp32": "fp32",
+        "full": "fp32",
+        "float16": "fp16",
+        "fp16": "fp16",
+        "half": "fp16",
+        "bfloat16": "bf16",
+        "bf16": "bf16",
+        "mixed": "precision",
+        "precision": "precision",
+        "auto": "precision",
+    }
+    if raw not in aliases:
+        raise ValueError("NNGPT_SFT_INITIAL_ADAPTER_DTYPE must be one of: fp32, fp16, bf16, precision")
+    return aliases[raw]
+
+
+def resolve_sft_initial_adapter_dtype(label: str, precision: Dict[str, Any]) -> Any:
+    import torch
+
+    if label == "precision":
+        return precision["torch_dtype"]
+    if label == "fp32":
+        return torch.float32
+    if label == "fp16":
+        return torch.float16
+    if label == "bf16":
+        if torch.cuda.is_available() and not torch.cuda.is_bf16_supported():
+            raise RuntimeError("NNGPT_SFT_INITIAL_ADAPTER_DTYPE=bf16 requested, but CUDA bf16 is not supported.")
+        return torch.bfloat16
+    raise ValueError(f"Unsupported SFT initial adapter dtype label: {label}")
+
+
+def resolve_sft_rl_nn_prefixes() -> tuple[str, ...]:
+    raw = os.getenv("NNGPT_SFT_RL_NN_PREFIXES", "").strip()
+    if not raw:
+        return tuple(SFT_RL_NN_PREFIXES)
+    prefixes = tuple(item.strip() for item in raw.split(",") if item.strip())
+    if not prefixes:
+        raise ValueError("NNGPT_SFT_RL_NN_PREFIXES must contain at least one prefix")
+    return prefixes
+
+
+def resolve_sft_rl_prompt_mode() -> str:
+    mode = _env_str("NNGPT_SFT_RL_PROMPT_MODE", SFT_RL_PROMPT_MODE).strip().lower()
+    aliases = {
+        "sft": "sft_aligned",
+        "sft-aligned": "sft_aligned",
+        "sft_aligned": "sft_aligned",
+        "goal": "goal_profiles",
+        "goal-profile": "goal_profiles",
+        "goal_profiles": "goal_profiles",
+        "open_discovery": "goal_profiles",
+    }
+    if mode not in aliases:
+        raise ValueError(
+            "NNGPT_SFT_RL_PROMPT_MODE must be one of: sft_aligned, goal_profiles"
+        )
+    return aliases[mode]
 
 
 def resolve_sft_save_rl_model() -> bool:
     return _env_flag("NNGPT_SFT_SAVE_RL_MODEL", SFT_SAVE_RL_MODEL)
+
+
+def resolve_sft_temperature() -> float:
+    return _env_float("NNGPT_SFT_TEMPERATURE", SFT_TEMPERATURE)
+
+
+def resolve_sft_top_p() -> float:
+    return _env_float("NNGPT_SFT_TOP_P", SFT_TOP_P)
+
+
+def resolve_sft_top_k() -> int:
+    return _env_int("NNGPT_SFT_TOP_K", SFT_TOP_K)
 
 
 def resolve_sft_model_out() -> str:
@@ -344,7 +719,7 @@ def resolve_sft_num_epochs() -> int:
 
 
 def resolve_sft_save_steps() -> int:
-    return max(1, _env_int("NNGPT_SFT_SAVE_STEPS", 5))
+    return max(1, _env_int("NNGPT_SFT_SAVE_STEPS", SFT_SAVE_STEPS))
 
 
 def resolve_sft_save_total_limit() -> int:
@@ -381,6 +756,179 @@ def _runtime_is_main_process(runtime: Dict[str, Any]) -> bool:
     return int(runtime.get("rank", 0)) == 0
 
 
+def _run_git_command(*args: str) -> str:
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=Path(__file__).resolve().parents[2],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except Exception:
+        return ""
+    return proc.stdout.strip()
+
+
+def _sft_git_metadata() -> Dict[str, Any]:
+    return {
+        "commit": _run_git_command("rev-parse", "HEAD"),
+        "commit_short": _run_git_command("rev-parse", "--short", "HEAD"),
+        "commit_subject": _run_git_command("log", "-1", "--pretty=%s"),
+        "branch": _run_git_command("branch", "--show-current"),
+        "dirty": bool(_run_git_command("status", "--porcelain")),
+    }
+
+
+def _selected_env(names: List[str]) -> Dict[str, str]:
+    return {name: os.environ[name] for name in names if os.getenv(name) not in (None, "")}
+
+
+def _write_sft_run_config(
+    *,
+    runtime: Dict[str, Any],
+    runtime_settings: Dict[str, Any],
+    generation_kwargs: Dict[str, Any],
+    resume_spec: Dict[str, Any],
+    gpu_role_plan: Optional[Dict[str, Any]],
+    reward_worker_plan: Dict[str, Any],
+    use_deepspeed: bool,
+    deepspeed_config_path: Optional[str],
+    restored_runtime_state_path: Optional[Any],
+) -> None:
+    source_info = dict(SFT_RUNTIME_SOURCE_INFO)
+    reward_env_names = [
+        TuneRL.REWARD_VARIANT_ENV,
+        "NNGPT_RL_FORMAL_REWARD_EPOCHS",
+        "NNGPT_RL_FORMAL_DATASET",
+        "NNGPT_RL_RESUME_STAGE",
+        "NNGPT_RL_STAGE1_ONLY",
+        "NNGPT_RL_SEED",
+        "NNGPT_RL_KL_COEF",
+        "NNGPT_RL_FORMAL_EVAL_LIMIT_SECONDS",
+        "NNGPT_RL_FORMAL_EPOCH_LIMIT_MINUTES",
+    ]
+    sampling_env_names = [
+        "NNGPT_SFT_TEMPERATURE",
+        "NNGPT_SFT_TOP_P",
+        "NNGPT_SFT_TOP_K",
+        "NNGPT_SFT_NUM_GENERATIONS",
+        "NNGPT_SFT_MAX_STEPS",
+        "NNGPT_SFT_GENERATION_BATCH_SIZE",
+        "NNGPT_SFT_STEPS_PER_GENERATION",
+        "NNGPT_SFT_MAX_PROMPT_LENGTH",
+        "NNGPT_SFT_MAX_COMPLETION_LENGTH",
+        "NNGPT_SFT_GENERATION_KWARGS_JSON",
+        "NNGPT_SFT_STOP_AFTER_FORWARD_XML",
+    ]
+    adapter_env_names = [
+        "NNGPT_SFT_BASE_MODEL_ID",
+        "NNGPT_SFT_TOKENIZER_ID",
+        "NNGPT_SFT_LOAD_INITIAL_ADAPTER",
+        "NNGPT_SFT_INITIAL_ADAPTER_MODE",
+        "NNGPT_SFT_INITIAL_ADAPTER_DTYPE",
+        "NNGPT_SFT_INIT_ADAPTER",
+        "NNGPT_SFT_RESUME_TRAINER_CHECKPOINT",
+        "NNGPT_SFT_RESUME_STAGE_CHECKPOINT",
+    ]
+    archive_env_names = [
+        "NNGPT_SFT_LOG_DIR",
+        "NNGPT_SFT_MODEL_OUT",
+        "NNGPT_SFT_TRAINER_OUT",
+        "NNGPT_SFT_EPOCH_ROOT",
+        "NNGPT_SFT_APPEND_LOGS",
+    ]
+    split_protocol = _env_str("NNGPT_SFT_EVAL_SPLIT_PROTOCOL", SFT_EVAL_SPLIT_PROTOCOL)
+    split_seed = _env_int("NNGPT_SFT_EVAL_SPLIT_SEED", SFT_EVAL_SPLIT_SEED)
+    eval_split_role = _env_str("NNGPT_SFT_EVAL_SPLIT_ROLE", SFT_EVAL_SPLIT_ROLE)
+    formal_dataset = resolve_sft_formal_dataset()
+    formal_out_shape = resolve_sft_formal_out_shape(formal_dataset)
+    train_set_label, reward_eval_label, heldout_test_label = _describe_sft_eval_split(
+        formal_dataset,
+        split_protocol,
+    )
+    payload = {
+        "phase": "four_pattern_reward_ablation",
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "git": _sft_git_metadata(),
+        "model_source": source_info.get("model_source", TuneRL.base_model),
+        "tokenizer_source": source_info.get("tokenizer_source", getattr(TuneRL, "tokenizer_source", TuneRL.base_model)),
+        "source_mode": source_info.get("source_mode", ""),
+        "reward": {
+            "variant": TuneRL.resolve_reward_variant(),
+            "env": _selected_env(reward_env_names),
+            "formal_epochs": os.getenv("NNGPT_RL_FORMAL_REWARD_EPOCHS", SFT_FORMAL_REWARD_EPOCHS),
+        },
+        "init": {
+            "load_initial_adapter": resolve_sft_load_initial_adapter(),
+            "initial_adapter_mode": resolve_sft_initial_adapter_mode(),
+            "initial_adapter_dtype": resolve_sft_initial_adapter_dtype_label(),
+            "init_adapter": resolve_sft_init_adapter(),
+            "resume": resume_spec,
+            "restored_runtime_state_path": str(restored_runtime_state_path) if restored_runtime_state_path else None,
+            "adapter_env": _selected_env(adapter_env_names),
+        },
+        "sampling": {
+            "seed": resolve_sft_rl_seed(),
+            "temperature": resolve_sft_temperature(),
+            "top_p": resolve_sft_top_p(),
+            "top_k": resolve_sft_top_k(),
+            "runtime_settings": runtime_settings,
+            "generation_kwargs": generation_kwargs,
+            "env": _selected_env(sampling_env_names),
+        },
+        "prompt": {
+            "nn_prefixes": list(resolve_sft_rl_nn_prefixes()),
+            "prompt_mode": resolve_sft_rl_prompt_mode(),
+            "feedback_char_budget": _env_int("NNGPT_SFT_FEEDBACK_CHAR_BUDGET", SFT_FEEDBACK_CHAR_BUDGET),
+        },
+        "archive": {
+            "fresh": not bool(resume_spec.get("active")),
+            "append_logs": _env_flag("NNGPT_SFT_APPEND_LOGS", False),
+            "log_dir": resolve_sft_log_dir(),
+            "model_out": resolve_sft_model_out(),
+            "trainer_out": resolve_sft_trainer_out(),
+            "epoch_root": resolve_sft_epoch_root(),
+            "env": _selected_env(archive_env_names),
+        },
+        "evaluator": {
+            "dataset": formal_dataset,
+            "out_shape": list(formal_out_shape),
+            "n_classes": int(formal_out_shape[0]),
+            "transform": SFT_EVAL_TRANSFORM,
+            "resize": SFT_EVAL_IMAGE_SIZE,
+            "batch": SFT_EVAL_BATCH_SIZE,
+            "split_protocol": split_protocol,
+            "split_seed": split_seed,
+            "eval_split_role": eval_split_role,
+            "train_subset_size": SFT_EVAL_TRAIN_SUBSET,
+            "val_subset_size": SFT_EVAL_VAL_SUBSET,
+            "train_set": train_set_label,
+            "reward_eval_set": reward_eval_label,
+            "heldout_test_set": heldout_test_label,
+            "train_epochs": SFT_EVAL_TRAIN_EPOCHS,
+            "formal_epochs": os.getenv("NNGPT_RL_FORMAL_REWARD_EPOCHS", SFT_FORMAL_REWARD_EPOCHS),
+            "full_test_acc": SFT_EVAL_FULL_TEST_ACC,
+            "run_unfrozen": SFT_EVAL_RUN_UNFROZEN,
+            "worker_eval_limit_seconds": SFT_EVAL_LIMIT_SECONDS,
+            "formal_epoch_limit_minutes": SFT_EVAL_FORMAL_EPOCH_LIMIT_MINUTES,
+            "data_root": SFT_EVAL_DATA_ROOT,
+            "download": SFT_EVAL_DOWNLOAD,
+        },
+        "runtime": {
+            "distributed": runtime,
+            "gpu_role_plan": gpu_role_plan,
+            "reward_worker_plan": reward_worker_plan,
+            "use_deepspeed": use_deepspeed,
+            "deepspeed_config_path": deepspeed_config_path,
+        },
+    }
+    log_dir = Path(resolve_sft_log_dir())
+    log_dir.mkdir(parents=True, exist_ok=True)
+    with open(log_dir / "run_config.json", "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, ensure_ascii=False, sort_keys=True)
+
+
 def _resolved_visible_cuda_device_tokens(visible_cuda_devices: int) -> List[str]:
     raw = os.environ.get("CUDA_VISIBLE_DEVICES")
     if raw is not None:
@@ -405,7 +953,39 @@ def _resolve_sft_mode(visible_gpu_tokens: List[str]) -> Dict[str, str]:
     }
 
 
-def _configure_sft_gpu_role_env(visible_cuda_devices: int) -> Dict[str, List[str] | str]:
+def resolve_sft_reward_exclude_train_gpu() -> bool:
+    if "NNGPT_SFT_REWARD_EXCLUDE_TRAIN_GPU" not in os.environ and "NNGPT_RL_REWARD_EXCLUDE_TRAIN_GPU" in os.environ:
+        return _env_flag("NNGPT_RL_REWARD_EXCLUDE_TRAIN_GPU", SFT_REWARD_EXCLUDE_TRAIN_GPU)
+    return _env_flag("NNGPT_SFT_REWARD_EXCLUDE_TRAIN_GPU", SFT_REWARD_EXCLUDE_TRAIN_GPU)
+
+
+def resolve_sft_compact_after_model_load() -> bool:
+    return _env_flag("NNGPT_SFT_COMPACT_AFTER_MODEL_LOAD", SFT_COMPACT_AFTER_MODEL_LOAD)
+
+
+def resolve_sft_compact_float_params() -> bool:
+    return _env_flag("NNGPT_SFT_COMPACT_FLOAT_PARAMS", SFT_COMPACT_FLOAT_PARAMS)
+
+
+def _sft_reward_gpu_tokens_for_plan(
+    *,
+    resolved_mode: str,
+    visible_gpu_tokens: List[str],
+    train_gpu_tokens: List[str],
+    default_reward_gpu_tokens: List[str],
+) -> List[str]:
+    if resolved_mode != "split" or not resolve_sft_reward_exclude_train_gpu():
+        return list(default_reward_gpu_tokens)
+    reward_gpu_tokens = [token for token in visible_gpu_tokens if token not in set(train_gpu_tokens)]
+    if not reward_gpu_tokens:
+        raise RuntimeError(
+            "NNGPT_SFT_REWARD_EXCLUDE_TRAIN_GPU=1 requires at least one non-training GPU "
+            f"in split mode; visible_gpu_tokens={visible_gpu_tokens} train_gpu_tokens={train_gpu_tokens}"
+        )
+    return reward_gpu_tokens
+
+
+def _configure_sft_gpu_role_env(visible_cuda_devices: int) -> Dict[str, Any]:
     visible_gpu_tokens = _resolved_visible_cuda_device_tokens(visible_cuda_devices)
     role_plan = TrainingRuntime.resolve_role_plan(
         visible_gpu_tokens=visible_gpu_tokens,
@@ -413,7 +993,12 @@ def _configure_sft_gpu_role_env(visible_cuda_devices: int) -> Dict[str, List[str
         default_mode=SFT_MODE_DEFAULT,
     )
     train_gpu_tokens = list(role_plan.train_gpu_tokens)
-    reward_gpu_tokens = list(role_plan.aux_gpu_tokens)
+    reward_gpu_tokens = _sft_reward_gpu_tokens_for_plan(
+        resolved_mode=str(role_plan.resolved_mode),
+        visible_gpu_tokens=list(role_plan.visible_gpu_tokens),
+        train_gpu_tokens=train_gpu_tokens,
+        default_reward_gpu_tokens=list(role_plan.aux_gpu_tokens),
+    )
     if train_gpu_tokens:
         os.environ[_TRAIN_GPU_TOKENS_ENV] = ",".join(train_gpu_tokens)
     else:
@@ -430,6 +1015,7 @@ def _configure_sft_gpu_role_env(visible_cuda_devices: int) -> Dict[str, List[str
         "visible_gpu_tokens": list(role_plan.visible_gpu_tokens),
         "train_gpu_tokens": list(train_gpu_tokens),
         "reward_gpu_tokens": list(reward_gpu_tokens),
+        "reward_exclude_train_gpu": resolve_sft_reward_exclude_train_gpu(),
     }
 
 
@@ -565,6 +1151,10 @@ def resolve_sft_runtime_settings(runtime: Dict[str, Any]) -> Dict[str, int]:
             SFT_DATASET_LIMIT,
         ),
         "grad_accum": grad_accum,
+        "max_prompt_length": _env_int(
+            "NNGPT_SFT_MAX_PROMPT_LENGTH",
+            SFT_MAX_PROMPT_LENGTH,
+        ),
         "max_completion_length": _env_int(
             "NNGPT_SFT_MAX_COMPLETION_LENGTH",
             SFT_MAX_COMPLETION_LENGTH,
@@ -575,9 +1165,9 @@ def resolve_sft_runtime_settings(runtime: Dict[str, Any]) -> Dict[str, int]:
         "effective_global_num_generations": generation_plan["effective_global_num_generations"],
         "global_num_generations_adapted": generation_plan["global_num_generations_adapted"],
         "valid_generation_values": generation_plan["valid_generation_values"],
-        "generation_batch_size": _env_optional_int("NNGPT_SFT_GENERATION_BATCH_SIZE"),
+        "generation_batch_size": _env_int("NNGPT_SFT_GENERATION_BATCH_SIZE", SFT_GENERATION_BATCH_SIZE),
         "steps_per_generation": _env_optional_int("NNGPT_SFT_STEPS_PER_GENERATION"),
-        "max_steps": _env_optional_int("NNGPT_SFT_MAX_STEPS"),
+        "max_steps": _env_int("NNGPT_SFT_MAX_STEPS", SFT_MAX_STEPS),
     }
 
 
@@ -741,7 +1331,13 @@ def _validate_configured_gpu_role_tokens(runtime: Dict[str, Any]) -> Dict[str, A
     train_tokens = _configured_device_tokens(_TRAIN_GPU_TOKENS_ENV)
     reward_tokens = _configured_device_tokens(_REWARD_GPU_TOKENS_ENV)
     expected_train_tokens = visible_tokens[:1]
-    expected_reward_tokens = list(visible_tokens) if resolved_mode == "split" else list(expected_train_tokens)
+    default_reward_tokens = list(visible_tokens) if resolved_mode == "split" else list(expected_train_tokens)
+    expected_reward_tokens = _sft_reward_gpu_tokens_for_plan(
+        resolved_mode=resolved_mode,
+        visible_gpu_tokens=visible_tokens,
+        train_gpu_tokens=expected_train_tokens,
+        default_reward_gpu_tokens=default_reward_tokens,
+    )
     if train_tokens != expected_train_tokens:
         raise RuntimeError(
             "Invalid configured training GPU tokens for SFT mode: "
@@ -758,6 +1354,7 @@ def _validate_configured_gpu_role_tokens(runtime: Dict[str, Any]) -> Dict[str, A
         "visible_tokens": visible_tokens,
         "train_tokens": train_tokens,
         "reward_tokens": reward_tokens,
+        "reward_exclude_train_gpu": resolve_sft_reward_exclude_train_gpu(),
     }
 
 
@@ -795,7 +1392,7 @@ def evaluate_code_and_reward_cifar(
     *,
     stage_name=None,
     in_shape=(1, 3, 256, 256),
-    out_shape=(10,),
+    out_shape=None,
     prm=None,
     device: str = "cpu",
     val_metric_baseline=None,
@@ -827,11 +1424,12 @@ def evaluate_code_and_reward_cifar(
             cfg=cfg,
             device=eval_device,
         )
+        effective_out_shape = (int(cfg.n_classes),)
 
         return RewardUtil.evaluate_code_and_reward(
             code,
             in_shape=in_shape,
-            out_shape=out_shape,
+            out_shape=effective_out_shape,
             prm=prm,
             device=eval_device,
             val_metric_baseline=val_metric_baseline,
@@ -849,7 +1447,7 @@ def build_sft_reward_eval_cfg(
     *,
     stage_name=None,
     in_shape=(1, 3, 256, 256),
-    out_shape=(10,),
+    out_shape=None,
     prm=None,
     cfg=None,
     device=None,
@@ -871,20 +1469,25 @@ def build_sft_reward_eval_cfg(
     }
     prm = {**defaults, **prm}
     effective_stage_name = str(stage_name or TuneRL.current_stage_name)
+    formal_dataset = normalize_sft_formal_dataset(getattr(cfg, "formal_dataset", None))
+    effective_out_shape = resolve_sft_formal_out_shape(formal_dataset) if out_shape is None else tuple(out_shape)
+    if tuple(effective_out_shape) == (10,) and formal_dataset != "cifar-10":
+        effective_out_shape = resolve_sft_formal_out_shape(formal_dataset)
 
     if cfg is None:
         cfg = TuneRL.build_stage_eval_cfg(
             stage_name=effective_stage_name,
             in_shape=tuple(in_shape),
-            out_shape=tuple(out_shape),
+            out_shape=tuple(effective_out_shape),
             prm=prm,
             device=eval_device,
         )
 
+    effective_n_classes = resolve_sft_formal_n_classes(formal_dataset)
     return RewardUtil.EvalConfig(
         device=eval_device,
         input_shape=tuple(getattr(cfg, "input_shape", in_shape)),
-        n_classes=int(getattr(cfg, "n_classes", out_shape[0])),
+        n_classes=effective_n_classes,
         train_epochs=int(prm.get("epoch", getattr(cfg, "train_epochs", SFT_EVAL_TRAIN_EPOCHS)) or SFT_EVAL_TRAIN_EPOCHS),
         train_steps=getattr(cfg, "train_steps", None),
         max_val_batches=SFT_EVAL_VAL_BATCHES,
@@ -893,6 +1496,9 @@ def build_sft_reward_eval_cfg(
         val_subset_size=SFT_EVAL_VAL_SUBSET,
         data_root=SFT_EVAL_DATA_ROOT,
         download=SFT_EVAL_DOWNLOAD,
+        split_protocol=_env_str("NNGPT_SFT_EVAL_SPLIT_PROTOCOL", SFT_EVAL_SPLIT_PROTOCOL),
+        split_seed=_env_int("NNGPT_SFT_EVAL_SPLIT_SEED", SFT_EVAL_SPLIT_SEED),
+        eval_split_role=_env_str("NNGPT_SFT_EVAL_SPLIT_ROLE", SFT_EVAL_SPLIT_ROLE),
         measure_latency=getattr(cfg, "measure_latency", True),
         kl_div=getattr(cfg, "kl_div", None),
         critic_fn=getattr(cfg, "critic_fn", None),
@@ -905,7 +1511,7 @@ def build_sft_reward_eval_cfg(
         formal_nn_eval=getattr(cfg, "formal_nn_eval", False),
         static_only=getattr(cfg, "static_only", False),
         formal_task=getattr(cfg, "formal_task", "img-classification"),
-        formal_dataset=getattr(cfg, "formal_dataset", "cifar-10"),
+        formal_dataset=formal_dataset,
         formal_metric=getattr(cfg, "formal_metric", "acc"),
         formal_epoch_limit_minutes=getattr(
             cfg,
@@ -923,25 +1529,33 @@ def _is_trainable_architecture(res: Dict[str, Any], graph_info) -> bool:
         and res.get("built_ok")
         and res.get("forward_shape_ok")
         and res.get("backward_ok")
-        and res.get("loss_drop_ok")
     )
 
 
 def _reapply_trainability_clamp(res: Dict[str, Any], reward_value: float, graph_info) -> float:
     discovery_meta = res.get("open_discovery", {})
     parse_ok = bool(getattr(graph_info, "parse_ok", False) or discovery_meta.get("parse_ok", False))
+    stage_name = str(res.get("current_stage_name") or TuneRL.current_stage_name)
+    if (
+        stage_name == TuneRL.STAGE1_STRUCTURE_EXPLORE
+        and bool(res.get("static_only") or res.get("stage_uses_static_only"))
+    ):
+        reward_value = TuneRL._apply_executability_clamp(res, reward_value, graph_info)
+        if bool(res.get("forward_shape_ok")):
+            return max(reward_value, 0.05)
+        return reward_value
 
     if not parse_ok:
         reward_value = min(reward_value, -0.25)
     if not res.get("built_ok"):
         build_partial = float(res.get("r_build_partial", 0.0))
         reward_value = min(reward_value, -0.8 + build_partial)
+    elif not res.get("forward_ok"):
+        reward_value = min(reward_value, -0.40)
     elif not res.get("forward_shape_ok"):
-        reward_value = min(reward_value, -0.50)
+        reward_value = min(reward_value, -0.30)
     elif not res.get("backward_ok"):
         reward_value = min(reward_value, -0.10)
-    elif not res.get("loss_drop_ok"):
-        reward_value = min(reward_value, 0.0)
     return reward_value
 
 
@@ -956,12 +1570,19 @@ def sft_reward_fn(
     batch_descriptor_keys: List[str] = None,
     batch_backbone_signatures: List[str] = None,
     batch_cnn_signatures: List[str] = None,
+    batch_block_signatures: List[str] = None,
+    batch_backbone_block_signatures: List[str] = None,
     prompt_goal_tags: List[str] = None,
+    prompt_target_pattern: str = "",
     archive_snapshot_family_counts: Dict[str, int] = None,
     archive_snapshot_descriptor_counts: Dict[str, int] = None,
     archive_snapshot_backbone_signature_counts: Dict[str, int] = None,
     archive_snapshot_cnn_signature_counts: Dict[str, int] = None,
+    archive_snapshot_graph_counts: Dict[str, int] = None,
+    archive_snapshot_block_signature_counts: Dict[str, int] = None,
     archive_snapshot_backbone_cnn_pair_counts: Dict[str, int] = None,
+    archive_snapshot_backbone_block_pair_counts: Dict[str, int] = None,
+    archive_snapshot_backbone_block_best_quality: Dict[str, float] = None,
     group_baseline_train_acc: float | None = None,
     group_baseline_reward_target_acc: float | None = None,
     reward_batch_index: int | None = None,
@@ -980,12 +1601,19 @@ def sft_reward_fn(
         batch_descriptor_keys=batch_descriptor_keys,
         batch_backbone_signatures=batch_backbone_signatures,
         batch_cnn_signatures=batch_cnn_signatures,
+        batch_block_signatures=batch_block_signatures,
+        batch_backbone_block_signatures=batch_backbone_block_signatures,
         prompt_goal_tags=prompt_goal_tags,
+        prompt_target_pattern=prompt_target_pattern,
         archive_snapshot_family_counts=archive_snapshot_family_counts,
         archive_snapshot_descriptor_counts=archive_snapshot_descriptor_counts,
         archive_snapshot_backbone_signature_counts=archive_snapshot_backbone_signature_counts,
         archive_snapshot_cnn_signature_counts=archive_snapshot_cnn_signature_counts,
+        archive_snapshot_graph_counts=archive_snapshot_graph_counts,
+        archive_snapshot_block_signature_counts=archive_snapshot_block_signature_counts,
         archive_snapshot_backbone_cnn_pair_counts=archive_snapshot_backbone_cnn_pair_counts,
+        archive_snapshot_backbone_block_pair_counts=archive_snapshot_backbone_block_pair_counts,
+        archive_snapshot_backbone_block_best_quality=archive_snapshot_backbone_block_best_quality,
         group_baseline_train_acc=group_baseline_train_acc,
         group_baseline_reward_target_acc=group_baseline_reward_target_acc,
         reward_batch_index=reward_batch_index,
@@ -996,7 +1624,7 @@ def sft_reward_fn(
     )
     res["reward"] = _reapply_trainability_clamp(res, float(res.get("reward", -2.0)), graph_info)
     res["anti_collapse"] = {
-        "goal_key": TuneRL.primary_goal_key(prompt_goal_tags),
+        "goal_key": TuneRL.primary_goal_key(prompt_goal_tags, prompt_target_pattern),
         "trainable_ok": _is_trainable_architecture(res, graph_info),
         "anti_collapse_delta": 0.0,
     }
@@ -1007,7 +1635,15 @@ SFT_DISCOVERY_PROMPT_TEMPLATE = SFTUtil.open_discovery_rl_prompt_template
 
 
 class DynamicSFTPromptDataset(TorchDataset):
-    column_names = ["prompt", "accuracy", "goal_name", "target_tags", "goal_profile_id"]
+    column_names = [
+        "prompt",
+        "accuracy",
+        "goal_name",
+        "target_tags",
+        "goal_profile_id",
+        "target_pattern",
+        "prompt_mode",
+    ]
 
     def __init__(
         self,
@@ -1039,38 +1675,52 @@ class DynamicSFTPromptDataset(TorchDataset):
         )
 
     def _render_prompt(self, row: Dict[str, Any]) -> str:
-        profile = SFTUtil.open_discovery_goal_profiles[int(row["goal_profile_id"])]
-        target_pattern = SFTUtil.goal_profile_target_pattern(profile)
-        module_hints = (
-            "self.backbone_a",
-            "self.backbone_b",
-            *profile["module_hints"],
-        )
-        user_prompt = SFT_DISCOVERY_PROMPT_TEMPLATE.format(
-            accuracy=row["accuracy"],
-            skeleton_code=SFTUtil.open_discovery_skeleton_code,
-            available_backbones=", ".join(SFTUtil.available_backbones),
-            legacy_patterns=", ".join(SFTUtil.legacy_patterns),
-            goal_name=profile["name"],
-            target_tags=", ".join(profile["tags"]),
-            target_pattern=target_pattern,
-            design_brief=profile["brief"],
-            tag_realization=profile.get("realization", profile["brief"]),
-            goal_tag_parser_cues=SFTUtil.goal_tag_parser_cues(profile["tags"]),
-            module_hints=", ".join(module_hints),
-            block_signature=self.block_signature,
-            init_signature=self.init_signature,
-            forward_signature=self.forward_signature,
-        )
-        feedback_text = TuneRL.render_prompt_feedback_text(
-            feedback_char_budget=SFT_FEEDBACK_CHAR_BUDGET,
-        )
-        feedback_section = "\n\n### Current Optimization Feedback\n" + feedback_text.strip() + "\n"
-        marker = "### Output Requirement (STRICT)"
-        if marker in user_prompt:
-            user_prompt = user_prompt.replace(marker, feedback_section + "\n" + marker, 1)
+        prompt_mode = str(row.get("prompt_mode") or "goal_profiles")
+        if prompt_mode == "sft_aligned":
+            user_prompt = SFTUtil.format_backbone_prompt(
+                accuracy=row["accuracy"],
+                target_pattern=str(row["target_pattern"]),
+            )
         else:
-            user_prompt = user_prompt + feedback_section
+            profile = SFTUtil.open_discovery_goal_profiles[int(row["goal_profile_id"])]
+            target_pattern = SFTUtil.goal_profile_target_pattern(profile)
+            module_hints = (
+                "self.backbone_a",
+                "self.backbone_b",
+                *profile["module_hints"],
+            )
+            user_prompt = SFT_DISCOVERY_PROMPT_TEMPLATE.format(
+                accuracy=row["accuracy"],
+                skeleton_code=SFTUtil.open_discovery_skeleton_code,
+                available_backbones=", ".join(SFTUtil.available_backbones),
+                legacy_patterns=", ".join(SFTUtil.legacy_patterns),
+                goal_name=profile["name"],
+                target_tags=", ".join(profile["tags"]),
+                target_pattern=target_pattern,
+                design_brief=profile["brief"],
+                tag_realization=profile.get("realization", profile["brief"]),
+                goal_tag_parser_cues=SFTUtil.goal_tag_parser_cues(profile["tags"]),
+                module_hints=", ".join(module_hints),
+                block_signature=self.block_signature,
+                init_signature=self.init_signature,
+                forward_signature=self.forward_signature,
+            )
+        feedback_char_budget = _env_int("NNGPT_SFT_FEEDBACK_CHAR_BUDGET", SFT_FEEDBACK_CHAR_BUDGET)
+        if feedback_char_budget > 0:
+            feedback_text = TuneRL.render_prompt_feedback_text(
+                feedback_char_budget=feedback_char_budget,
+            )
+            feedback_section = "\n\n### Current Optimization Feedback\n" + feedback_text.strip() + "\n"
+            contract_heading = "\n### Completion Contract\n"
+            if contract_heading not in user_prompt:
+                contract_heading = "\n### Contract\n"
+            if contract_heading not in user_prompt:
+                raise RuntimeError("SFT RL prompt template is missing a contract heading")
+            user_prompt = user_prompt.replace(
+                contract_heading,
+                feedback_section + contract_heading,
+                1,
+            )
         messages = [{"role": "user", "content": user_prompt}]
         return self.tokenizer.apply_chat_template(
             messages,
@@ -1086,35 +1736,62 @@ class DynamicSFTPromptDataset(TorchDataset):
             "goal_name": row["goal_name"],
             "target_tags": row["target_tags"],
             "goal_profile_id": row["goal_profile_id"],
+            "target_pattern": row["target_pattern"],
+            "prompt_mode": row["prompt_mode"],
         }
 
 
 def load_rl_dataset_sft(tokenizer) -> TuneRL.Dataset:
     """Load SFT-aligned RL prompts while rendering feedback lazily at access time."""
     runtime_settings = resolve_sft_runtime_settings(RewardUtil.get_distributed_runtime_info())
-    data = TuneRL.api.data(task="img-classification", nn_prefixes=("rl-bb-test1",))
+    nn_prefixes = resolve_sft_rl_nn_prefixes()
+    prompt_mode = resolve_sft_rl_prompt_mode()
+    data = TuneRL.api.data(task="img-classification", nn_prefixes=nn_prefixes)
     if data.empty:
-        print("No 'rl-bb-test1' data found, falling back to all img-classification")
-        data = TuneRL.api.data(only_best_accuracy=True, task="img-classification", dataset="cifar-10")
+        raise RuntimeError(f"No data found for SFT RL prefixes {nn_prefixes}; sync the dataset prefix before training.")
 
-    print(f"Loaded {len(data)} examples for SFT RL")
+    print(f"Loaded {len(data)} examples for SFT RL prefixes={nn_prefixes} prompt_mode={prompt_mode}")
     TuneRL.bootstrap_trainset_reference_library(data)
 
     rows: List[Dict[str, Any]] = []
 
-    for _, row in data.iterrows():
-        accuracy = TuneRL._coerce_accuracy_baseline(row.get("accuracy"), context="seed row accuracy")
-        for profile_id, profile in enumerate(SFTUtil.open_discovery_goal_profiles):
+    if prompt_mode == "sft_aligned":
+        for row_index, row in data.iterrows():
+            full_code = row.get("nn_code")
+            target_pattern = SFTUtil.extract_target_pattern_from_code(full_code) if isinstance(full_code, str) else None
+            if not target_pattern:
+                print(f"Skipping row {row_index} due to missing target_pattern")
+                continue
+            accuracy = TuneRL._coerce_accuracy_baseline(row.get("accuracy"), context="seed row accuracy")
             rows.append(
                 {
                     "accuracy": accuracy,
-                    "goal_name": profile["name"],
-                    "target_tags": ", ".join(profile["tags"]),
-                    "goal_profile_id": profile_id,
+                    "goal_name": str(target_pattern),
+                    "target_tags": "",
+                    "goal_profile_id": -1,
+                    "target_pattern": str(target_pattern),
+                    "prompt_mode": "sft_aligned",
                 }
             )
+    else:
+        for _, row in data.iterrows():
+            accuracy = TuneRL._coerce_accuracy_baseline(row.get("accuracy"), context="seed row accuracy")
+            for profile_id, profile in enumerate(SFTUtil.open_discovery_goal_profiles):
+                rows.append(
+                    {
+                        "accuracy": accuracy,
+                        "goal_name": profile["name"],
+                        "target_tags": ", ".join(profile["tags"]),
+                        "goal_profile_id": profile_id,
+                        "target_pattern": SFTUtil.goal_profile_target_pattern(profile),
+                        "prompt_mode": "goal_profiles",
+                    }
+                )
 
-    random.Random(42).shuffle(rows)
+    if not rows:
+        raise RuntimeError(f"No SFT RL prompt rows built for prefixes={nn_prefixes} prompt_mode={prompt_mode}")
+
+    random.Random(resolve_sft_rl_seed()).shuffle(rows)
     if len(rows) > runtime_settings["dataset_limit"]:
         rows = rows[:runtime_settings["dataset_limit"]]
     return DynamicSFTPromptDataset(
@@ -1133,17 +1810,43 @@ def sft_run_epoch_dir(*args) -> Path:
     return epoch_dir
 
 
+def _resolve_sft_generation_kwargs(tokenizer) -> Dict[str, Any]:
+    kwargs = dict(_env_optional_json("NNGPT_SFT_GENERATION_KWARGS_JSON") or {})
+    eos_token_id = getattr(tokenizer, "eos_token_id", None)
+    if eos_token_id is not None:
+        kwargs.setdefault("eos_token_id", eos_token_id)
+        kwargs.setdefault("pad_token_id", eos_token_id)
+    kwargs.setdefault("use_cache", True)
+    if _env_flag("NNGPT_SFT_STOP_AFTER_FORWARD_XML", True):
+        kwargs.setdefault("stop_strings", ["</forward>"])
+    return kwargs
+
+
+def _attach_sft_generate_tokenizer(model, tokenizer) -> None:
+    original_generate = model.generate
+
+    def generate(*args, **kwargs):
+        generation_config = kwargs.get("generation_config")
+        if generation_config is not None and getattr(generation_config, "stop_strings", None):
+            kwargs["tokenizer"] = tokenizer
+        return original_generate(*args, **kwargs)
+
+    model.generate = generate
+
+
 def _build_sft_grpo_config(
     *,
     precision: Dict[str, Any],
     use_deepspeed: bool,
     deepspeed_config_path: str | None,
     runtime_settings: Dict[str, int],
+    generation_kwargs: Dict[str, Any],
 ) -> Any:
     signature_parameters = _sft_grpo_signature_parameters()
     config_kwargs: Dict[str, Any] = {
-        "temperature": SFT_TEMPERATURE,
-        "learning_rate": SFT_LR,
+        "temperature": resolve_sft_temperature(),
+        "learning_rate": TuneRL.env_float("NNGPT_RL_LR", SFT_LR),
+        "max_prompt_length": runtime_settings["max_prompt_length"],
         "max_completion_length": runtime_settings["max_completion_length"],
         "per_device_train_batch_size": 1,
         "gradient_accumulation_steps": runtime_settings["grad_accum"],
@@ -1160,6 +1863,11 @@ def _build_sft_grpo_config(
     }
     if "gradient_checkpointing_kwargs" in signature_parameters:
         config_kwargs["gradient_checkpointing_kwargs"] = {"use_reentrant": False}
+    seed = resolve_sft_rl_seed()
+    if "seed" in signature_parameters:
+        config_kwargs["seed"] = seed
+    if "data_seed" in signature_parameters:
+        config_kwargs["data_seed"] = seed
     if "save_strategy" in signature_parameters:
         config_kwargs["save_strategy"] = "steps"
     if "save_steps" in signature_parameters:
@@ -1183,6 +1891,18 @@ def _build_sft_grpo_config(
         signature_parameters,
         "max_steps",
         runtime_settings.get("max_steps"),
+    )
+    _set_optional_grpo_config(
+        config_kwargs,
+        signature_parameters,
+        "top_p",
+        resolve_sft_top_p(),
+    )
+    _set_optional_grpo_config(
+        config_kwargs,
+        signature_parameters,
+        "top_k",
+        resolve_sft_top_k(),
     )
     use_vllm = _env_flag("NNGPT_SFT_USE_VLLM", False)
     if use_vllm:
@@ -1220,7 +1940,7 @@ def _build_sft_grpo_config(
         config_kwargs,
         signature_parameters,
         "generation_kwargs",
-        _env_optional_json("NNGPT_SFT_GENERATION_KWARGS_JSON"),
+        generation_kwargs,
     )
     explicit_kl_coef = TuneRL.env_float("NNGPT_RL_KL_COEF", SFT_KL_COEF)
     if "beta" in signature_parameters:
@@ -1238,13 +1958,14 @@ def _build_sft_grpo_config(
     return TuneRL.GRPOConfig(**config_kwargs)
 
 
-def run_sft_training():
+def run_sft_training(*, gpu_role_plan: Optional[Dict[str, Any]] = None):
     import torch
 
     if not torch.cuda.is_available():
         raise RuntimeError("SFT RL requires CUDA for GRPO training, but no CUDA device is available")
     resume_spec = _resolve_sft_resume_spec()
     load_initial_adapter = resolve_sft_load_initial_adapter()
+    initial_adapter_mode = resolve_sft_initial_adapter_mode()
     init_adapter_path = resolve_sft_init_adapter()
     save_rl_model = resolve_sft_save_rl_model()
     model_out_path = resolve_sft_model_out()
@@ -1285,27 +2006,31 @@ def run_sft_training():
     stage_checkpoint_dir = resume_spec["stage_checkpoint_dir"]
     stage_adapter_dir = resume_spec["stage_adapter_dir"]
     resume_state_dir = trainer_checkpoint if trainer_checkpoint is not None else stage_checkpoint_dir
-    resume_stage_override = os.getenv("NNGPT_RL_RESUME_STAGE", "").strip()
+    resume_stage_override = _env_str("NNGPT_RL_RESUME_STAGE", SFT_RL_RESUME_STAGE).strip()
     # Restore pipeline runtime bookkeeping the same way for trainer and stage checkpoints.
     restored_runtime_state_path = TrainingRuntime.restore_or_reset_runtime_state(
         resume_state_dir,
         _sft_runtime_state_hooks(),
         legacy_state_filenames=("reward_state.json",),
     )
-    if resume_state_dir is not None and resume_stage_override:
-        current_state_stage = str(TuneRL.current_stage_name)
-        if current_state_stage != resume_stage_override:
-            print(
-                "[SFT RL] Resume stage override "
-                f"checkpoint_stage={current_state_stage} requested_stage={resume_stage_override}"
-            )
-            TuneRL.current_stage_name = resume_stage_override
+    if resume_stage_override:
+        TuneRL.apply_resume_stage_override(resume_stage_override, log_prefix="[SFT RL]")
     precision = TuneRL.best_mixed_precision()
+    tokenizer_source = getattr(TuneRL, "tokenizer_source", TuneRL.base_model)
+    if tokenizer_source != TuneRL.base_model:
+        print(f"Using RL tokenizer: {tokenizer_source}")
+    tokenizer = TrainerRuntime.load_tokenizer(tokenizer_source)
+    generation_kwargs = _resolve_sft_generation_kwargs(tokenizer)
+    initial_adapter_dtype_label = resolve_sft_initial_adapter_dtype_label()
+    if load_initial_adapter and initial_adapter_mode != "trainable" and initial_adapter_dtype_label != "fp32":
+        raise ValueError("NNGPT_SFT_INITIAL_ADAPTER_DTYPE only applies to trainable initial adapters.")
+    initial_adapter_dtype = resolve_sft_initial_adapter_dtype(initial_adapter_dtype_label, precision)
     grpo_config = _build_sft_grpo_config(
         precision=precision,
         use_deepspeed=use_deepspeed,
         deepspeed_config_path=deepspeed_config_path,
         runtime_settings=runtime_settings,
+        generation_kwargs=generation_kwargs,
     )
     hf_deepspeed_config = _maybe_init_hf_deepspeed_config(deepspeed_config_path) if use_deepspeed else None
     if not trainer_checkpoint_supported:
@@ -1332,10 +2057,16 @@ def run_sft_training():
     print(f"[SFT RL] Fixed training device: {train_device}")
     print(f"[SFT RL] Visible CUDA devices: {visible_cuda_devices}")
     print(f"[SFT RL] Mixed precision: {precision['label']} (torch_dtype={precision['torch_dtype']})")
+    if load_initial_adapter and initial_adapter_mode == "trainable":
+        print(
+            "[SFT RL] Initial adapter dtype: "
+            f"{initial_adapter_dtype_label} (torch_dtype={initial_adapter_dtype})"
+        )
     print(f"[SFT RL] Current stage: {TuneRL.current_stage_name}")
     print(
         "[SFT RL] Runtime limits: "
         f"dataset_limit={runtime_settings['dataset_limit']} "
+        f"max_prompt_length={runtime_settings['max_prompt_length']} "
         f"max_completion_length={runtime_settings['max_completion_length']} "
         f"grad_accum={runtime_settings['grad_accum']} "
         f"effective_train_batch_size={runtime_settings['effective_train_batch_size']} "
@@ -1351,6 +2082,7 @@ def run_sft_training():
         f"use_vllm={_env_flag('NNGPT_SFT_USE_VLLM', False)} "
         f"vllm_mode={_env_str('NNGPT_SFT_VLLM_MODE', 'colocate') if _env_flag('NNGPT_SFT_USE_VLLM', False) else None}"
     )
+    print(f"[SFT RL] Generation kwargs: {generation_kwargs}")
     if runtime_settings["global_num_generations_adapted"]:
         print(
             "[SFT RL] Generation plan adapted "
@@ -1379,13 +2111,23 @@ def run_sft_training():
         f"requested_mode={mode_validation['requested_mode']} "
         f"resolved_mode={mode_validation['resolved_mode']} "
         f"train_tokens={mode_validation['train_tokens']} "
-        f"reward_tokens={mode_validation['reward_tokens']}"
+        f"reward_tokens={mode_validation['reward_tokens']} "
+        f"reward_exclude_train_gpu={mode_validation['reward_exclude_train_gpu']}"
     )
+    if _runtime_is_main_process(runtime):
+        _write_sft_run_config(
+            runtime=runtime,
+            runtime_settings=runtime_settings,
+            generation_kwargs=generation_kwargs,
+            resume_spec=resume_spec,
+            gpu_role_plan=gpu_role_plan,
+            reward_worker_plan=reward_worker_plan,
+            use_deepspeed=use_deepspeed,
+            deepspeed_config_path=deepspeed_config_path,
+            restored_runtime_state_path=restored_runtime_state_path,
+        )
+        print(f"[SFT RL] Run config: {Path(resolve_sft_log_dir()) / 'run_config.json'}")
     _print_runtime_cache_roots()
-    tokenizer_source = getattr(TuneRL, "tokenizer_source", TuneRL.base_model)
-    if tokenizer_source != TuneRL.base_model:
-        print(f"Using RL tokenizer: {tokenizer_source}")
-    tokenizer = TrainerRuntime.load_tokenizer(tokenizer_source)
 
     rl_dataset = TuneRL.load_rl_dataset(tokenizer)
     if len(rl_dataset) > runtime_settings["dataset_limit"]:
@@ -1397,49 +2139,110 @@ def run_sft_training():
         train_device=train_device,
         use_deepspeed=use_deepspeed,
     )
+    if resolve_sft_compact_after_model_load():
+        TrainerRuntime.compact_cuda_cache(log_prefix="[SFT RL]", stage="after_base_model_load")
     _ = hf_deepspeed_config
 
-    model = TrainerRuntime.maybe_merge_initial_adapter(
-        model,
-        enabled=load_initial_adapter,
-        adapter_path=init_adapter_path,
-        label="SFT",
-        empty_adapter_message="SFT_INIT_ADAPTER is empty, but SFT_LOAD_INITIAL_ADAPTER is True.",
-        missing_adapter_message=f"Initial adapter not found: {init_adapter_path}",
-        load_message=f"Loading initial SFT adapter from {init_adapter_path}...",
-    )
+    if load_initial_adapter and initial_adapter_mode == "merge" and stage_adapter_dir is None:
+        model = TrainerRuntime.maybe_merge_initial_adapter(
+            model,
+            enabled=True,
+            adapter_path=init_adapter_path,
+            label="SFT",
+            empty_adapter_message="SFT_INIT_ADAPTER is empty, but SFT_LOAD_INITIAL_ADAPTER is True.",
+            missing_adapter_message=f"Initial adapter not found: {init_adapter_path}",
+            load_message=f"Loading initial SFT adapter from {init_adapter_path} for merge...",
+        )
 
     model = TuneRL.prepare_model_for_kbit_training(model)
     TuneRL.align_generation_head_dtype(model, precision["torch_dtype"])
+    if resolve_sft_compact_float_params():
+        model = TrainerRuntime.cast_non_lora_float_parameter_dtype(
+            model,
+            dtype=precision["torch_dtype"],
+            label="[SFT RL] Prepared model",
+        )
+    if resolve_sft_compact_after_model_load():
+        TrainerRuntime.compact_cuda_cache(log_prefix="[SFT RL]", stage="after_prepare_kbit")
 
-    peft_config = TrainerRuntime.build_lora_config(
-        r=SFT_LORA_R,
-        alpha=SFT_LORA_ALPHA,
-        dropout=SFT_LORA_DROPOUT,
-    )
-    model = TrainerRuntime.attach_or_resume_lora(
-        model,
-        peft_config=peft_config,
-        stage_adapter_dir=stage_adapter_dir,
-        log_prefix="[SFT RL]",
-        missing_adapter_message=f"Missing adapter directory under SFT stage checkpoint: {stage_adapter_dir}",
-    )
+    if trainer_checkpoint is not None:
+        model = TrainerRuntime.load_trainable_initial_adapter(
+            model,
+            enabled=True,
+            adapter_path=str(trainer_checkpoint),
+            label="trainer checkpoint",
+            empty_adapter_message="SFT trainer checkpoint is empty.",
+            missing_adapter_message=f"Missing SFT trainer checkpoint adapter: {trainer_checkpoint}",
+            load_message=f"Loading trainable SFT trainer checkpoint adapter from {trainer_checkpoint}...",
+        )
+    elif stage_adapter_dir is not None:
+        peft_config = TrainerRuntime.build_lora_config(
+            r=SFT_LORA_R,
+            alpha=SFT_LORA_ALPHA,
+            dropout=SFT_LORA_DROPOUT,
+        )
+        model = TrainerRuntime.attach_or_resume_lora(
+            model,
+            peft_config=peft_config,
+            stage_adapter_dir=stage_adapter_dir,
+            log_prefix="[SFT RL]",
+            missing_adapter_message=f"Missing adapter directory under SFT stage checkpoint: {stage_adapter_dir}",
+        )
+    elif load_initial_adapter and initial_adapter_mode == "trainable":
+        model = TrainerRuntime.load_trainable_initial_adapter(
+            model,
+            enabled=True,
+            adapter_path=init_adapter_path,
+            label="SFT",
+            adapter_dtype=initial_adapter_dtype,
+            empty_adapter_message="SFT_INIT_ADAPTER is empty, but SFT_LOAD_INITIAL_ADAPTER is True.",
+            missing_adapter_message=f"Initial adapter not found: {init_adapter_path}",
+            load_message=f"Loading trainable initial SFT adapter from {init_adapter_path}...",
+        )
+    else:
+        peft_config = TrainerRuntime.build_lora_config(
+            r=SFT_LORA_R,
+            alpha=SFT_LORA_ALPHA,
+            dropout=SFT_LORA_DROPOUT,
+        )
+        model = TrainerRuntime.attach_or_resume_lora(
+            model,
+            peft_config=peft_config,
+            stage_adapter_dir=None,
+            log_prefix="[SFT RL]",
+            missing_adapter_message=f"Missing adapter directory under SFT stage checkpoint: {stage_adapter_dir}",
+        )
     TuneRL.align_generation_head_dtype(model, precision["torch_dtype"])
+    if resolve_sft_compact_float_params():
+        model = TrainerRuntime.cast_non_lora_float_parameter_dtype(
+            model,
+            dtype=precision["torch_dtype"],
+            label="[SFT RL] PEFT model",
+        )
+    if resolve_sft_compact_after_model_load():
+        TrainerRuntime.compact_cuda_cache(log_prefix="[SFT RL]", stage="after_adapter_load")
 
     TrainerRuntime.enable_non_reentrant_gradient_checkpointing(
         model,
         log_prefix="[SFT RL]",
     )
+    if resolve_sft_compact_after_model_load():
+        TrainerRuntime.compact_cuda_cache(log_prefix="[SFT RL]", stage="after_gradient_checkpointing")
     model.print_trainable_parameters()
     TuneRL.active_rl_model = model
     TuneRL.active_rl_tokenizer = tokenizer
 
-    trainer = TuneRL.GRPOTrainer(
-        model=model,
-        train_dataset=rl_dataset,
-        reward_funcs=TuneRL.compute_reward,
-        args=grpo_config,
-    )
+    trainer_kwargs = {
+        "model": model,
+        "train_dataset": rl_dataset,
+        "reward_funcs": TuneRL.compute_reward,
+        "args": grpo_config,
+    }
+    if "processing_class" in inspect.signature(TuneRL.GRPOTrainer.__init__).parameters:
+        trainer_kwargs["processing_class"] = tokenizer
+    trainer = TuneRL.GRPOTrainer(**trainer_kwargs)
+    _attach_sft_generate_tokenizer(model, tokenizer)
+    print("[SFT RL] Stop-string generation tokenizer attached")
     trainer_gc_patch_stats = TrainerRuntime.enforce_non_reentrant_gradient_checkpointing(trainer.model)
     print(
         "[SFT RL] Trainer gradient checkpointing enforcement: "
@@ -1455,6 +2258,8 @@ def run_sft_training():
             trainer.add_callback(runtime_callback)
     warmup_diagnostics = RewardUtil.prewarm_eval_workers(timeout_seconds=60.0, require_gpu=True)
     _validate_gpu_reward_worker_bindings(warmup_diagnostics)
+    if resolve_sft_compact_after_model_load():
+        TrainerRuntime.compact_cuda_cache(log_prefix="[SFT RL]", stage="before_grpo_train")
     TuneRL.register_stage_checkpoint_signal_handlers()
 
     print("Starting GRPO training for Backbone Search...")
@@ -1489,7 +2294,13 @@ def run_sft_training():
 
 def patch_sft_runtime() -> tuple[str, str, str]:
     """Patch TuneRL to use the SFT runtime and CIFAR-aware reward."""
+    global SFT_RUNTIME_SOURCE_INFO
     model_source, tokenizer_source, source_mode = resolve_sft_model_sources()
+    SFT_RUNTIME_SOURCE_INFO = {
+        "model_source": model_source,
+        "tokenizer_source": tokenizer_source,
+        "source_mode": source_mode,
+    }
     load_initial_adapter = resolve_sft_load_initial_adapter()
     init_adapter_path = resolve_sft_init_adapter()
     TuneRL.base_model = model_source
@@ -1560,13 +2371,15 @@ def bootstrap_sft_runtime() -> None:
 def main() -> None:
     import torch
 
+    TuneRL.apply_rl_seed(log_prefix="[SFT RL]")
     resume_spec = _resolve_sft_resume_spec()
-    gpu_role_plan: Dict[str, List[str] | str] = {
+    gpu_role_plan: Dict[str, Any] = {
         "requested_mode": "auto",
         "resolved_mode": "single",
         "visible_gpu_tokens": [],
         "train_gpu_tokens": [],
         "reward_gpu_tokens": [],
+        "reward_exclude_train_gpu": False,
     }
     if torch.cuda.is_available():
         gpu_role_plan = _configure_sft_gpu_role_env(int(torch.cuda.device_count()))
@@ -1576,21 +2389,27 @@ def main() -> None:
             f"resolved_mode={gpu_role_plan['resolved_mode']} "
             f"visible_gpu_tokens={gpu_role_plan['visible_gpu_tokens']} "
             f"train_gpu_tokens={gpu_role_plan['train_gpu_tokens']} "
-            f"reward_gpu_tokens={gpu_role_plan['reward_gpu_tokens']}"
+            f"reward_gpu_tokens={gpu_role_plan['reward_gpu_tokens']} "
+            f"reward_exclude_train_gpu={gpu_role_plan['reward_exclude_train_gpu']}"
         )
     _maybe_relaunch_sft_with_visible_gpu_workers()
     _validate_sft_visible_worker_count(RewardUtil.get_distributed_runtime_info())
     model_source, tokenizer_source, source_mode = patch_sft_runtime()
     bootstrap_sft_runtime()
 
-    print(f"[SFT RL] Base model id: {SFT_BASE_MODEL_ID}")
+    print(f"[SFT RL] Base model id: {resolve_sft_base_model_id()}")
     print(f"[SFT RL] Base model source ({source_mode}): {model_source}")
     if tokenizer_source != model_source:
         print(f"[SFT RL] Tokenizer source: {tokenizer_source}")
     print(f"[SFT RL] Resume mode: {resume_spec['mode']}")
     print(f"[SFT RL] Load init adapter: {resolve_sft_load_initial_adapter()}")
+    print(f"[SFT RL] Initial adapter mode: {resolve_sft_initial_adapter_mode()}")
+    print(f"[SFT RL] Reward excludes train GPU: {resolve_sft_reward_exclude_train_gpu()}")
+    print(f"[SFT RL] Compact after model load: {resolve_sft_compact_after_model_load()}")
+    print(f"[SFT RL] Compact float params: {resolve_sft_compact_float_params()}")
     if resolve_sft_load_initial_adapter():
         print(f"[SFT RL] Init adapter path: {resolve_sft_init_adapter()}")
+        print(f"[SFT RL] Initial adapter dtype request: {resolve_sft_initial_adapter_dtype_label()}")
     if resume_spec["trainer_checkpoint"] is not None:
         print(f"[SFT RL] Resume trainer checkpoint: {resume_spec['trainer_checkpoint']}")
     if resume_spec["stage_checkpoint_dir"] is not None:
@@ -1600,20 +2419,46 @@ def main() -> None:
     print(f"[SFT RL] Model out: {resolve_sft_model_out()}")
     print(f"[SFT RL] Stage1 only: {TuneRL.env_flag('NNGPT_RL_STAGE1_ONLY', False)}")
     print(f"[SFT RL] Num epochs: {resolve_sft_num_epochs()}")
-    print(f"[SFT RL] Temperature: {SFT_TEMPERATURE}")
+    print(f"[SFT RL] Temperature: {resolve_sft_temperature()}")
+    print(f"[SFT RL] Top-p: {resolve_sft_top_p()}")
+    print(f"[SFT RL] Top-k: {resolve_sft_top_k()}")
+    print(f"[SFT RL] Seed: {resolve_sft_rl_seed()}")
     print(f"[SFT RL] KL coef: {TuneRL.env_float('NNGPT_RL_KL_COEF', SFT_KL_COEF):.6f}")
+    formal_dataset = resolve_sft_formal_dataset()
+    formal_out_shape = resolve_sft_formal_out_shape(formal_dataset)
+    train_set_label, reward_eval_label, heldout_test_label = _describe_sft_eval_split(
+        formal_dataset,
+        _env_str("NNGPT_SFT_EVAL_SPLIT_PROTOCOL", SFT_EVAL_SPLIT_PROTOCOL),
+    )
     print(
-        f"[SFT RL] Eval plan: stage1=static_only(no-check_nn), stage2/3=nn-dataset-formal(cifar-10), "
+        f"[SFT RL] Eval plan: stage1=static_only(no-check_nn), stage2/3=nn-dataset-formal({formal_dataset}), "
+        f"out_shape={formal_out_shape}, n_classes={formal_out_shape[0]}, "
         f"transform={SFT_EVAL_TRANSFORM}, resize={SFT_EVAL_IMAGE_SIZE}, batch={SFT_EVAL_BATCH_SIZE}, "
-        f"train_set=full, test_set=full, train_epochs={SFT_EVAL_TRAIN_EPOCHS}, "
+        f"split={_env_str('NNGPT_SFT_EVAL_SPLIT_PROTOCOL', SFT_EVAL_SPLIT_PROTOCOL)}, "
+        f"split_seed={_env_int('NNGPT_SFT_EVAL_SPLIT_SEED', SFT_EVAL_SPLIT_SEED)}, "
+        f"eval_split_role={_env_str('NNGPT_SFT_EVAL_SPLIT_ROLE', SFT_EVAL_SPLIT_ROLE)}, "
+        f"train_set={train_set_label}, "
+        f"reward_eval_set={reward_eval_label}, heldout_test_set={heldout_test_label}, train_epochs={SFT_EVAL_TRAIN_EPOCHS}, "
         f"freeze_only_backbone_eval=True, formal_epoch_limit_minutes={SFT_EVAL_FORMAL_EPOCH_LIMIT_MINUTES}, "
         f"worker_eval_limit_seconds={SFT_EVAL_LIMIT_SECONDS}, "
         f"baseline={SFT_VAL_METRIC_BASELINE:.2f}"
     )
     print(f"[SFT RL] Save RL adapter: {resolve_sft_save_rl_model()}")
 
-    run_sft_training()
+    run_sft_training(gpu_role_plan=gpu_role_plan)
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except BaseException:
+        traceback.print_exc()
+        try:
+            import ab.gpt.TuneRL as _TuneRL
+
+            logger = getattr(_TuneRL, "code_logger", None)
+            if logger is not None:
+                logger.log_to_file("[SFT RL] Fatal exception:\n" + traceback.format_exc())
+        except Exception:
+            pass
+        raise

--- a/ab/gpt/TuneRLSft.py
+++ b/ab/gpt/TuneRLSft.py
@@ -141,23 +141,20 @@ def resolve_sft_formal_out_shape(dataset: str | None = None) -> tuple[int, ...]:
     return (resolve_sft_formal_n_classes(dataset),)
 
 
-def _normalize_sft_eval_split_protocol(split_protocol: str | None) -> str:
-    normalized = str(split_protocol or "").strip().lower().replace("-", "").replace("_", "").replace(" ", "")
-    if normalized in {"721", "7/2/1", "trainvaltest"}:
-        return "trainvaltest"
-    return "official"
+def _normalize_sft_eval_split_protocol(_split_protocol: str | None = None) -> str:
+    return "trainvaltest"
 
 
 def _describe_sft_eval_split(formal_dataset: str, split_protocol: str) -> tuple[str, str, str]:
     dataset = normalize_sft_formal_dataset(formal_dataset)
-    if _normalize_sft_eval_split_protocol(split_protocol) == "trainvaltest":
-        if dataset == "cifar-10":
-            return "cifar10-train[45k]", "cifar10-train[5k]", "cifar10-test[10k]"
-        if dataset == "cifar-100":
-            return "cifar100-train[45k]", "cifar100-train[5k]", "cifar100-test[10k]"
-        if dataset == "imagenette":
-            return "imagenette-train[7500]", "imagenette-train[1969]", "imagenette-test[3925]"
-    return "official-train", "official-test", "none"
+    _normalize_sft_eval_split_protocol(split_protocol)
+    if dataset == "cifar-10":
+        return "cifar10-train[45k]", "cifar10-train[5k]", "cifar10-test[10k]"
+    if dataset == "cifar-100":
+        return "cifar100-train[45k]", "cifar100-train[5k]", "cifar100-test[10k]"
+    if dataset == "imagenette":
+        return "imagenette-train[7500]", "imagenette-train[1969]", "imagenette-test[3925]"
+    raise ValueError(f"Unsupported formal dataset: {formal_dataset!r}")
 
 
 def _stage1_fixed_failure_reward(res: Dict[str, Any], meta: Dict[str, Any], graph_info) -> Optional[float]:
@@ -830,7 +827,7 @@ def _write_sft_run_config(
         "NNGPT_SFT_EPOCH_ROOT",
         "NNGPT_SFT_APPEND_LOGS",
     ]
-    split_protocol = _env_str("NNGPT_SFT_EVAL_SPLIT_PROTOCOL", SFT_EVAL_SPLIT_PROTOCOL)
+    split_protocol = SFT_EVAL_SPLIT_PROTOCOL
     split_seed = _env_int("NNGPT_SFT_EVAL_SPLIT_SEED", SFT_EVAL_SPLIT_SEED)
     eval_split_role = _env_str("NNGPT_SFT_EVAL_SPLIT_ROLE", SFT_EVAL_SPLIT_ROLE)
     formal_dataset = resolve_sft_formal_dataset()
@@ -1488,7 +1485,7 @@ def build_sft_reward_eval_cfg(
         val_subset_size=SFT_EVAL_VAL_SUBSET,
         data_root=SFT_EVAL_DATA_ROOT,
         download=SFT_EVAL_DOWNLOAD,
-        split_protocol=_env_str("NNGPT_SFT_EVAL_SPLIT_PROTOCOL", SFT_EVAL_SPLIT_PROTOCOL),
+        split_protocol=SFT_EVAL_SPLIT_PROTOCOL,
         split_seed=_env_int("NNGPT_SFT_EVAL_SPLIT_SEED", SFT_EVAL_SPLIT_SEED),
         eval_split_role=_env_str("NNGPT_SFT_EVAL_SPLIT_ROLE", SFT_EVAL_SPLIT_ROLE),
         measure_latency=getattr(cfg, "measure_latency", True),
@@ -2420,13 +2417,13 @@ def main() -> None:
     formal_out_shape = resolve_sft_formal_out_shape(formal_dataset)
     train_set_label, reward_eval_label, heldout_test_label = _describe_sft_eval_split(
         formal_dataset,
-        _env_str("NNGPT_SFT_EVAL_SPLIT_PROTOCOL", SFT_EVAL_SPLIT_PROTOCOL),
+        SFT_EVAL_SPLIT_PROTOCOL,
     )
     print(
         f"[SFT RL] Eval plan: stage1=static_only(no-check_nn), stage2/3=nn-dataset-formal({formal_dataset}), "
         f"out_shape={formal_out_shape}, n_classes={formal_out_shape[0]}, "
         f"transform={SFT_EVAL_TRANSFORM}, resize={SFT_EVAL_IMAGE_SIZE}, batch={SFT_EVAL_BATCH_SIZE}, "
-        f"split={_env_str('NNGPT_SFT_EVAL_SPLIT_PROTOCOL', SFT_EVAL_SPLIT_PROTOCOL)}, "
+        f"split={SFT_EVAL_SPLIT_PROTOCOL}, "
         f"split_seed={_env_int('NNGPT_SFT_EVAL_SPLIT_SEED', SFT_EVAL_SPLIT_SEED)}, "
         f"eval_split_role={_env_str('NNGPT_SFT_EVAL_SPLIT_ROLE', SFT_EVAL_SPLIT_ROLE)}, "
         f"train_set={train_set_label}, "

--- a/ab/gpt/TuneRLSft.py
+++ b/ab/gpt/TuneRLSft.py
@@ -143,15 +143,7 @@ def resolve_sft_formal_out_shape(dataset: str | None = None) -> tuple[int, ...]:
 
 def _normalize_sft_eval_split_protocol(split_protocol: str | None) -> str:
     normalized = str(split_protocol or "").strip().lower().replace("-", "").replace("_", "").replace(" ", "")
-    if normalized in {
-        "721",
-        "7/2/1",
-        "702010",
-        "70/20/10",
-        "trainval",
-        "trainvaltest",
-        "trainvaltestsplit",
-    }:
+    if normalized in {"721", "7/2/1", "trainvaltest"}:
         return "trainvaltest"
     return "official"
 

--- a/ab/gpt/conf/chat_template/qwen2_no_think_prefill.jinja
+++ b/ab/gpt/conf/chat_template/qwen2_no_think_prefill.jinja
@@ -1,0 +1,54 @@
+{%- if tools %}
+    {{- '<|im_start|>system\n' }}
+    {%- if messages[0]['role'] == 'system' %}
+        {{- messages[0]['content'] }}
+    {%- else %}
+        {{- 'You are Qwen, created by Alibaba Cloud. You are a helpful assistant.' }}
+    {%- endif %}
+    {{- "\n\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n" }}
+{%- else %}
+    {%- if messages[0]['role'] == 'system' %}
+        {{- '<|im_start|>system\n' + messages[0]['content'] + '<|im_end|>\n' }}
+    {%- else %}
+        {{- '<|im_start|>system\nYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- for message in messages %}
+    {%- if (message.role == "user") or (message.role == "system" and not loop.first) or (message.role == "assistant" and not message.tool_calls) %}
+        {{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {{- '<|im_start|>' + message.role }}
+        {%- if message.content %}
+            {{- '\n' + message.content }}
+        {%- endif %}
+        {%- for tool_call in message.tool_calls %}
+            {%- if tool_call.function is defined %}
+                {%- set tool_call = tool_call.function %}
+            {%- endif %}
+            {{- '\n<tool_call>\n{"name": "' }}
+            {{- tool_call.name }}
+            {{- '", "arguments": ' }}
+            {{- tool_call.arguments | tojson }}
+            {{- '}\n</tool_call>' }}
+        {%- endfor %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if (loop.index0 == 0) or (messages[loop.index0 - 1].role != "tool") %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- message.content }}
+        {{- '\n</tool_response>' }}
+        {%- if loop.last or (messages[loop.index0 + 1].role != "tool") %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+{%- endif %}

--- a/ab/gpt/conf/llm/backbone_sft_fullbase_config.json
+++ b/ab/gpt/conf/llm/backbone_sft_fullbase_config.json
@@ -1,0 +1,13 @@
+{
+    "token_from_file": false,
+    "base_model_name": "deepseek-ai/deepseek-coder-6.7b-instruct",
+    "num_epochs": 20,
+    "use_deepspeed": false,
+    "only_best_accuracy": true,
+    "context_length": 4096,
+    "max_input_length": 4096,
+    "use_unsloth": false,
+    "load_in_4bit": false,
+    "max_new_tokens": 2048,
+    "backbone": true
+}

--- a/ab/gpt/conf/llm/backbone_sft_granite_4_1_8b.json
+++ b/ab/gpt/conf/llm/backbone_sft_granite_4_1_8b.json
@@ -1,0 +1,13 @@
+{
+    "token_from_file": false,
+    "base_model_name": "ibm-granite/granite-4.1-8b",
+    "num_epochs": 20,
+    "use_deepspeed": false,
+    "only_best_accuracy": true,
+    "context_length": 4096,
+    "max_input_length": 4096,
+    "use_unsloth": false,
+    "load_in_4bit": false,
+    "max_new_tokens": 2048,
+    "backbone": true
+}

--- a/ab/gpt/conf/llm/backbone_sft_mistral_7b_instruct_v03.json
+++ b/ab/gpt/conf/llm/backbone_sft_mistral_7b_instruct_v03.json
@@ -1,0 +1,13 @@
+{
+    "token_from_file": false,
+    "base_model_name": "mistralai/Mistral-7B-Instruct-v0.3",
+    "num_epochs": 20,
+    "use_deepspeed": false,
+    "only_best_accuracy": true,
+    "context_length": 4096,
+    "max_input_length": 4096,
+    "use_unsloth": false,
+    "load_in_4bit": false,
+    "max_new_tokens": 2048,
+    "backbone": true
+}

--- a/ab/gpt/conf/llm/backbone_sft_olympic_coder_7b.json
+++ b/ab/gpt/conf/llm/backbone_sft_olympic_coder_7b.json
@@ -1,0 +1,14 @@
+{
+    "token_from_file": false,
+    "base_model_name": "open-r1/OlympicCoder-7B",
+    "num_epochs": 20,
+    "use_deepspeed": false,
+    "only_best_accuracy": true,
+    "context_length": 4096,
+    "max_input_length": 4096,
+    "chat_template_path": "qwen2_no_think_prefill.jinja",
+    "use_unsloth": false,
+    "load_in_4bit": false,
+    "max_new_tokens": 2048,
+    "backbone": true
+}

--- a/ab/gpt/conf/llm/backbone_sft_qwen2.5_coder_7b_instruct.json
+++ b/ab/gpt/conf/llm/backbone_sft_qwen2.5_coder_7b_instruct.json
@@ -1,0 +1,13 @@
+{
+    "token_from_file": false,
+    "base_model_name": "Qwen/Qwen2.5-Coder-7B-Instruct",
+    "num_epochs": 20,
+    "use_deepspeed": false,
+    "only_best_accuracy": true,
+    "context_length": 4096,
+    "max_input_length": 4096,
+    "use_unsloth": false,
+    "load_in_4bit": false,
+    "max_new_tokens": 2048,
+    "backbone": true
+}

--- a/ab/gpt/rl_pipeline/completion.py
+++ b/ab/gpt/rl_pipeline/completion.py
@@ -11,6 +11,9 @@ REQUIRED_BACKBONE_NAMES = ("backbone_a", "backbone_b")
 BLOCK_SIGNATURE = "def drop_conv3x3_block(in_channels, out_channels, stride=1, padding=1, bias=False, dropout_prob=0.0):"
 INIT_SIGNATURE = "def __init__(self, in_shape: tuple, out_shape: tuple, prm: dict, device: torch.device) -> None:"
 FORWARD_SIGNATURE = "def forward(self, x: torch.Tensor, is_probing: bool = False) -> torch.Tensor:"
+FORWARD_SIGNATURE_ALIASES = (
+    "def forward(self, x: torch.Tensor, is_probing: bool=False) -> torch.Tensor:",
+)
 
 _BLOCKED_ATTRS = {
     "device",
@@ -105,27 +108,20 @@ def _scan_raw_attrs(*texts: str) -> List[str]:
     return _dedupe_keep_order(attrs)
 
 
-def _prepare_completion_for_xml(completion: str) -> str:
-    stripped = _strip_outer_code_fences(completion or "").lstrip()
-    if "<block>" not in stripped and "</block>" in stripped and "<init>" in stripped:
-        return stripped
-    if "<block>" not in stripped and "</block>" not in stripped and "<init>" in stripped:
-        init_pos = stripped.find("<init>")
-        pre_init = stripped[:init_pos].strip()
-        rest = stripped[init_pos:]
-        if pre_init:
-            return f"<block>\n{BLOCK_SIGNATURE}\n{pre_init}\n</block>\n{rest}"
-        return (
-            f"<block>\n{BLOCK_SIGNATURE}\n"
-            "    return nn.Sequential(nn.Conv2d(in_channels, out_channels, 3, stride, padding, bias=bias))\n"
-            f"</block>\n{rest}"
-        )
-    return stripped
-
-
-def _normalize_required_function(code: str, fn_name: str, signature: str) -> str:
+def _accept_exact_function(
+    code: str,
+    signature: str,
+    *,
+    aliases: Sequence[str] = (),
+) -> str:
     code = _strip_outer_code_fences(code)
-    if not code:
+    code = textwrap.dedent(code).strip()
+    if code.startswith(signature):
+        return code
+    for alias in aliases:
+        if code.startswith(alias):
+            return signature + code[len(alias):]
+    if not code.startswith(signature):
         return ""
     code = textwrap.dedent(code).strip()
     if not code:
@@ -242,6 +238,11 @@ def _build_extraction_meta(
 ) -> Dict[str, object]:
     xml_tag_count = sum(bool(code) for code in (block_code, init_code, forward_code))
     xml_counts = {tag: _count_xml_tags(candidate, tag) for tag in ("block", "init", "forward")}
+    forward_close_match = re.search(r"</forward>", candidate, re.IGNORECASE)
+    trailing_after_forward = ""
+    if forward_close_match:
+        trailing_after_forward = candidate[forward_close_match.end():].strip()
+    jupyter_artifact_count = len(re.findall(r"<jupyter_[^>]*>", candidate, re.IGNORECASE))
     class_count = len(re.findall(r"^\s*class\s+\w+", candidate, re.MULTILINE))
     import_count = len(re.findall(r"^\s*(?:from|import)\s+\w+", candidate, re.MULTILINE))
     bad_signature_count = len(re.findall(r"\)\s*-\s*:", candidate))
@@ -260,7 +261,8 @@ def _build_extraction_meta(
     exact_signatures = {
         "block": block_code.startswith(BLOCK_SIGNATURE),
         "init": init_code.startswith(INIT_SIGNATURE),
-        "forward": forward_code.startswith(FORWARD_SIGNATURE),
+        "forward": forward_code.startswith(FORWARD_SIGNATURE)
+        or any(forward_code.startswith(alias) for alias in FORWARD_SIGNATURE_ALIASES),
     }
 
     quality_score = 0
@@ -279,6 +281,9 @@ def _build_extraction_meta(
         "class_count": class_count,
         "import_count": import_count,
         "bad_signature_count": bad_signature_count,
+        "trailing_after_forward": bool(trailing_after_forward),
+        "trailing_after_forward_chars": len(trailing_after_forward),
+        "jupyter_artifact_count": jupyter_artifact_count,
         "structural_attr_detected": structural_attr_detected,
         "quality_score": quality_score,
         "exact_block_signature": exact_signatures["block"],
@@ -303,11 +308,29 @@ def extract_completion_payload_tolerant(completion: str) -> Tuple[Tuple[str, str
             dict(cached["meta"]),
         )
 
-    candidate = _prepare_completion_for_xml(completion or "")
-    block_code = _normalize_block_code(_extract_xml_tag(candidate, "block"))
-    init_code = _normalize_init_code(_extract_xml_tag(candidate, "init"))
-    forward_code = _normalize_forward_code(_extract_xml_tag(candidate, "forward"))
-    meta = _build_extraction_meta(completion or "", candidate, block_code, init_code, forward_code)
+    candidate = _strip_outer_code_fences(completion or "").lstrip()
+    raw_block_code = _extract_xml_tag(candidate, "block")
+    raw_init_code = _extract_xml_tag(candidate, "init")
+    raw_forward_code = _extract_xml_tag(candidate, "forward")
+    meta = _build_extraction_meta(
+        completion or "",
+        candidate,
+        raw_block_code,
+        raw_init_code,
+        raw_forward_code,
+    )
+    if meta.get("xml_tag_exact"):
+        block_code = _accept_exact_function(raw_block_code, BLOCK_SIGNATURE)
+        init_code = _accept_exact_function(raw_init_code, INIT_SIGNATURE)
+        forward_code = _accept_exact_function(
+            raw_forward_code,
+            FORWARD_SIGNATURE,
+            aliases=FORWARD_SIGNATURE_ALIASES,
+        )
+    else:
+        block_code = ""
+        init_code = ""
+        forward_code = ""
 
     _EXTRACTION_META_CACHE[cache_key] = {
         "block_code": block_code,

--- a/ab/gpt/rl_pipeline/stage_state.py
+++ b/ab/gpt/rl_pipeline/stage_state.py
@@ -117,7 +117,9 @@ def capture_reward_runtime_state(
         "descriptor_archive_counts": counter_payload(runtime["descriptor_archive_counts"]),
         "backbone_signature_archive_counts": counter_payload(runtime["backbone_signature_archive_counts"]),
         "cnn_signature_archive_counts": counter_payload(runtime["cnn_signature_archive_counts"]),
+        "block_signature_archive_counts": counter_payload(runtime["block_signature_archive_counts"]),
         "backbone_cnn_pair_archive_counts": counter_payload(runtime["backbone_cnn_pair_archive_counts"]),
+        "backbone_block_pair_archive_counts": counter_payload(runtime["backbone_block_pair_archive_counts"]),
         "family_metric_best": {
             str(key): float(value)
             for key, value in runtime["family_metric_best"].items()
@@ -128,6 +130,7 @@ def capture_reward_runtime_state(
         "saved_backbone_signature_counts": counter_payload(runtime["saved_backbone_signature_counts"]),
         "saved_cnn_signature_counts": counter_payload(runtime["saved_cnn_signature_counts"]),
         "saved_backbone_cnn_pair_counts": counter_payload(runtime["saved_backbone_cnn_pair_counts"]),
+        "saved_backbone_block_pair_counts": counter_payload(runtime["saved_backbone_block_pair_counts"]),
         "goal_graph_archive_counts": nested_counter_payload(runtime["goal_graph_archive_counts"]),
         "goal_family_hash_archive_counts": nested_counter_payload(runtime["goal_family_hash_archive_counts"]),
         "saved_goal_family_hash_counts": nested_counter_payload(runtime["saved_goal_family_hash_counts"]),
@@ -136,6 +139,7 @@ def capture_reward_runtime_state(
         "prev_closed_group_mean_reward_target_by_backbone": float_dict_payload(runtime["prev_closed_group_mean_reward_target_by_backbone"]),
         "best_closed_group_mean_reward_target_by_backbone": float_dict_payload(runtime["best_closed_group_mean_reward_target_by_backbone"]),
         "saved_best_reward_target_by_backbone_cnn": float_dict_payload(runtime["saved_best_reward_target_by_backbone_cnn"]),
+        "best_quality_acc_by_backbone_block": float_dict_payload(runtime["best_quality_acc_by_backbone_block"]),
         "prev_group_feedback": feedback_summary_payload(runtime["prev_group_feedback"]),
         "best_group_feedback": feedback_summary_payload(runtime["best_group_feedback"]),
         "current_group_top_feedback": current_group_top_feedback_payload(),
@@ -226,7 +230,9 @@ def restore_reward_runtime_state(
     restore_counter(runtime["descriptor_archive_counts"], state.get("descriptor_archive_counts"))
     restore_counter(runtime["backbone_signature_archive_counts"], state.get("backbone_signature_archive_counts"))
     restore_counter(runtime["cnn_signature_archive_counts"], state.get("cnn_signature_archive_counts"))
+    restore_counter(runtime["block_signature_archive_counts"], state.get("block_signature_archive_counts"))
     restore_counter(runtime["backbone_cnn_pair_archive_counts"], state.get("backbone_cnn_pair_archive_counts"))
+    restore_counter(runtime["backbone_block_pair_archive_counts"], state.get("backbone_block_pair_archive_counts"))
     runtime["family_metric_best"].clear()
     runtime["family_metric_best"].update(
         {
@@ -240,6 +246,7 @@ def restore_reward_runtime_state(
     restore_counter(runtime["saved_backbone_signature_counts"], state.get("saved_backbone_signature_counts"))
     restore_counter(runtime["saved_cnn_signature_counts"], state.get("saved_cnn_signature_counts"))
     restore_counter(runtime["saved_backbone_cnn_pair_counts"], state.get("saved_backbone_cnn_pair_counts"))
+    restore_counter(runtime["saved_backbone_block_pair_counts"], state.get("saved_backbone_block_pair_counts"))
     restore_nested_counters(runtime["goal_graph_archive_counts"], state.get("goal_graph_archive_counts"))
     restore_nested_counters(runtime["goal_family_hash_archive_counts"], state.get("goal_family_hash_archive_counts"))
     restore_nested_counters(runtime["saved_goal_family_hash_counts"], state.get("saved_goal_family_hash_counts"))
@@ -248,6 +255,7 @@ def restore_reward_runtime_state(
     restore_float_dict(runtime["prev_closed_group_mean_reward_target_by_backbone"], state.get("prev_closed_group_mean_reward_target_by_backbone"))
     restore_float_dict(runtime["best_closed_group_mean_reward_target_by_backbone"], state.get("best_closed_group_mean_reward_target_by_backbone"))
     restore_float_dict(runtime["saved_best_reward_target_by_backbone_cnn"], state.get("saved_best_reward_target_by_backbone_cnn"))
+    restore_float_dict(runtime["best_quality_acc_by_backbone_block"], state.get("best_quality_acc_by_backbone_block"))
 
     runtime["best_reward_target_by_goal"].clear()
     runtime["best_reward_target_by_goal"].update(
@@ -309,7 +317,9 @@ def reset_reward_runtime_state(
         "descriptor_archive_counts",
         "backbone_signature_archive_counts",
         "cnn_signature_archive_counts",
+        "block_signature_archive_counts",
         "backbone_cnn_pair_archive_counts",
+        "backbone_block_pair_archive_counts",
         "family_metric_best",
         "motif_name_counts",
         "saved_graph_counts",
@@ -317,6 +327,7 @@ def reset_reward_runtime_state(
         "saved_backbone_signature_counts",
         "saved_cnn_signature_counts",
         "saved_backbone_cnn_pair_counts",
+        "saved_backbone_block_pair_counts",
         "goal_graph_archive_counts",
         "goal_family_hash_archive_counts",
         "saved_goal_family_hash_counts",
@@ -325,6 +336,7 @@ def reset_reward_runtime_state(
         "prev_closed_group_mean_reward_target_by_backbone",
         "best_closed_group_mean_reward_target_by_backbone",
         "saved_best_reward_target_by_backbone_cnn",
+        "best_quality_acc_by_backbone_block",
         "stage_closed_group_counts",
         "stage_best_group_mean_reward_target",
         "stage_entry_generation_totals",
@@ -446,9 +458,13 @@ def evaluate_stage_transitions(rl, group_progress_payload):
     if rl._stage1_only_enabled() and stage_name == rl.STAGE1_STRUCTURE_EXPLORE:
         return
     if stage_name == rl.STAGE1_STRUCTURE_EXPLORE:
+        trainable_stable_snapshot = rl._stage1_trainable_stable_ready()
+        if trainable_stable_snapshot is not None:
+            rl._transition_to_stage(rl.STAGE2_FORMAL_EXPLORE, event='entered', reason=f"stage1_trainable_stable_promotion: stage_groups={trainable_stable_snapshot['stage_group_count']}, recent_generations={trainable_stable_snapshot['recent_generation_count']}, recent_executable_count={trainable_stable_snapshot['recent_executable_count']}, recent_executable_rate={trainable_stable_snapshot['recent_executable_rate']:.4f}, recent_trainable_count={trainable_stable_snapshot['recent_trainable_count']}, recent_trainable_rate={trainable_stable_snapshot['recent_trainable_rate']:.4f}", group_progress_payload=group_progress_payload)
+            return
         force_promotion_snapshot = rl._stage1_force_promotion_ready()
         if force_promotion_snapshot is not None:
-            rl._transition_to_stage(rl.STAGE2_FORMAL_EXPLORE, event='entered', reason=f"stage1_forced_promotion_after_plateau: stage_groups={force_promotion_snapshot['stage_group_count']}, recent_generations={force_promotion_snapshot['recent_generation_count']}, recent_executable_count={force_promotion_snapshot['recent_executable_count']}, recent_discovery_count={force_promotion_snapshot['recent_discovery_count']}, recent_unique_discovery_families={force_promotion_snapshot['recent_unique_discovery_families']}", group_progress_payload=group_progress_payload)
+            rl._transition_to_stage(rl.STAGE2_FORMAL_EXPLORE, event='entered', reason=f"stage1_forced_promotion_after_plateau: stage_groups={force_promotion_snapshot['stage_group_count']}, recent_generations={force_promotion_snapshot['recent_generation_count']}, recent_executable_count={force_promotion_snapshot['recent_executable_count']}, recent_trainable_count={force_promotion_snapshot['recent_trainable_count']}, recent_discovery_count={force_promotion_snapshot['recent_discovery_count']}, recent_unique_discovery_families={force_promotion_snapshot['recent_unique_discovery_families']}", group_progress_payload=group_progress_payload)
             return
         if rl._stage1_gate_ready():
             rl._transition_to_stage(rl.STAGE2_FORMAL_EXPLORE, event='entered', reason='stage1_gate_satisfied', group_progress_payload=group_progress_payload)

--- a/ab/gpt/rl_pipeline/trainer_runtime.py
+++ b/ab/gpt/rl_pipeline/trainer_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+import gc
 import os
 from pathlib import Path
 from typing import Any, Dict, Optional, Set
@@ -72,6 +73,145 @@ def maybe_merge_initial_adapter(
     print(load_message or f"Loading initial {label} adapter from {adapter_path}...")
     model = PeftModel.from_pretrained(model, adapter_path)
     return model.merge_and_unload()
+
+
+def _dtype_numel_summary(model, *, lora_only: bool) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for name, param in model.named_parameters():
+        if lora_only and "lora_" not in name:
+            continue
+        if not torch.is_floating_point(param.data):
+            continue
+        key = str(param.dtype)
+        counts[key] = counts.get(key, 0) + int(param.numel())
+    return counts
+
+
+def _trainable_dtype_numel_summary(model, *, lora_only: bool) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for name, param in model.named_parameters():
+        if lora_only and "lora_" not in name:
+            continue
+        if not param.requires_grad or not torch.is_floating_point(param.data):
+            continue
+        key = str(param.dtype)
+        counts[key] = counts.get(key, 0) + int(param.numel())
+    return counts
+
+
+def compact_cuda_cache(
+    *,
+    log_prefix: str,
+    stage: str,
+    reset_peak_stats: bool = True,
+) -> None:
+    if not torch.cuda.is_available():
+        return
+    device = torch.cuda.current_device()
+    before_allocated = float(torch.cuda.memory_allocated(device)) / float(1024 ** 3)
+    before_reserved = float(torch.cuda.memory_reserved(device)) / float(1024 ** 3)
+    gc.collect()
+    torch.cuda.empty_cache()
+    if reset_peak_stats:
+        try:
+            torch.cuda.reset_peak_memory_stats(device)
+        except Exception:
+            pass
+    after_allocated = float(torch.cuda.memory_allocated(device)) / float(1024 ** 3)
+    after_reserved = float(torch.cuda.memory_reserved(device)) / float(1024 ** 3)
+    print(
+        f"{log_prefix} CUDA cache compact stage={stage} "
+        f"allocated_gib={before_allocated:.2f}->{after_allocated:.2f} "
+        f"reserved_gib={before_reserved:.2f}->{after_reserved:.2f}"
+    )
+
+
+def cast_non_lora_float_parameter_dtype(
+    model,
+    *,
+    dtype: torch.dtype,
+    label: str,
+):
+    before = _dtype_numel_summary(model, lora_only=False)
+    changed = 0
+    skipped_lora = 0
+    for name, param in model.named_parameters():
+        if not torch.is_floating_point(param.data):
+            continue
+        if "lora_" in name:
+            skipped_lora += int(param.numel())
+            continue
+        if param.dtype == dtype:
+            continue
+        changed += int(param.numel())
+        param.data = param.data.to(dtype=dtype)
+        if param.grad is not None:
+            param.grad = param.grad.to(dtype=dtype)
+    after = _dtype_numel_summary(model, lora_only=False)
+    print(
+        f"{label} non-LoRA float dtype cast: target={dtype} changed={changed} "
+        f"skipped_lora={skipped_lora} before={before} after={after}"
+    )
+    return model
+
+
+def cast_lora_parameter_dtype(
+    model,
+    *,
+    dtype: torch.dtype,
+    label: str,
+):
+    before = _dtype_numel_summary(model, lora_only=True)
+    before_trainable = _trainable_dtype_numel_summary(model, lora_only=True)
+    if not before:
+        raise RuntimeError(f"No LoRA parameters found while casting {label} adapter to {dtype}.")
+
+    changed = 0
+    for name, param in model.named_parameters():
+        if "lora_" not in name or not torch.is_floating_point(param.data):
+            continue
+        if param.dtype == dtype:
+            continue
+        changed += int(param.numel())
+        param.data = param.data.to(dtype=dtype)
+        if param.grad is not None:
+            param.grad = param.grad.to(dtype=dtype)
+
+    after = _dtype_numel_summary(model, lora_only=True)
+    after_trainable = _trainable_dtype_numel_summary(model, lora_only=True)
+    print(
+        f"{label} LoRA dtype cast: target={dtype} changed={changed} "
+        f"before={before} before_trainable={before_trainable} "
+        f"after={after} after_trainable={after_trainable}"
+    )
+    return model
+
+
+def load_trainable_initial_adapter(
+    model,
+    *,
+    enabled: bool,
+    adapter_path: str,
+    label: str,
+    adapter_dtype: Optional[torch.dtype] = None,
+    empty_adapter_message: Optional[str] = None,
+    missing_adapter_message: Optional[str] = None,
+    load_message: Optional[str] = None,
+):
+    if not enabled:
+        return model
+    if not adapter_path:
+        raise ValueError(empty_adapter_message or f"{label} adapter path is empty.")
+    if not os.path.exists(adapter_path):
+        raise FileNotFoundError(missing_adapter_message or f"{label} adapter not found: {adapter_path}")
+
+    from peft import PeftModel
+
+    print(load_message or f"Loading trainable initial {label} adapter from {adapter_path}...")
+    model = PeftModel.from_pretrained(model, adapter_path, is_trainable=True)
+    if adapter_dtype is not None:
+        model = cast_lora_parameter_dtype(model, dtype=adapter_dtype, label=f"Initial {label}")
+    return model
 
 
 def build_lora_config(

--- a/ab/gpt/util/ArchDiscovery.py
+++ b/ab/gpt/util/ArchDiscovery.py
@@ -219,8 +219,12 @@ def _extract_attr_types(init_code: str) -> Dict[str, str]:
     if fn is None:
         return attr_types
 
+    local_module_types: Dict[str, str] = {}
     for node in ast.walk(fn):
         if not isinstance(node, ast.Assign):
+            continue
+        if len(node.targets) == 1 and isinstance(node.targets[0], ast.Name) and isinstance(node.value, ast.Call):
+            local_module_types[node.targets[0].id] = _canonical_ctor_from_call(node.value)
             continue
         if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Attribute):
             continue
@@ -255,6 +259,31 @@ def _extract_attr_types(init_code: str) -> Dict[str, str]:
             role = _infer_attr_role(attr_name)
             if role:
                 attr_types[attr_name] = role
+
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (
+            isinstance(func, ast.Attribute)
+            and func.attr == "add_module"
+            and isinstance(func.value, ast.Attribute)
+            and isinstance(func.value.value, ast.Name)
+            and func.value.value.id == "self"
+        ):
+            continue
+        attr_name = func.value.attr
+        module_arg = node.args[1] if len(node.args) >= 2 else None
+        if isinstance(module_arg, ast.Call):
+            module_label = _canonical_ctor_from_call(module_arg, attr_name=attr_name)
+        elif isinstance(module_arg, ast.Name):
+            module_label = local_module_types.get(module_arg.id, "")
+        else:
+            module_label = ""
+        if not module_label:
+            continue
+        if "Fractal" in module_label or "drop_conv3x3_block" in module_label:
+            attr_types[attr_name] = f"Fractal[{module_label}]"
 
     return attr_types
 

--- a/ab/gpt/util/Chatbot.py
+++ b/ab/gpt/util/Chatbot.py
@@ -1,5 +1,8 @@
 # ab/gpt/util/Chatbot.py
 
+import os
+import re
+
 from transformers import PreTrainedTokenizer, PreTrainedModel, pipeline
 from ab.gpt.util.Util import extract_code, extract_hyperparam, extract_transform, extract_all_to_train
 import torch
@@ -48,6 +51,39 @@ def _strip_prompt_prefix(text, prompt):
         return text[len(prompt):].lstrip()
     return text
 
+
+def _env_flag(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _safe_tokenizer_max_length(tokenizer, fallback: int = 4096) -> int:
+    tokenizer_max_len = getattr(tokenizer, "model_max_length", None)
+    try:
+        tokenizer_max_len = int(tokenizer_max_len)
+    except (TypeError, ValueError, OverflowError):
+        tokenizer_max_len = int(fallback)
+    if tokenizer_max_len <= 0 or tokenizer_max_len > 10**8:
+        tokenizer_max_len = int(fallback)
+    return tokenizer_max_len
+
+
+def _strip_reasoning_output(text: str) -> str:
+    if not isinstance(text, str) or not text:
+        return text
+    cleaned = re.sub(r"<think>[\s\S]*?</think>", "", text, flags=re.IGNORECASE)
+    first_tag_positions = [
+        pos for pos in (
+            cleaned.find("<block>"),
+            cleaned.find("<nn>"),
+            cleaned.find("```python"),
+            cleaned.find("```"),
+        )
+        if pos >= 0
+    ]
+    if first_tag_positions:
+        return cleaned[min(first_tag_positions):].lstrip()
+    return cleaned
+
 class ChatBot:
     def __init__(self, model: PreTrainedModel, tokenizer: PreTrainedTokenizer, keep_memory=False,
                  temperature=1.0, top_k=50, top_p=0.9, system_prompt: str = None):
@@ -59,6 +95,8 @@ class ChatBot:
         self.top_k = top_k
         self.top_p = top_p
         self.system_prompt = system_prompt
+        self.disable_chat_template = _env_flag("NNGPT_DISABLE_CHAT_TEMPLATE")
+        self.strip_think_output = _env_flag("NNGPT_STRIP_THINK_OUTPUT")
         
         # Check if model is ONNX (wrapped or direct ORTModel)
         self.is_onnx = (
@@ -68,7 +106,11 @@ class ChatBot:
         )
         
         # Only create pipeline for PyTorch models
-        if not self.is_onnx:
+        force_direct = os.getenv("NNGPT_FORCE_DIRECT_GENERATE", "").strip().lower() in {"1", "true", "yes", "on"}
+        if force_direct:
+            print("[INFO] NNGPT_FORCE_DIRECT_GENERATE set, using direct generation")
+            self.__pipeline = None
+        elif not self.is_onnx:
             try:
                 self.__pipeline = pipeline(
                     "text-generation",
@@ -98,12 +140,14 @@ class ChatBot:
     def _prepare_pipeline_input(self, prompt_text):
         """Build a pipeline-ready text prompt using chat template when available."""
         messages = self._build_messages(prompt_text)
-        if hasattr(self.tokenizer, 'apply_chat_template'):
+        if not self.disable_chat_template and hasattr(self.tokenizer, 'apply_chat_template'):
             return self.tokenizer.apply_chat_template(
                 messages,
                 tokenize=False,
                 add_generation_prompt=True
             )
+        if self.system_prompt:
+            return f"System: {self.system_prompt}\nUser: {prompt_text}\nAssistant:"
         return prompt_text
 
     def _direct_generate_batch(self, prompts, max_new_tokens=None, max_len=None):
@@ -112,9 +156,7 @@ class ChatBot:
             self.model.eval()
 
         formatted_prompts = [self._prepare_pipeline_input(p) for p in prompts]
-        tokenizer_max_len = getattr(self.tokenizer, "model_max_length", None)
-        if tokenizer_max_len is None or tokenizer_max_len > 10**8:
-            tokenizer_max_len = 4096
+        tokenizer_max_len = _safe_tokenizer_max_length(self.tokenizer)
         token_budget = max_new_tokens or 4096
         max_input_len = max(1, tokenizer_max_len - token_budget)
 
@@ -173,6 +215,8 @@ class ChatBot:
         for i in range(outputs.shape[0]):
             generated_ids = outputs[i][padded_input_length:]
             generated = self.tokenizer.decode(generated_ids, skip_special_tokens=True)
+            if self.strip_think_output:
+                generated = _strip_reasoning_output(generated)
             nn = extract_code(generated)
             results.append((nn, extract_hyperparam(generated), extract_transform(generated), generated))
         return results
@@ -216,6 +260,8 @@ class ChatBot:
                     out = _extract_generated_content(out_item)
                 
                 assert isinstance(out, str)
+                if self.strip_think_output:
+                    out = _strip_reasoning_output(out)
                 
                 if self.__keep_memory:
                     self.__messages.append({"role": "assistant", "content": out})
@@ -251,7 +297,7 @@ class ChatBot:
         """Direct model.generate() call without pipeline - works for ONNX and PyTorch"""
         try:
             # Apply chat template to format messages
-            if hasattr(self.tokenizer, 'apply_chat_template'):
+            if not self.disable_chat_template and hasattr(self.tokenizer, 'apply_chat_template'):
                 formatted_prompt = self.tokenizer.apply_chat_template(
                     messages,
                     tokenize=False,
@@ -259,14 +305,19 @@ class ChatBot:
                 )
             else:
                 # Fallback: concatenate messages
-                formatted_prompt = "\n".join([f"{msg['role']}: {msg['content']}" for msg in messages])
+                formatted_prompt = "\n".join([f"{msg['role'].capitalize()}: {msg['content']}" for msg in messages])
+                formatted_prompt = f"{formatted_prompt}\nAssistant:"
             
+            tokenizer_max_len = _safe_tokenizer_max_length(self.tokenizer)
+            token_budget = max_new_tokens or 4096
+            max_input_len = max(1, tokenizer_max_len - token_budget)
+
             # Tokenize input
             inputs = self.tokenizer(
                 formatted_prompt,
                 return_tensors="pt",
                 truncation=True,
-                max_length=max(self.tokenizer.model_max_length - (max_new_tokens or 4096), 128),
+                max_length=max(max_input_len, 128),
                 add_special_tokens=False,  # chat template already includes BOS; prevents EOS being appended
             )
 
@@ -277,14 +328,15 @@ class ChatBot:
                 vocab_size = self.tokenizer.vocab_size
                 max_token_id = input_ids.max().item()
 
-            if max_token_id >= vocab_size:
-                print(f"[WARN] Invalid token IDs detected: max_id={max_token_id}, vocab_size={vocab_size}")
-                print(f"[WARN] Clamping to valid range [0, {vocab_size-1}]")
+                if max_token_id >= vocab_size:
+                    print(f"[WARN] Invalid token IDs detected: max_id={max_token_id}, vocab_size={vocab_size}")
+                    print(f"[WARN] Clamping to valid range [0, {vocab_size-1}]")
 
-            clamp_value = self.tokenizer.eos_token_id if self.tokenizer.eos_token_id is not None else vocab_size - 1
-            input_ids = torch.clamp(input_ids, max=clamp_value)
-            inputs['input_ids'] = input_ids
-            print(f"[WARN] After clamping: max_id={input_ids.max().item()}")
+                clamp_value = self.tokenizer.eos_token_id if self.tokenizer.eos_token_id is not None else vocab_size - 1
+                input_ids = torch.clamp(input_ids, max=clamp_value)
+                inputs['input_ids'] = input_ids
+                if max_token_id >= vocab_size:
+                    print(f"[WARN] After clamping: max_id={input_ids.max().item()}")
 
             
             # Move to appropriate device
@@ -329,6 +381,8 @@ class ChatBot:
             # FIX: Decode only the generated part (skip input prompt)
             generated_ids = outputs[0][input_length:]  # Use input_length, not shape[1]
             out = self.tokenizer.decode(generated_ids, skip_special_tokens=True)
+            if self.strip_think_output:
+                out = _strip_reasoning_output(out)
             
             assert isinstance(out, str)
             

--- a/ab/gpt/util/Const.py
+++ b/ab/gpt/util/Const.py
@@ -15,6 +15,7 @@ conf_prompt_dir = conf_dir / 'prompt'
 conf_test_dir = conf_prompt_dir / 'test'
 conf_train_dir = conf_prompt_dir / 'train'
 conf_llm_dir = conf_dir / 'llm'
+conf_chat_template_dir = conf_dir / 'chat_template'
 
 nngpt_dir = out_dir / 'nngpt'
 

--- a/ab/gpt/util/DatasetSplit.py
+++ b/ab/gpt/util/DatasetSplit.py
@@ -6,11 +6,7 @@ from typing import Any, Optional
 TRAIN_VAL_TEST_PROTOCOL = "trainvaltest"
 
 
-def normalize_split_protocol(_raw: Any = None) -> str:
-    return TRAIN_VAL_TEST_PROTOCOL
-
-
-def stratified_721_indices(targets: Any, *, seed: int = 42) -> tuple[list[int], list[int], list[int]]:
+def stratified_trainvaltest_indices(targets: Any, *, seed: int = 42) -> tuple[list[int], list[int], list[int]]:
     by_class: dict[int, list[int]] = {}
     for index, target in enumerate(list(targets)):
         by_class.setdefault(int(target), []).append(int(index))
@@ -35,7 +31,7 @@ def stratified_721_indices(targets: Any, *, seed: int = 42) -> tuple[list[int], 
     return train_indices, val_indices, test_indices
 
 
-def split_existing_dataset_721(
+def split_existing_dataset_trainvaltest(
     train_source: Any,
     *,
     seed: int = 42,
@@ -47,9 +43,9 @@ def split_existing_dataset_721(
     if targets is None:
         targets = getattr(train_source, "labels", None)
     if targets is None:
-        raise ValueError("Cannot build 7/2/1 split: dataset has no targets/labels attribute")
+        raise ValueError("Cannot build trainvaltest split: dataset has no targets/labels attribute")
 
-    train_indices, val_indices, test_indices = stratified_721_indices(
+    train_indices, val_indices, test_indices = stratified_trainvaltest_indices(
         targets,
         seed=int(seed),
     )

--- a/ab/gpt/util/DatasetSplit.py
+++ b/ab/gpt/util/DatasetSplit.py
@@ -9,23 +9,9 @@ OFFICIAL_PROTOCOL = "official"
 
 def normalize_split_protocol(raw: Any) -> str:
     normalized = str(raw or OFFICIAL_PROTOCOL).strip().lower().replace("-", "").replace("_", "").replace(" ", "")
-    if normalized in {"official", "offical"}:
+    if normalized == "official":
         return OFFICIAL_PROTOCOL
-    if normalized in {
-        "721",
-        "7/2/1",
-        "702010",
-        "70/20/10",
-        "trainval",
-        "trainvaltest",
-        "trainvaltestsplit",
-        "trainvaltestprotocol",
-        "trainvaltestsplitprotocol",
-        "45k5k",
-        "90/10",
-        "45/5",
-        "7500/1969",
-    }:
+    if normalized in {"721", "7/2/1", "trainvaltest"}:
         return TRAIN_VAL_TEST_PROTOCOL
     return OFFICIAL_PROTOCOL
 

--- a/ab/gpt/util/DatasetSplit.py
+++ b/ab/gpt/util/DatasetSplit.py
@@ -4,16 +4,10 @@ import random
 from typing import Any, Optional
 
 TRAIN_VAL_TEST_PROTOCOL = "trainvaltest"
-OFFICIAL_PROTOCOL = "official"
 
 
-def normalize_split_protocol(raw: Any) -> str:
-    normalized = str(raw or OFFICIAL_PROTOCOL).strip().lower().replace("-", "").replace("_", "").replace(" ", "")
-    if normalized == "official":
-        return OFFICIAL_PROTOCOL
-    if normalized in {"721", "7/2/1", "trainvaltest"}:
-        return TRAIN_VAL_TEST_PROTOCOL
-    return OFFICIAL_PROTOCOL
+def normalize_split_protocol(_raw: Any = None) -> str:
+    return TRAIN_VAL_TEST_PROTOCOL
 
 
 def stratified_721_indices(targets: Any, *, seed: int = 42) -> tuple[list[int], list[int], list[int]]:
@@ -61,7 +55,7 @@ def split_existing_dataset_721(
     )
     eval_dataset = eval_source if eval_source is not None else train_source
     return {
-        "protocol": "721",
+        "protocol": TRAIN_VAL_TEST_PROTOCOL,
         "seed": int(seed),
         "train": Subset(train_source, train_indices),
         "reward_eval": Subset(eval_dataset, val_indices),
@@ -95,7 +89,6 @@ def build_classification_reward_split_datasets(
     train_size: int,
     val_size: int,
     seed: int = 42,
-    protocol: str = TRAIN_VAL_TEST_PROTOCOL,
 ) -> dict[str, Any]:
     train_subset, val_subset = split_train_val_dataset(
         train_source,
@@ -104,7 +97,7 @@ def build_classification_reward_split_datasets(
         seed=int(seed),
     )
     return {
-        "protocol": normalize_split_protocol(protocol),
+        "protocol": TRAIN_VAL_TEST_PROTOCOL,
         "seed": int(seed),
         "train": train_subset,
         "reward_eval": val_subset,
@@ -146,61 +139,40 @@ def build_cifar10_split_datasets(
     train_transform: Any,
     eval_transform: Any,
     download: bool,
-    protocol: str = OFFICIAL_PROTOCOL,
     seed: int = 42,
 ) -> dict[str, Any]:
     from torch.utils.data import Subset
     from torchvision import datasets
 
-    split_protocol = normalize_split_protocol(protocol)
-    if split_protocol == TRAIN_VAL_TEST_PROTOCOL:
-        train_source = datasets.CIFAR10(
-            root=root,
-            train=True,
-            download=download,
-            transform=train_transform,
-        )
-        eval_source = datasets.CIFAR10(
-            root=root,
-            train=True,
-            download=download,
-            transform=eval_transform,
-        )
-        train_subset, val_subset = split_train_val_dataset(
-            train_source,
-            train_size=45000,
-            val_size=5000,
-            seed=int(seed),
-        )
-        return {
-            "protocol": TRAIN_VAL_TEST_PROTOCOL,
-            "seed": int(seed),
-            "train": train_subset,
-            "reward_eval": Subset(eval_source, list(getattr(val_subset, "indices", []))),
-            "heldout_test": datasets.CIFAR10(
-                root=root,
-                train=False,
-                download=download,
-                transform=eval_transform,
-            ),
-        }
-
+    train_source = datasets.CIFAR10(
+        root=root,
+        train=True,
+        download=download,
+        transform=train_transform,
+    )
+    eval_source = datasets.CIFAR10(
+        root=root,
+        train=True,
+        download=download,
+        transform=eval_transform,
+    )
+    train_subset, val_subset = split_train_val_dataset(
+        train_source,
+        train_size=45000,
+        val_size=5000,
+        seed=int(seed),
+    )
     return {
-        "protocol": OFFICIAL_PROTOCOL,
+        "protocol": TRAIN_VAL_TEST_PROTOCOL,
         "seed": int(seed),
-        "train": datasets.CIFAR10(
-            root=root,
-            train=True,
-            download=download,
-            transform=train_transform,
-        ),
-        "reward_eval": datasets.CIFAR10(
+        "train": train_subset,
+        "reward_eval": Subset(eval_source, list(getattr(val_subset, "indices", []))),
+        "heldout_test": datasets.CIFAR10(
             root=root,
             train=False,
             download=download,
             transform=eval_transform,
         ),
-        "heldout_test": None,
     }
 
 
@@ -238,61 +210,40 @@ def build_cifar100_split_datasets(
     train_transform: Any,
     eval_transform: Any,
     download: bool,
-    protocol: str = OFFICIAL_PROTOCOL,
     seed: int = 42,
 ) -> dict[str, Any]:
     from torch.utils.data import Subset
     from torchvision import datasets
 
-    split_protocol = normalize_split_protocol(protocol)
-    if split_protocol == TRAIN_VAL_TEST_PROTOCOL:
-        train_source = datasets.CIFAR100(
-            root=root,
-            train=True,
-            download=download,
-            transform=train_transform,
-        )
-        eval_source = datasets.CIFAR100(
-            root=root,
-            train=True,
-            download=download,
-            transform=eval_transform,
-        )
-        train_subset, val_subset = split_train_val_dataset(
-            train_source,
-            train_size=45000,
-            val_size=5000,
-            seed=int(seed),
-        )
-        return {
-            "protocol": TRAIN_VAL_TEST_PROTOCOL,
-            "seed": int(seed),
-            "train": train_subset,
-            "reward_eval": Subset(eval_source, list(getattr(val_subset, "indices", []))),
-            "heldout_test": datasets.CIFAR100(
-                root=root,
-                train=False,
-                download=download,
-                transform=eval_transform,
-            ),
-        }
-
+    train_source = datasets.CIFAR100(
+        root=root,
+        train=True,
+        download=download,
+        transform=train_transform,
+    )
+    eval_source = datasets.CIFAR100(
+        root=root,
+        train=True,
+        download=download,
+        transform=eval_transform,
+    )
+    train_subset, val_subset = split_train_val_dataset(
+        train_source,
+        train_size=45000,
+        val_size=5000,
+        seed=int(seed),
+    )
     return {
-        "protocol": OFFICIAL_PROTOCOL,
+        "protocol": TRAIN_VAL_TEST_PROTOCOL,
         "seed": int(seed),
-        "train": datasets.CIFAR100(
-            root=root,
-            train=True,
-            download=download,
-            transform=train_transform,
-        ),
-        "reward_eval": datasets.CIFAR100(
+        "train": train_subset,
+        "reward_eval": Subset(eval_source, list(getattr(val_subset, "indices", []))),
+        "heldout_test": datasets.CIFAR100(
             root=root,
             train=False,
             download=download,
             transform=eval_transform,
         ),
-        "heldout_test": None,
     }
 
 

--- a/ab/gpt/util/DatasetSplit.py
+++ b/ab/gpt/util/DatasetSplit.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+import random
+from typing import Any, Optional
+
+TRAIN_VAL_TEST_PROTOCOL = "trainvaltest"
+OFFICIAL_PROTOCOL = "official"
+
+
+def normalize_split_protocol(raw: Any) -> str:
+    normalized = str(raw or OFFICIAL_PROTOCOL).strip().lower().replace("-", "").replace("_", "").replace(" ", "")
+    if normalized in {"official", "offical"}:
+        return OFFICIAL_PROTOCOL
+    if normalized in {
+        "721",
+        "7/2/1",
+        "702010",
+        "70/20/10",
+        "trainval",
+        "trainvaltest",
+        "trainvaltestsplit",
+        "trainvaltestprotocol",
+        "trainvaltestsplitprotocol",
+        "45k5k",
+        "90/10",
+        "45/5",
+        "7500/1969",
+    }:
+        return TRAIN_VAL_TEST_PROTOCOL
+    return OFFICIAL_PROTOCOL
+
+
+def stratified_721_indices(targets: Any, *, seed: int = 42) -> tuple[list[int], list[int], list[int]]:
+    by_class: dict[int, list[int]] = {}
+    for index, target in enumerate(list(targets)):
+        by_class.setdefault(int(target), []).append(int(index))
+
+    rng = random.Random(int(seed))
+    train_indices: list[int] = []
+    val_indices: list[int] = []
+    test_indices: list[int] = []
+    for label in sorted(by_class):
+        indices = list(by_class[label])
+        rng.shuffle(indices)
+        n_total = len(indices)
+        n_train = int(round(n_total * 0.70))
+        n_val = int(round(n_total * 0.20))
+        train_indices.extend(indices[:n_train])
+        val_indices.extend(indices[n_train : n_train + n_val])
+        test_indices.extend(indices[n_train + n_val :])
+
+    rng.shuffle(train_indices)
+    rng.shuffle(val_indices)
+    rng.shuffle(test_indices)
+    return train_indices, val_indices, test_indices
+
+
+def split_existing_dataset_721(
+    train_source: Any,
+    *,
+    seed: int = 42,
+    eval_source: Optional[Any] = None,
+) -> dict[str, Any]:
+    from torch.utils.data import Subset
+
+    targets = getattr(train_source, "targets", None)
+    if targets is None:
+        targets = getattr(train_source, "labels", None)
+    if targets is None:
+        raise ValueError("Cannot build 7/2/1 split: dataset has no targets/labels attribute")
+
+    train_indices, val_indices, test_indices = stratified_721_indices(
+        targets,
+        seed=int(seed),
+    )
+    eval_dataset = eval_source if eval_source is not None else train_source
+    return {
+        "protocol": "721",
+        "seed": int(seed),
+        "train": Subset(train_source, train_indices),
+        "reward_eval": Subset(eval_dataset, val_indices),
+        "heldout_test": Subset(eval_dataset, test_indices),
+    }
+
+
+def split_train_val_dataset(
+    train_source: Any,
+    *,
+    train_size: int,
+    val_size: int,
+    seed: int = 42,
+) -> tuple[Any, Any]:
+    from torch import Generator
+    from torch.utils.data import random_split
+
+    total_size = int(train_size) + int(val_size)
+    if len(train_source) != total_size:
+        raise ValueError(
+            f"Cannot split dataset of length {len(train_source)} into {train_size}+{val_size}"
+        )
+    generator = Generator().manual_seed(int(seed))
+    return random_split(train_source, [int(train_size), int(val_size)], generator=generator)
+
+
+def build_classification_reward_split_datasets(
+    *,
+    train_source: Any,
+    heldout_test_source: Any,
+    train_size: int,
+    val_size: int,
+    seed: int = 42,
+    protocol: str = TRAIN_VAL_TEST_PROTOCOL,
+) -> dict[str, Any]:
+    train_subset, val_subset = split_train_val_dataset(
+        train_source,
+        train_size=int(train_size),
+        val_size=int(val_size),
+        seed=int(seed),
+    )
+    return {
+        "protocol": normalize_split_protocol(protocol),
+        "seed": int(seed),
+        "train": train_subset,
+        "reward_eval": val_subset,
+        "heldout_test": heldout_test_source,
+    }
+
+
+def build_cifar10_reward_split_datasets(
+    *,
+    root: str,
+    transform: Any,
+    download: bool,
+    seed: int = 42,
+) -> dict[str, Any]:
+    from torchvision import datasets
+
+    return build_classification_reward_split_datasets(
+        train_source=datasets.CIFAR10(
+            root=root,
+            train=True,
+            download=download,
+            transform=transform,
+        ),
+        heldout_test_source=datasets.CIFAR10(
+            root=root,
+            train=False,
+            download=download,
+            transform=transform,
+        ),
+        train_size=45000,
+        val_size=5000,
+        seed=int(seed),
+    )
+
+
+def build_cifar10_split_datasets(
+    *,
+    root: str,
+    train_transform: Any,
+    eval_transform: Any,
+    download: bool,
+    protocol: str = OFFICIAL_PROTOCOL,
+    seed: int = 42,
+) -> dict[str, Any]:
+    from torch.utils.data import Subset
+    from torchvision import datasets
+
+    split_protocol = normalize_split_protocol(protocol)
+    if split_protocol == TRAIN_VAL_TEST_PROTOCOL:
+        train_source = datasets.CIFAR10(
+            root=root,
+            train=True,
+            download=download,
+            transform=train_transform,
+        )
+        eval_source = datasets.CIFAR10(
+            root=root,
+            train=True,
+            download=download,
+            transform=eval_transform,
+        )
+        train_subset, val_subset = split_train_val_dataset(
+            train_source,
+            train_size=45000,
+            val_size=5000,
+            seed=int(seed),
+        )
+        return {
+            "protocol": TRAIN_VAL_TEST_PROTOCOL,
+            "seed": int(seed),
+            "train": train_subset,
+            "reward_eval": Subset(eval_source, list(getattr(val_subset, "indices", []))),
+            "heldout_test": datasets.CIFAR10(
+                root=root,
+                train=False,
+                download=download,
+                transform=eval_transform,
+            ),
+        }
+
+    return {
+        "protocol": OFFICIAL_PROTOCOL,
+        "seed": int(seed),
+        "train": datasets.CIFAR10(
+            root=root,
+            train=True,
+            download=download,
+            transform=train_transform,
+        ),
+        "reward_eval": datasets.CIFAR10(
+            root=root,
+            train=False,
+            download=download,
+            transform=eval_transform,
+        ),
+        "heldout_test": None,
+    }
+
+
+def build_cifar100_reward_split_datasets(
+    *,
+    root: str,
+    transform: Any,
+    download: bool,
+    seed: int = 42,
+) -> dict[str, Any]:
+    from torchvision import datasets
+
+    return build_classification_reward_split_datasets(
+        train_source=datasets.CIFAR100(
+            root=root,
+            train=True,
+            download=download,
+            transform=transform,
+        ),
+        heldout_test_source=datasets.CIFAR100(
+            root=root,
+            train=False,
+            download=download,
+            transform=transform,
+        ),
+        train_size=45000,
+        val_size=5000,
+        seed=int(seed),
+    )
+
+
+def build_cifar100_split_datasets(
+    *,
+    root: str,
+    train_transform: Any,
+    eval_transform: Any,
+    download: bool,
+    protocol: str = OFFICIAL_PROTOCOL,
+    seed: int = 42,
+) -> dict[str, Any]:
+    from torch.utils.data import Subset
+    from torchvision import datasets
+
+    split_protocol = normalize_split_protocol(protocol)
+    if split_protocol == TRAIN_VAL_TEST_PROTOCOL:
+        train_source = datasets.CIFAR100(
+            root=root,
+            train=True,
+            download=download,
+            transform=train_transform,
+        )
+        eval_source = datasets.CIFAR100(
+            root=root,
+            train=True,
+            download=download,
+            transform=eval_transform,
+        )
+        train_subset, val_subset = split_train_val_dataset(
+            train_source,
+            train_size=45000,
+            val_size=5000,
+            seed=int(seed),
+        )
+        return {
+            "protocol": TRAIN_VAL_TEST_PROTOCOL,
+            "seed": int(seed),
+            "train": train_subset,
+            "reward_eval": Subset(eval_source, list(getattr(val_subset, "indices", []))),
+            "heldout_test": datasets.CIFAR100(
+                root=root,
+                train=False,
+                download=download,
+                transform=eval_transform,
+            ),
+        }
+
+    return {
+        "protocol": OFFICIAL_PROTOCOL,
+        "seed": int(seed),
+        "train": datasets.CIFAR100(
+            root=root,
+            train=True,
+            download=download,
+            transform=train_transform,
+        ),
+        "reward_eval": datasets.CIFAR100(
+            root=root,
+            train=False,
+            download=download,
+            transform=eval_transform,
+        ),
+        "heldout_test": None,
+    }
+
+
+def build_imagenette_reward_split_datasets(
+    *,
+    root: str,
+    transform: Any,
+    download: bool,
+    seed: int = 42,
+) -> dict[str, Any]:
+    from torchvision import datasets
+
+    return build_classification_reward_split_datasets(
+        train_source=datasets.Imagenette(
+            root=root,
+            split="train",
+            download=download,
+            transform=transform,
+        ),
+        heldout_test_source=datasets.Imagenette(
+            root=root,
+            split="val",
+            download=download,
+            transform=transform,
+        ),
+        train_size=7500,
+        val_size=1969,
+        seed=int(seed),
+    )
+
+
+def build_formal_reward_split_datasets(
+    *,
+    dataset_name: str,
+    root: str,
+    transform: Any,
+    download: bool,
+    seed: int = 42,
+) -> dict[str, Any]:
+    normalized_dataset = str(dataset_name or "").strip().lower().replace("_", "-")
+    if normalized_dataset in {"cifar-10", "cifar10"}:
+        return build_cifar10_reward_split_datasets(
+            root=root,
+            transform=transform,
+            download=download,
+            seed=int(seed),
+        )
+    if normalized_dataset in {"cifar-100", "cifar100"}:
+        return build_cifar100_reward_split_datasets(
+            root=root,
+            transform=transform,
+            download=download,
+            seed=int(seed),
+        )
+    if normalized_dataset == "imagenette":
+        return build_imagenette_reward_split_datasets(
+            root=root,
+            transform=transform,
+            download=download,
+            seed=int(seed),
+        )
+    raise ValueError(f"Unsupported formal dataset for reward split: {dataset_name!r}")

--- a/ab/gpt/util/LLM.py
+++ b/ab/gpt/util/LLM.py
@@ -1,6 +1,6 @@
 # ab/gpt/util/LLM.py
 from ab.nn.util.Const import out_dir
-from ab.gpt.util.Const import llm_dir, llm_tokenizer_dir
+from ab.gpt.util.Const import conf_chat_template_dir, llm_dir, llm_tokenizer_dir
 from ab.gpt.util.LLMUtil import quantization_config_4bit
 from ab.gpt.util.Util import exists
 
@@ -8,6 +8,7 @@ import os
 import json
 import tempfile
 import shutil
+from pathlib import Path
 import torch
 import torch.cuda
 from transformers import (
@@ -33,9 +34,11 @@ class LLM:
                  gguf_file=None,
                  training_args=None,
                  use_unsloth=False,
-                 load_in_4bit=True):
+                 load_in_4bit=True,
+                 chat_template_path=None):
         self.context_length = context_length
         self._use_unsloth = use_unsloth
+        self.chat_template_path = chat_template_path
         
         # ===== Unsloth Fast Path =====
         if use_unsloth:
@@ -52,6 +55,7 @@ class LLM:
             if self.tokenizer.pad_token_id is None:
                 self.tokenizer.pad_token = self.tokenizer.eos_token
             self.tokenizer.padding_side = "right"
+            self._apply_chat_template_override()
             print(f"[Unsloth] Loaded {model_path}, 4bit={load_in_4bit}")
             return
         
@@ -72,6 +76,7 @@ class LLM:
             # This is safer for LLaMA-like models (e.g., DeepSeek-Coder)
             self.tokenizer.pad_token = self.tokenizer.eos_token
         self.tokenizer.padding_side = "right"
+        self._apply_chat_template_override()
 
         if tokenizer_exists:
             print("Loading Tokenizer from local files:", tok_fl_nm)
@@ -168,6 +173,17 @@ class LLM:
         else:
             self.model.save_pretrained(raw_fl_nm, access_token=access_token)
             print("Model saved to: ", raw_fl_nm)
+
+    def _apply_chat_template_override(self) -> None:
+        if not self.chat_template_path:
+            return
+        template_path = Path(str(self.chat_template_path)).expanduser()
+        if not template_path.is_absolute():
+            template_path = conf_chat_template_dir / template_path
+        if not template_path.exists():
+            raise FileNotFoundError(f"chat_template_path not found: {template_path}")
+        self.tokenizer.chat_template = template_path.read_text(encoding="utf-8")
+        print(f"[LLM] Applied chat template override: {template_path}")
 
     def get_model(self) -> PreTrainedModel:
         return self.model

--- a/ab/gpt/util/LoRA.py
+++ b/ab/gpt/util/LoRA.py
@@ -175,8 +175,12 @@ class LoRA:
         """
         self.peft_model.config.use_cache = False
         
-        # Check if dataset has "text" field (pre-rendered) or needs formatting
-        has_text_field = "text" in dataset.column_names if hasattr(dataset, 'column_names') else False
+        # Check if dataset has pre-rendered text or prompt/completion pairs.
+        column_names = set(dataset.column_names) if hasattr(dataset, 'column_names') else set()
+        has_text_field = "text" in column_names
+        has_prompt_completion = {"prompt", "completion"}.issubset(column_names)
+        if has_prompt_completion:
+            train_on_completions_only = True
         
         # Split The dataset
         dataset = dataset.train_test_split(test_size=0.1)
@@ -188,7 +192,7 @@ class LoRA:
         print_trainable_parameters(self.peft_model)
 
         # Determine data collator and trainer kwargs
-        if train_on_completions_only:
+        if train_on_completions_only and not has_prompt_completion:
             if response_template is None:
                 # Try to auto-detect response template from first example
                 if has_text_field and len(train_dataset) > 0:
@@ -240,44 +244,44 @@ class LoRA:
                 return_tensors="pt"
             )
 
-        # Use SFTTrainer for pre-rendered text, or fallback to Trainer if needed
-        # TL;DR: Feed Dataset.from_list([...{"text": ...}...]) to SFTTrainer with dataset_text_field="text"
-        # Choose:
-        #   Simple: train on full text (packing=True)
-        #   Precise: DataCollatorForCompletionOnlyLM with response_template + packing=False
-        if has_text_field:
-            print("[INFO] Using SFTTrainer with pre-rendered text (dataset_text_field='text')")
-            # Packing: enable when NOT using completion-only masking (completion-only requires packing=False)
-            # Simple mode: packing=True (train on full text)
-            # Precise mode: packing=False + DataCollatorForCompletionOnlyLM (train on completions only)
-            use_packing = not train_on_completions_only
+        # Use SFTTrainer for pre-rendered text or prompt/completion pairs.
+        if has_text_field or has_prompt_completion:
+            if has_prompt_completion:
+                print("[INFO] Using SFTTrainer with prompt/completion dataset")
+            else:
+                print("[INFO] Using SFTTrainer with pre-rendered text (dataset_text_field='text')")
+            use_packing = False if has_prompt_completion else not train_on_completions_only
             print(f"[INFO] Packing enabled: {use_packing} ({'Simple mode: full text' if use_packing else 'Precise mode: completions only'})")
+            sft_max_length = getattr(self.training_args, "max_length", None) or 4096
+            print(f"[INFO] SFT max_length: {sft_max_length}")
             
             # Configure tokenizer for SFT: truncate from left (keep assistant response), pad on right
             # This ensures sequences are truncated correctly when SFTTrainer tokenizes
             self.tokenizer.truncation_side = "left"
             self.tokenizer.padding_side = "right"
-            # self.tokenizer.model_max_length = 4096  # DeepSeek-Coder-7B-Instruct-v1.5 has ~4K context
+            self.tokenizer.model_max_length = sft_max_length
             
             # Suppress sequence length warnings - SFTTrainer will handle truncation correctly
             import warnings
             warnings.filterwarnings("ignore", message=".*sequence length.*longer than.*maximum.*")
             warnings.filterwarnings("ignore", message=".*Token indices sequence length.*")
             
-            # Set packing, max_seq_length, and dataset_text_field in SFTConfig to avoid warnings
+            # Set packing, max_length, and dataset_text_field in SFTConfig to avoid warnings
             # Convert to SFTConfig if not already, or set attributes directly
             if isinstance(self.training_args, SFTConfig):
                 self.training_args.remove_unused_columns = False  # critical when using raw text
                 self.training_args.packing = use_packing  # Simple: True, Precise: False
-                self.training_args.max_seq_length = 4096  # DeepSeek-Coder-7B-Instruct-v1.5 has ~4K context (4k/4.1k)
-                self.training_args.dataset_text_field = "text"  # Feed Dataset with {"text": ...} format
+                self.training_args.max_length = sft_max_length
+                if has_text_field:
+                    self.training_args.dataset_text_field = "text"  # Feed Dataset with {"text": ...} format
             else:
                 # If training_args is TrainingArguments, create SFTConfig with all attributes
                 sft_config = SFTConfig(**self.training_args.to_dict())
                 sft_config.remove_unused_columns = False  # critical when using raw text
                 sft_config.packing = use_packing  # Simple: True, Precise: False
-                sft_config.max_seq_length = 8192  # DeepSeek-Coder-7B-Instruct-v1.5 has ~4K context (4k/4.1k)
-                sft_config.dataset_text_field = "text"  # Feed Dataset with {"text": ...} format
+                sft_config.max_length = sft_max_length
+                if has_text_field:
+                    sft_config.dataset_text_field = "text"  # Feed Dataset with {"text": ...} format
                 self.training_args = sft_config
             
             # SFTTrainer will handle tokenization and truncation internally
@@ -288,9 +292,9 @@ class LoRA:
                 train_dataset=train_dataset,
                 eval_dataset=eval_dataset,
                 args=self.training_args,
-                #data_collator=collator  # Simple: DataCollatorForLanguageModeling, Precise: DataCollatorForCompletionOnlyLM
-                # packing, max_seq_length, and dataset_text_field are in training_args (SFTConfig)
-                # SFTTrainer will handle truncation based on max_seq_length and tokenizer settings
+                data_collator=collator  # Simple: DataCollatorForLanguageModeling, Precise: DataCollatorForCompletionOnlyLM
+                # packing, max_length, and dataset_text_field are in training_args (SFTConfig)
+                # SFTTrainer will handle truncation based on max_length and tokenizer settings
             )
         else:
             print("[WARN] Dataset does not have 'text' field. Using standard Trainer.")

--- a/ab/gpt/util/Reward.py
+++ b/ab/gpt/util/Reward.py
@@ -2482,7 +2482,6 @@ def _build_cifar10_loaders(cfg: "EvalConfig") -> Tuple[DataLoader, DataLoader]:
         train_transform=train_transform,
         eval_transform=val_transform,
         download=cfg.download,
-        protocol=getattr(cfg, "split_protocol", "official"),
         seed=int(getattr(cfg, "split_seed", 42)),
     )
     eval_split_role = str(getattr(cfg, "eval_split_role", "reward_eval") or "reward_eval")
@@ -2531,7 +2530,7 @@ class EvalConfig:
     val_subset_size: int = 0
     data_root: str = "data_v2"
     download: bool = True
-    split_protocol: str = "official"
+    split_protocol: str = DatasetSplit.TRAIN_VAL_TEST_PROTOCOL
     split_seed: int = 42
     eval_split_role: str = "reward_eval"
     # Optional efficiency logging
@@ -2757,9 +2756,7 @@ def _restore_nn_dataset_dataroll_patch(patch_token: Optional[Tuple[type, Any, An
 
 
 def _patch_nn_dataset_load_dataset_for_reward(cfg: "EvalConfig") -> Optional[Dict[str, Any]]:
-    split_protocol = DatasetSplit.normalize_split_protocol(getattr(cfg, "split_protocol", "official"))
-    if split_protocol == "official":
-        return None
+    split_protocol = DatasetSplit.TRAIN_VAL_TEST_PROTOCOL
 
     try:
         import ab.nn.util.Loader as nn_loader  # type: ignore
@@ -3299,7 +3296,7 @@ def _formal_eval_with_nn_dataset(
         "epoch_limit_minutes": epoch_limit_minutes,
         "formal_reward_epochs": list(formal_reward_epochs),
         "formal_reward_max_epoch": int(formal_reward_max_epoch),
-        "split_protocol": DatasetSplit.normalize_split_protocol(getattr(cfg, "split_protocol", "official")),
+        "split_protocol": DatasetSplit.TRAIN_VAL_TEST_PROTOCOL,
         "split_seed": int(getattr(cfg, "split_seed", 42)),
         "eval_split_role": str(getattr(cfg, "eval_split_role", "reward_eval") or "reward_eval"),
     }
@@ -4312,7 +4309,7 @@ def _loader_cache_key(cfg: EvalConfig) -> Tuple[Any, ...]:
         cfg.val_subset_size,
         cfg.data_root,
         cfg.download,
-        DatasetSplit.normalize_split_protocol(getattr(cfg, "split_protocol", "official")),
+        DatasetSplit.TRAIN_VAL_TEST_PROTOCOL,
         int(getattr(cfg, "split_seed", 42)),
         str(getattr(cfg, "eval_split_role", "reward_eval") or "reward_eval"),
         bool(getattr(cfg, "full_test_acc", False)),

--- a/ab/gpt/util/Reward.py
+++ b/ab/gpt/util/Reward.py
@@ -2,6 +2,7 @@ from typing import Optional, Dict, Tuple, Callable, Any
 from dataclasses import dataclass, asdict, replace
 import atexit
 import ast
+import ctypes
 import csv
 import gc
 import importlib
@@ -14,13 +15,15 @@ import subprocess
 import sys
 import tempfile
 import time
+import traceback
 from concurrent.futures import ThreadPoolExecutor
 
 import torch
+import ab.gpt.util.DatasetSplit as DatasetSplit
 import ab.gpt.rl_pipeline.reward_payload as RewardPayload
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.utils.data import DataLoader, Subset
+from torch.utils.data import DataLoader, Subset, TensorDataset
 
 
 _NN_DATASET_IMPORT_READY = False
@@ -99,6 +102,26 @@ def _env_is_set(name: str) -> bool:
     return raw is not None and raw != ""
 
 
+def _clear_exception_frames(exc: BaseException) -> None:
+    try:
+        traceback.clear_frames(exc.__traceback__)
+    except Exception:
+        pass
+
+
+def _trim_cpu_allocator() -> None:
+    gc.collect()
+    if not sys.platform.startswith("linux"):
+        return
+    try:
+        libc = ctypes.CDLL("libc.so.6")
+        malloc_trim = getattr(libc, "malloc_trim", None)
+        if callable(malloc_trim):
+            malloc_trim(0)
+    except Exception:
+        pass
+
+
 def _optional_positive_int_env(name: str) -> Optional[int]:
     raw = os.environ.get(name)
     if raw is None or raw == "":
@@ -111,8 +134,10 @@ def _optional_positive_int_env(name: str) -> Optional[int]:
 
 
 FORMAL_MULTI_HORIZON_REWARD_TARGET_METRIC = "formal_multi_horizon_acc"
-DEFAULT_FORMAL_REWARD_EPOCHS: tuple[int, ...] = (1, 5, 10)
+DEFAULT_FORMAL_REWARD_EPOCHS: tuple[int, ...] = (1,)
 FORMAL_REWARD_SCORE_HORIZONS: tuple[int, ...] = (1, 5, 10)
+CPU_SMOKE_MAX_ESTIMATED_PARAM_GIB_DEFAULT = 8.0
+CPU_SMOKE_TRAIN_STATE_MULTIPLIER_DEFAULT = 4.0
 
 
 def _parse_formal_reward_epochs(raw: Optional[str]) -> list[int]:
@@ -190,6 +215,8 @@ def get_distributed_runtime_info() -> Dict[str, Any]:
         visible_gpu_tokens = [str(index) for index in range(max(0, visible_gpu_count))]
     configured_train_gpu_tokens = _configured_cuda_device_tokens("NNGPT_TRAIN_GPU_TOKENS")
     configured_reward_gpu_tokens = _configured_cuda_device_tokens("NNGPT_REWARD_GPU_TOKENS")
+    if configured_reward_gpu_tokens is None:
+        configured_reward_gpu_tokens = _configured_cuda_device_tokens("NNGPT_REWARD_GPU_INDICES")
     if configured_reward_gpu_tokens is None:
         configured_reward_gpu_tokens = _configured_cuda_device_tokens("NNGPT_AUX_GPU_TOKENS")
 
@@ -602,7 +629,6 @@ def get_reward_worker_plan() -> Dict[str, Any]:
                 reason="configured_reward_gpu_unavailable",
                 gpu_memory_snapshots=gpu_memory_snapshots,
             )
-        gpu_priority_indices = _ordered_reward_gpu_indices(reward_gpu_indices, gpu_memory_snapshots)
         per_gpu_worker_counts = [0] * visible_gpu_count
         for reward_gpu_index in reward_gpu_indices:
             per_gpu_worker_counts[int(reward_gpu_index)] = workers_per_gpu
@@ -615,12 +641,12 @@ def get_reward_worker_plan() -> Dict[str, Any]:
             mode=mode,
             per_gpu_worker_counts=per_gpu_worker_counts,
             dynamic_scaling=False,
-            gpu_priority_indices=gpu_priority_indices,
+            gpu_priority_indices=list(reward_gpu_indices),
             gpu_memory_snapshots=gpu_memory_snapshots,
             reason="fixed_workers_override",
         )
 
-    dynamic_scaling = _safe_bool_env("NNGPT_REWARD_ENABLE_DYNAMIC_SCALING", True)
+    dynamic_scaling = _safe_bool_env("NNGPT_REWARD_ENABLE_DYNAMIC_SCALING", False)
     if not dynamic_scaling:
         reward_gpu_indices = list(configured_reward_gpu_indices)
         gpu_memory_snapshots = [
@@ -633,7 +659,6 @@ def get_reward_worker_plan() -> Dict[str, Any]:
                 reason="configured_reward_gpu_unavailable",
                 gpu_memory_snapshots=gpu_memory_snapshots,
             )
-        gpu_priority_indices = _ordered_reward_gpu_indices(reward_gpu_indices, gpu_memory_snapshots)
         per_gpu_worker_counts = [0] * visible_gpu_count
         for reward_gpu_index in reward_gpu_indices:
             per_gpu_worker_counts[int(reward_gpu_index)] = 1
@@ -646,7 +671,7 @@ def get_reward_worker_plan() -> Dict[str, Any]:
             mode=mode,
             per_gpu_worker_counts=per_gpu_worker_counts,
             dynamic_scaling=False,
-            gpu_priority_indices=gpu_priority_indices,
+            gpu_priority_indices=list(reward_gpu_indices),
             gpu_memory_snapshots=gpu_memory_snapshots,
             reason="dynamic_scaling_disabled",
         )
@@ -729,12 +754,16 @@ def _reward_worker_plan_signature(plan: Dict[str, Any]) -> Tuple[Any, ...]:
         int(plan.get("world_size", 1)),
         tuple(int(index) for index in plan.get("reward_gpu_indices", [])),
         tuple(str(token) for token in plan.get("reward_gpu_tokens", [])),
+        tuple(int(count) for count in plan.get("per_gpu_worker_counts", [])),
+        int(plan.get("pool_size", 0)),
+        bool(plan.get("dynamic_scaling", False)),
     )
 
 
 def _clear_reward_cuda_state() -> None:
     gc.collect()
     if not torch.cuda.is_available():
+        _trim_cpu_allocator()
         return
     try:
         torch.cuda.empty_cache()
@@ -742,6 +771,38 @@ def _clear_reward_cuda_state() -> None:
         pass
     try:
         torch.cuda.ipc_collect()
+    except Exception:
+        pass
+    _trim_cpu_allocator()
+
+
+def _shutdown_reward_dataloader(loader: Any) -> None:
+    if loader is None:
+        return
+    iterator = getattr(loader, "_iterator", None)
+    if iterator is not None:
+        try:
+            shutdown_workers = getattr(iterator, "_shutdown_workers", None)
+            if callable(shutdown_workers):
+                shutdown_workers()
+        except Exception:
+            pass
+        try:
+            loader._iterator = None
+        except Exception:
+            pass
+
+
+def _shutdown_registered_reward_loaders(patch_token: Optional[Dict[str, Any]]) -> None:
+    if not isinstance(patch_token, dict):
+        return
+    loaders = patch_token.get("loaders")
+    if not loaders:
+        return
+    for loader in list(loaders):
+        _shutdown_reward_dataloader(loader)
+    try:
+        loaders.clear()
     except Exception:
         pass
 
@@ -1489,18 +1550,72 @@ def _cpu_smoke_prevalidate_reward_code(
     safe_prm["epoch"] = 1
 
     model = None
+    builder = None
+    forward_input = None
+    output = None
+    strict_forward = _safe_bool_env("NNGPT_RL_CPU_SMOKE_STRICT_FORWARD", True)
     smoke_context = {
         "code_trace": code_trace,
         "cpu_smoke": True,
         "cpu_smoke_input_shape": cpu_input_shape,
+        "cpu_smoke_strict_forward": strict_forward,
     }
     original_cuda_is_available = getattr(torch.cuda, "is_available", None)
     original_cuda_device_count = getattr(torch.cuda, "device_count", None)
+    original_smoke_flag = os.environ.get("NNGPT_SMOKE_PREVALIDATE")
     try:
+        os.environ["NNGPT_SMOKE_PREVALIDATE"] = "1"
         if callable(original_cuda_is_available):
             torch.cuda.is_available = lambda: False  # type: ignore[method-assign]
         if callable(original_cuda_device_count):
             torch.cuda.device_count = lambda: 0  # type: ignore[method-assign]
+        if _safe_bool_env("NNGPT_RL_CPU_SMOKE_META_ESTIMATE", True):
+            max_gib = max(
+                0.0,
+                _safe_float_env("NNGPT_RL_CPU_SMOKE_MAX_ESTIMATED_PARAM_GIB", CPU_SMOKE_MAX_ESTIMATED_PARAM_GIB_DEFAULT),
+            )
+            multiplier = max(
+                1.0,
+                _safe_float_env("NNGPT_RL_CPU_SMOKE_TRAIN_STATE_MULTIPLIER", CPU_SMOKE_TRAIN_STATE_MULTIPLIER_DEFAULT),
+            )
+            try:
+                meta_builder = build_fn_from_code(
+                    code,
+                    cpu_input_shape,
+                    (int(getattr(effective_cfg, "n_classes", 10)),),
+                    safe_prm,
+                    "meta",
+                )
+                with torch.device("meta"):
+                    meta_model = meta_builder()
+                params = sum(int(p.numel()) for p in meta_model.parameters())
+                buffers = sum(int(b.numel()) for b in meta_model.buffers())
+                param_gib = float(params + buffers) * 4.0 / float(1024 ** 3)
+                estimated_gib = param_gib * multiplier
+                smoke_context.update(
+                    {
+                        "memory_preflight": "meta_build",
+                        "estimated_params_m": params / 1e6,
+                        "estimated_param_gib": param_gib,
+                        "estimated_train_state_gib": estimated_gib,
+                        "max_estimated_param_gib": max_gib,
+                    }
+                )
+                if max_gib > 0 and estimated_gib > max_gib:
+                    return _cpu_prevalidation_failure_result(
+                        reward=-3.0,
+                        error_message=(
+                            "RuntimeError: estimated reward eval memory "
+                            f"{estimated_gib:.2f}GiB exceeds limit {max_gib:.2f}GiB"
+                        ),
+                        error_type="RuntimeError",
+                        error_context=smoke_context,
+                        seed_accuracy_baseline=seed_accuracy_baseline,
+                        effective_cfg=effective_cfg,
+                        backbone_model_names=backbone_model_names,
+                    )
+            except Exception as meta_exc:
+                _clear_exception_frames(meta_exc)
         builder = build_fn_from_code(
             code,
             cpu_input_shape,
@@ -1515,13 +1630,15 @@ def _cpu_smoke_prevalidate_reward_code(
         train_setup = getattr(model, "train_setup", None)
         if callable(train_setup):
             train_setup(safe_prm)
-        forward_input = torch.randn(*cpu_input_shape, device="cpu")
-        with torch.no_grad():
-            output = model(forward_input)
-        smoke_context["cpu_smoke_output_shape"] = tuple(output.shape) if hasattr(output, "shape") else None
+        if strict_forward:
+            forward_input = torch.randn(*cpu_input_shape, device="cpu")
+            with torch.no_grad():
+                output = model(forward_input)
+            smoke_context["cpu_smoke_output_shape"] = tuple(output.shape) if hasattr(output, "shape") else None
     except Exception as exc:
         error_type = type(exc).__name__
         error_message = f"{error_type}: {exc}"
+        _clear_exception_frames(exc)
         return _cpu_prevalidation_failure_result(
             reward=-3.0,
             error_message=error_message,
@@ -1536,13 +1653,32 @@ def _cpu_smoke_prevalidate_reward_code(
             torch.cuda.is_available = original_cuda_is_available  # type: ignore[method-assign]
         if callable(original_cuda_device_count):
             torch.cuda.device_count = original_cuda_device_count  # type: ignore[method-assign]
+        if original_smoke_flag is None:
+            os.environ.pop("NNGPT_SMOKE_PREVALIDATE", None)
+        else:
+            os.environ["NNGPT_SMOKE_PREVALIDATE"] = original_smoke_flag
+        try:
+            del output
+        except Exception:
+            pass
+        try:
+            del forward_input
+        except Exception:
+            pass
         if model is not None:
             try:
                 model.to("cpu")
             except Exception:
                 pass
+        try:
             del model
-        gc.collect()
+        except Exception:
+            pass
+        try:
+            del builder
+        except Exception:
+            pass
+        _trim_cpu_allocator()
     return None
 
 
@@ -1674,7 +1810,7 @@ def _base_eval_result(
         seed_accuracy_baseline=seed_accuracy_baseline,
         eval_limit_seconds=eval_limit_seconds,
         backbone_model_names=backbone_model_names,
-        formal_reward_epochs=DEFAULT_FORMAL_REWARD_EPOCHS,
+        formal_reward_epochs=_resolve_formal_reward_epochs(),
     )
 
 
@@ -2317,7 +2453,7 @@ def _quick_accuracy(
 
 
 def _build_cifar10_loaders(cfg: "EvalConfig") -> Tuple[DataLoader, DataLoader]:
-    from torchvision import datasets, transforms
+    from torchvision import transforms
 
     height = int(cfg.input_shape[2])
     width = int(cfg.input_shape[3])
@@ -2341,18 +2477,17 @@ def _build_cifar10_loaders(cfg: "EvalConfig") -> Tuple[DataLoader, DataLoader]:
         ]
     )
 
-    train_dataset = datasets.CIFAR10(
+    split_datasets = DatasetSplit.build_cifar10_split_datasets(
         root=cfg.data_root,
-        train=True,
+        train_transform=train_transform,
+        eval_transform=val_transform,
         download=cfg.download,
-        transform=train_transform,
+        protocol=getattr(cfg, "split_protocol", "official"),
+        seed=int(getattr(cfg, "split_seed", 42)),
     )
-    val_dataset = datasets.CIFAR10(
-        root=cfg.data_root,
-        train=False,
-        download=cfg.download,
-        transform=val_transform,
-    )
+    eval_split_role = str(getattr(cfg, "eval_split_role", "reward_eval") or "reward_eval")
+    train_dataset = split_datasets["train"]
+    val_dataset = split_datasets.get(eval_split_role) or split_datasets["reward_eval"]
 
     if 0 < cfg.train_subset_size < len(train_dataset):
         train_dataset = Subset(train_dataset, range(cfg.train_subset_size))
@@ -2392,10 +2527,13 @@ class EvalConfig:
     train_steps: Optional[int] = None
     max_val_batches: int = 2
     default_batch_size: int = 32
-    train_subset_size: int = 256
-    val_subset_size: int = 128
+    train_subset_size: int = 0
+    val_subset_size: int = 0
     data_root: str = "data_v2"
     download: bool = True
+    split_protocol: str = "official"
+    split_seed: int = 42
+    eval_split_role: str = "reward_eval"
     # Optional efficiency logging
     measure_latency: bool = True
     # Optional PPO/critic
@@ -2618,6 +2756,85 @@ def _restore_nn_dataset_dataroll_patch(patch_token: Optional[Tuple[type, Any, An
     data_roll_cls.__next__ = original_next
 
 
+def _patch_nn_dataset_load_dataset_for_reward(cfg: "EvalConfig") -> Optional[Dict[str, Any]]:
+    split_protocol = DatasetSplit.normalize_split_protocol(getattr(cfg, "split_protocol", "official"))
+    if split_protocol == "official":
+        return None
+
+    try:
+        import ab.nn.util.Loader as nn_loader  # type: ignore
+        import ab.nn.util.Train as nn_train  # type: ignore
+    except Exception:
+        return None
+
+    original_train_load_dataset = getattr(nn_train, "load_dataset", None)
+    original_loader_load_dataset = getattr(nn_loader, "load_dataset", None)
+    if original_train_load_dataset is None:
+        return None
+
+    split_seed = int(getattr(cfg, "split_seed", 42))
+    eval_split_role = str(getattr(cfg, "eval_split_role", "reward_eval") or "reward_eval")
+    supported_dataset_meta = {
+        "cifar-10": ((10,), 1.0 / 10.0, 45000, 5000),
+        "cifar10": ((10,), 1.0 / 10.0, 45000, 5000),
+        "cifar-100": ((100,), 1.0 / 100.0, 45000, 5000),
+        "cifar100": ((100,), 1.0 / 100.0, 45000, 5000),
+        "imagenette": ((10,), 1.0 / 10.0, 7500, 1969),
+    }
+
+
+    # Cache: avoid rebuilding split datasets on every single model evaluation.
+    # Each call triggers torch.utils.data.random_split + Subset construction,
+    # which adds up over 1000+ reward evaluations and causes timeouts.
+    _split_datasets_cache: Dict[tuple, tuple] = {}
+
+    def _patched_load_dataset(task, dataset_name, transform_name, transform_dir=None):
+        normalized_dataset = str(dataset_name or "").strip().lower().replace("_", "-")
+        dataset_meta = supported_dataset_meta.get(normalized_dataset)
+        if dataset_meta is None:
+            return original_train_load_dataset(task, dataset_name, transform_name, transform_dir)
+
+        dataset_loader = original_loader_load_dataset or original_train_load_dataset
+        _, _, train_size, val_size = dataset_meta
+        cache_key = (normalized_dataset, split_seed)
+        if cache_key not in _split_datasets_cache:
+            class_shape, min_acc, train_source, heldout_test_source = dataset_loader(
+                task, dataset_name, transform_name, transform_dir
+            )
+            split_datasets = DatasetSplit.build_classification_reward_split_datasets(
+                train_source=train_source,
+                heldout_test_source=heldout_test_source,
+                train_size=train_size,
+                val_size=val_size,
+                seed=split_seed,
+            )
+            _split_datasets_cache[cache_key] = (class_shape, min_acc, split_datasets)
+        class_shape, min_acc, split_datasets = _split_datasets_cache[cache_key]
+        eval_set = split_datasets.get(eval_split_role) or split_datasets["reward_eval"]
+        return class_shape, min_acc, split_datasets["train"], eval_set
+
+    nn_train.load_dataset = _patched_load_dataset
+    if original_loader_load_dataset is not None:
+        nn_loader.load_dataset = _patched_load_dataset
+    return {
+        "nn_train": nn_train,
+        "nn_loader": nn_loader,
+        "train_load_dataset": original_train_load_dataset,
+        "loader_load_dataset": original_loader_load_dataset,
+    }
+
+
+def _restore_nn_dataset_load_dataset_patch(patch_token: Optional[Dict[str, Any]]) -> None:
+    if not isinstance(patch_token, dict):
+        return
+    nn_train = patch_token.get("nn_train")
+    nn_loader = patch_token.get("nn_loader")
+    if nn_train is not None:
+        nn_train.load_dataset = patch_token.get("train_load_dataset")
+    if nn_loader is not None and patch_token.get("loader_load_dataset") is not None:
+        nn_loader.load_dataset = patch_token.get("loader_load_dataset")
+
+
 def _patch_nn_dataset_loader_utils_for_reward() -> Optional[Dict[str, Any]]:
     try:
         import ab.nn.util.Train as nn_train  # type: ignore
@@ -2643,9 +2860,10 @@ def _patch_nn_dataset_loader_utils_for_reward() -> Optional[Dict[str, Any]]:
     )
     persistent_workers = _safe_bool_env(
         "NNGPT_RL_FORMAL_PERSISTENT_WORKERS",
-        True,
+        False,
     )
     prefetch_factor = _optional_positive_int_env("NNGPT_RL_FORMAL_PREFETCH_FACTOR")
+    loaders: list[DataLoader] = []
 
     def _resolved_num_workers(dataset: Any, default_num_workers: int) -> int:
         value = getattr(dataset, "num_workers", default_num_workers)
@@ -2670,7 +2888,9 @@ def _patch_nn_dataset_loader_utils_for_reward() -> Optional[Dict[str, Any]]:
                 loader_kwargs["persistent_workers"] = True
             if prefetch_factor is not None:
                 loader_kwargs["prefetch_factor"] = max(1, int(prefetch_factor))
-        return DataLoader(dataset, **loader_kwargs)
+        loader = DataLoader(dataset, **loader_kwargs)
+        loaders.append(loader)
+        return loader
 
     def _train_loader(dataset: Any, batch: int, num_workers: int) -> DataLoader:
         return _build_loader(dataset, batch, num_workers, shuffle=True)
@@ -2689,12 +2909,14 @@ def _patch_nn_dataset_loader_utils_for_reward() -> Optional[Dict[str, Any]]:
         "test_loader_f": original_test_loader,
         "util_train_loader_f": original_util_train_loader,
         "util_test_loader_f": original_util_test_loader,
+        "loaders": loaders,
     }
 
 
 def _restore_nn_dataset_loader_utils_patch(patch_token: Optional[Dict[str, Any]]) -> None:
     if not isinstance(patch_token, dict):
         return
+    _shutdown_registered_reward_loaders(patch_token)
     nn_train = patch_token.get("nn_train")
     nn_util = patch_token.get("nn_util")
     if nn_train is not None:
@@ -3077,6 +3299,9 @@ def _formal_eval_with_nn_dataset(
         "epoch_limit_minutes": epoch_limit_minutes,
         "formal_reward_epochs": list(formal_reward_epochs),
         "formal_reward_max_epoch": int(formal_reward_max_epoch),
+        "split_protocol": DatasetSplit.normalize_split_protocol(getattr(cfg, "split_protocol", "official")),
+        "split_seed": int(getattr(cfg, "split_seed", 42)),
+        "eval_split_role": str(getattr(cfg, "eval_split_role", "reward_eval") or "reward_eval"),
     }
     safe_prm = dict(prm)
     safe_prm["freeze_backbones"] = bool(freeze_backbones)
@@ -3236,6 +3461,7 @@ def _formal_eval_with_nn_dataset(
         _clear_reward_cuda_state()
 
     started_at = time.time()
+    dataset_split_patch = None
     data_roll_patch = None
     loader_patch = None
     cuda_backend_state = None
@@ -3244,6 +3470,7 @@ def _formal_eval_with_nn_dataset(
             f"# reward formal eval nonce pid={os.getpid()} ns={time.time_ns()} "
             f"freeze={int(bool(freeze_backbones))}\n{code}"
         )
+        dataset_split_patch = _patch_nn_dataset_load_dataset_for_reward(cfg)
         data_roll_patch = _patch_nn_dataset_dataroll_for_reward()
         loader_patch = _patch_nn_dataset_loader_utils_for_reward()
         cuda_backend_state = _configure_formal_eval_cuda_backend(str(cfg.device))
@@ -3261,7 +3488,7 @@ def _formal_eval_with_nn_dataset(
         )
         formal_trace_context["reward_loader_persistent_workers"] = _safe_bool_env(
             "NNGPT_RL_FORMAL_PERSISTENT_WORKERS",
-            True,
+            False,
         )
         formal_trace_context["reward_loader_prefetch_factor"] = _optional_positive_int_env(
             "NNGPT_RL_FORMAL_PREFETCH_FACTOR"
@@ -3391,6 +3618,7 @@ def _formal_eval_with_nn_dataset(
     finally:
         _restore_formal_eval_cuda_backend(cuda_backend_state)
         _restore_nn_dataset_loader_utils_patch(loader_patch)
+        _restore_nn_dataset_load_dataset_patch(dataset_split_patch)
         _restore_nn_dataset_dataroll_patch(data_roll_patch)
         _clear_reward_cuda_state()
 
@@ -3409,7 +3637,7 @@ def _empty_eval_result(
         seed_accuracy_baseline=seed_accuracy_baseline,
         eval_limit_seconds=eval_limit_seconds,
         backbone_model_names=backbone_model_names,
-        formal_reward_epochs=DEFAULT_FORMAL_REWARD_EPOCHS,
+        formal_reward_epochs=_resolve_formal_reward_epochs(),
     )
 
 
@@ -3478,7 +3706,7 @@ def _timeout_eval_result(
         training_context_metric_value=training_context_metric_value,
         latency_ms=latency_ms,
         params_m=params_m,
-        formal_reward_epochs=DEFAULT_FORMAL_REWARD_EPOCHS,
+        formal_reward_epochs=_resolve_formal_reward_epochs(),
     )
 
 def evaluate_and_reward(
@@ -3921,12 +4149,67 @@ def evaluate_static_build_and_forward(
         forward_shape_ok = bool(forward_result.get("forward_shape_ok"))
         if cfg.measure_latency:
             latency_ms = forward_result.get("latency_ms")
+        train_result = {
+            "backward_ok": False,
+            "trained_step_ok": False,
+            "loss_start": None,
+            "loss_end": None,
+            "loss_drop": None,
+            "loss_drop_ok": False,
+            "steps_completed": 0,
+            "best_epoch_loss": None,
+            "avg_epoch_loss": None,
+            "epochs_completed": 0,
+            "epoch_loss_series": [],
+            "training_context_metric_name": "best_epoch_loss",
+            "training_context_metric_value": None,
+        }
+        if forward_shape_ok:
+            try:
+                smoke_batch = max(1, _safe_int_env("NNGPT_RL_STAGE1_TRAIN_SMOKE_BATCH", 2))
+                smoke_steps = max(1, _safe_int_env("NNGPT_RL_STAGE1_TRAIN_SMOKE_STEPS", 2))
+                smoke_batch = min(smoke_batch, 4)
+                c, h, w = int(cfg.input_shape[1]), int(cfg.input_shape[2]), int(cfg.input_shape[3])
+                xs = torch.randn(smoke_batch * smoke_steps, c, h, w)
+                ys = torch.arange(smoke_batch * smoke_steps, dtype=torch.long) % int(cfg.n_classes)
+                train_loader = DataLoader(
+                    TensorDataset(xs, ys),
+                    batch_size=smoke_batch,
+                    shuffle=False,
+                    num_workers=0,
+                )
+                train_setup = getattr(mdl, "train_setup", None)
+                if callable(train_setup):
+                    train_setup(
+                        {
+                            "lr": 1e-3,
+                            "momentum": 0.9,
+                            "batch": smoke_batch,
+                            "epoch": 1,
+                            "dropout": 0.1,
+                            "freeze_backbones": True,
+                        }
+                    )
+                train_result = _train_steps(
+                    mdl,
+                    train_loader,
+                    epochs=1,
+                    max_steps=smoke_steps,
+                    device=device,
+                    n_classes=int(cfg.n_classes),
+                    freeze_backbones=True,
+                )
+            except Exception as exc:
+                train_result = {
+                    **train_result,
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
         estimated_total_seconds = max(0.0, time.time() - started_at)
         components = compute_cv_reward_simple(
             built_ok=built_ok,
             forward_shape_ok=forward_shape_ok,
-            backward_ok=False,
-            loss_drop_ok=False,
+            backward_ok=bool(train_result.get("backward_ok")),
+            loss_drop_ok=bool(train_result.get("loss_drop_ok")),
             val_metric=None,
             val_metric_baseline=None,
             latency_ms=latency_ms,
@@ -3947,6 +4230,23 @@ def evaluate_static_build_and_forward(
             "built_ok": built_ok,
             "forward_ok": forward_ok,
             "forward_shape_ok": forward_shape_ok,
+            "backward_ok": bool(train_result.get("backward_ok")),
+            "trained_step_ok": bool(train_result.get("trained_step_ok")),
+            "loss_start": train_result.get("loss_start"),
+            "loss_end": train_result.get("loss_end"),
+            "loss_drop": train_result.get("loss_drop"),
+            "loss_drop_ok": bool(train_result.get("loss_drop_ok")),
+            "steps_completed": int(train_result.get("steps_completed", 0) or 0),
+            "best_epoch_loss": train_result.get("best_epoch_loss"),
+            "avg_epoch_loss": train_result.get("avg_epoch_loss"),
+            "epochs_completed": int(train_result.get("epochs_completed", 0) or 0),
+            "epoch_loss_series": list(train_result.get("epoch_loss_series") or []),
+            "training_context_metric_name": train_result.get(
+                "training_context_metric_name",
+                "best_epoch_loss",
+            ),
+            "training_context_metric_value": train_result.get("training_context_metric_value"),
+            "error": train_result.get("error"),
             "latency_ms": latency_ms,
             "params_m": params_m,
             "estimated_total_seconds": estimated_total_seconds,
@@ -4012,6 +4312,9 @@ def _loader_cache_key(cfg: EvalConfig) -> Tuple[Any, ...]:
         cfg.val_subset_size,
         cfg.data_root,
         cfg.download,
+        DatasetSplit.normalize_split_protocol(getattr(cfg, "split_protocol", "official")),
+        int(getattr(cfg, "split_seed", 42)),
+        str(getattr(cfg, "eval_split_role", "reward_eval") or "reward_eval"),
         bool(getattr(cfg, "full_test_acc", False)),
     )
 
@@ -4051,6 +4354,23 @@ def _await_eval_worker_pool(*, require_gpu: bool, timeout: float) -> Optional[_E
     deadline = time.time() + max(0.0, float(timeout))
     logged_wait = False
     while True:
+        desired_plan = get_reward_worker_plan()
+        desired_has_gpu_worker = any(index is not None for index in desired_plan.get("reward_gpu_indices", []))
+        if not desired_has_gpu_worker:
+            remaining = max(0.0, deadline - time.time())
+            if remaining <= 0.0:
+                return None
+            if not logged_wait:
+                print(
+                    "[Reward Worker Pool] Waiting "
+                    f"mode={desired_plan.get('mode')} "
+                    f"reason={desired_plan.get('reason', '')!r} "
+                    f"timeout_seconds={timeout:.0f}"
+                )
+                logged_wait = True
+            time.sleep(min(5.0, remaining))
+            continue
+
         pool = _get_or_create_eval_worker_pool()
         diagnostics = pool.diagnostics()
         has_gpu_worker = any(worker.get("assigned_gpu") is not None for worker in diagnostics.get("workers", []))
@@ -4690,7 +5010,11 @@ def _persistent_eval_worker_loop(conn, *, worker_device: str, assigned_gpu: Opti
                     backbone_model_names=_extract_backbone_model_names_from_code(request.get("code", "")),
                 )
                 result["components"]["reward"] = -1.0
-            worker_restart_requested = _is_fatal_cuda_worker_error(result.get("error"))
+            worker_error = result.get("error")
+            worker_restart_requested = (
+                _is_cuda_oom_error_message(worker_error)
+                or _is_fatal_cuda_worker_error(worker_error)
+            )
             result["assigned_gpu"] = assigned_gpu
             result["worker_device"] = worker_device
             result["worker_slot"] = request.get("worker_slot", None)

--- a/ab/gpt/util/SFTUtil.py
+++ b/ab/gpt/util/SFTUtil.py
@@ -93,7 +93,8 @@ def goal_tag_parser_cues(tags) -> str:
             cues.append("- `branch_reuse`: let one branch explicitly feed or condition another through a reuse, adapter, mixer, or extra merge stage.")
     return "\n".join(cues) if cues else "- No extra parser-visible cues."
 
-skeleton_code = """import torch
+skeleton_code = """import os
+import torch
 import torch.nn as nn
 import numpy as np
 import gc
@@ -110,6 +111,10 @@ class TorchVision(nn.Module):
         self.model_name = str(model)
         self.adapter = nn.Conv2d(in_channels, 3, kernel_size=1) if in_channels != 3 else nn.Identity()
         kwargs = {"aux_logits": False} if "inception" in model.lower() else {}
+        if os.environ.get("NNGPT_SMOKE_PREVALIDATE") == "1":
+            weights = None
+        if isinstance(weights, str) and weights.strip().lower() in {"", "none"}:
+            weights = None
         try:
             if hasattr(torchvision.models, "get_model"):
                 self.m = torchvision.models.get_model(model, weights=weights, **kwargs)
@@ -146,7 +151,7 @@ def make_scaler(enabled=True):
     return GradScaler("cuda", enabled=enabled)
 
 def supported_hyperparameters():
-    return { 'lr', 'dropout', 'momentum' }
+    return { 'lr', 'momentum' }
 
 # ==========================================
 # 2. DYNAMIC COMPONENTS (TO BE IMPLEMENTED)
@@ -191,6 +196,9 @@ class Net(nn.Module):
         
 
     def infer_dimensions_dynamically(self, num_classes):
+        if not hasattr(self, "_input_spec"):
+            raise RuntimeError("_input_spec must be set before infer_dimensions_dynamically")
+        c, h, w = self._input_spec
         self.to(self.device)
         was_training = self.training
         self.eval()
@@ -221,6 +229,7 @@ class Net(nn.Module):
         
     def train_setup(self, prm):
         self.to(self.device)
+        self.use_amp = bool(getattr(self, 'use_amp', False))
         self.freeze_backbones = bool(prm.get('freeze_backbones', getattr(self, 'freeze_backbones', True)))
         for backbone in (self.backbone_a, self.backbone_b):
             for param in backbone.parameters():
@@ -283,6 +292,22 @@ class Net(nn.Module):
         return train_accuracy, train_loss
 """
 
+def _build_prompt_skeleton(code):
+    train_setup_marker = "    def train_setup(self, prm):"
+    if train_setup_marker in code:
+        code = code[:code.index(train_setup_marker)]
+    code = re.sub(
+        r"\n    def _feature_to_input_image\(self, x: torch\.Tensor, adapter_name: str\) -> torch\.Tensor:\n.*?(?=\n    def forward\()",
+        "\n",
+        code,
+        flags=re.DOTALL,
+    )
+    code = re.sub(r"\n# =+\n# .+?\n# =+\n", "\n", code, flags=re.DOTALL)
+    code = re.sub(r"\n{3,}", "\n\n", code)
+    return code.rstrip() + "\n"
+
+prompt_skeleton_code = _build_prompt_skeleton(skeleton_code)
+
 prompt_template="""
 ### Role & Context
 You are a Senior AI Architect. Your task is to implement a **specific** model instance based on a strict skeleton to achieve an accuracy of {accuracy}. 
@@ -294,46 +319,20 @@ Complete the three missing components. **DO NOT** write generic code. You must i
 {skeleton_code}
 [CODE SKELETON END]
 
-### Technical Specifications (MANDATORY REQUIREMENTS)
-
-1. **Target Pattern: `{target_pattern}`**
-   - YOU MUST explicitly set `self.pattern = '{target_pattern}'` inside `__init__`.
-   - YOU MUST implement the logic for this specific pattern throughout the code.
-   - **CRITICAL REQUIREMENT**: DO NOT just blindly copy the standard Parallel_Triple structure. You MUST be highly creative and design a truly unique structural flow in `forward`. Vary your module usage and connection topology!
-
-2. **Component: `drop_conv3x3_block`**
-   - Implement starting with `def drop_conv3x3_block(in_channels, out_channels, stride=1, padding=1, bias=False, dropout_prob=0.0):`.
-   - Return an `nn.Sequential` block (Conv2d -> BatchNorm2d -> Activation -> Dropout2d).
-
-3. **Component: `Net.__init__`**
-   - Implement starting with `def __init__(self, in_shape: tuple, out_shape: tuple, prm: dict, device: torch.device) -> None:`.
-   - **MANDATORY**: `self.pattern = '{target_pattern}'`
-   - **Backbone Selection**: Choose EXACTLY TWO models from [{available_backbones}].
-   - **Initialization**: 
-     - Initialize `self.backbone_a` and `self.backbone_b` using `TorchVision(model='...', in_channels=...)`.
-     - Initialize `self.features` (1-2 `FractalUnit` layers).
-     - Store the image input spec on `self._input_spec` so the provided dynamic sizing helper can probe the classifier dimension.
-     - Finish `__init__` by using the existing `infer_dimensions_dynamically` helper once with the class count from `out_shape`.
-   - **Example Implementation Fragment**:
-     ```python
-     self.pattern = '{target_pattern}'
-     self.backbone_a = TorchVision(model='resnet18', in_channels=in_shape[1]).to(device)
-     ...
-     ```
-
-4. **Component: `Net.forward`**
-   - Implement starting with `def forward(self, x: torch.Tensor, is_probing: bool = False) -> torch.Tensor:`.
-   - **Flow Control**: Implement the data flow for `{target_pattern}`. Use `adaptive_pool_flatten` for module outputs before fusion.
-   - **Fusion Patterns Logic Blueprint**:
-     * `Parallel_Triple`: `Result = Concat(backbone_a(x), backbone_b(x), features(x))`
-     * `Backbone_A_to_Fractal`: `Result = features(backbone_a(x))` (Sequential flow)
-     * `Split_Stem_Parallel_Fuse`: `stem_out = STEM(x); Result = Concat(backbone_a(stem_out), backbone_b(stem_out))`
-   - **CRITICAL - NO GHOSTING**: You MUST use ALL defined components in the `forward` pass.
-   - **CRITICAL RESTRICTION**: You MUST build the computational graph directly without using ANY `if self.pattern == ...` control flow or dynamic loops (like `getattr`/`hasattr`) inside `forward`.
-   - **PARAM REMINDER**: Always pass `in_channels=...` when creating `TorchVision` models.
-
-### Output Requirement (STRICT)
-Output ONLY the implementation within the XML tags. Each tag MUST contain the complete function/method definition (signature and body). No markdown, no conversation.
+### Contract
+- Target pattern: `{target_pattern}`. Set `self.pattern` to this value.
+- Implement only `drop_conv3x3_block`, `Net.__init__`, and `Net.forward`.
+- The `<init>` section must start with the exact `def __init__(self, in_shape: tuple, out_shape: tuple, prm: dict, device: torch.device) -> None:` signature, not `def Net(...)`.
+- Use exactly two `TorchVision` backbones named `self.backbone_a` and `self.backbone_b` from [{available_backbones}].
+- `in_shape` is a 4D batch shape `(B, C, H, W)` during RL/eval. Derive channels as `_, c_in, h_in, w_in = in_shape`; never use `in_shape[0]` as the channel count.
+- Set `self._input_spec = (c_in, h_in, w_in)` in `Net.__init__`; never set it to `in_shape`, `in_shape[:]`, or any 4-tuple.
+- Call `self.infer_dimensions_dynamically(out_shape[0])` exactly once after defining every module used by `forward`, and do not change `self._input_spec` after that call.
+- Do not advertise `dropout` in `supported_hyperparameters()` unless `train_setup` actually reads it from `prm`; this SFT target only requires `lr` and `momentum`.
+- Use `adaptive_pool_flatten(...)` before concatenating branch outputs or feeding `self.classifier`.
+- Do not feed 4D feature maps directly into `nn.Linear` or `self.classifier`.
+- Do not instantiate new `nn.Module` objects inside `forward`; define all trainable modules in `__init__` and move them to `device`.
+- Keep `supported_hyperparameters()` consistent with actual `prm` usage; every advertised parameter must be read in the implementation.
+- Return only the three XML sections below, each containing the complete function or method definition.
 
 <block>
 # Full drop_conv3x3_block implementation
@@ -346,7 +345,16 @@ Output ONLY the implementation within the XML tags. Each tag MUST contain the co
 </forward>
 """
 
-open_discovery_skeleton_code = skeleton_code
+
+def format_backbone_prompt(*, accuracy, target_pattern):
+    return prompt_template.format(
+        accuracy=accuracy,
+        target_pattern=target_pattern,
+        skeleton_code=prompt_skeleton_code,
+        available_backbones=", ".join(available_backbones),
+    )
+
+open_discovery_skeleton_code = prompt_skeleton_code
 
 compact_backbone_rl_prompt_template = """
 ### Role & Goal
@@ -469,6 +477,8 @@ def parse_nn_code(code_str):
         block_code = None
         init_code = None
         forward_code = None
+        init_node = None
+        forward_node = None
 
         def get_source(node):
             return ast.get_source_segment(code_str, node)
@@ -482,13 +492,24 @@ def parse_nn_code(code_str):
                     if isinstance(sub_node, ast.FunctionDef):
                         if sub_node.name == '__init__':
                             init_code = get_source(sub_node)
+                            init_node = sub_node
                         elif sub_node.name == 'forward':
                             forward_code = get_source(sub_node)
+                            forward_node = sub_node
 
         def clean_code(c):
             return textwrap.dedent(c).strip() if c else None
 
-        return clean_code(block_code), clean_code(init_code), clean_code(forward_code)
+        def clean_method_code(node):
+            if node is None:
+                return None
+            return ast.unparse(node).strip()
+
+        return (
+            clean_code(block_code),
+            clean_method_code(init_node),
+            clean_method_code(forward_node),
+        )
 
     except Exception as e:
         print(f"AST Parsing Failed: {e}")

--- a/ab/gpt/util/Tune.py
+++ b/ab/gpt/util/Tune.py
@@ -106,6 +106,8 @@ def nn_gen(
     unsloth_max_input_length,
     prompt_batch,
     use_backbone=False,
+    sft_nn_prefixes=None,
+    sft_dataset=None,
 ):
     print("Preparing prompts for generation, this might take a while...")
 
@@ -146,11 +148,22 @@ def nn_gen(
                 enrich_dataframe(data)
             addon_data = None
         else:
+            data_kwargs = {"only_best_accuracy": True, "task": key_config["task"]}
+            if use_backbone and sft_nn_prefixes:
+                data_kwargs["nn_prefixes"] = sft_nn_prefixes
+            if use_backbone and sft_dataset:
+                data_kwargs["dataset"] = sft_dataset
             data = (
                 lemur.data(only_best_accuracy=True, task=key_config["task"])
                 .groupby(by="nn")
                 .sample(n=1)[:test_nn]
             )
+            if use_backbone:
+                datasets = sorted(data["dataset"].dropna().unique().tolist()) if "dataset" in data else []
+                print(
+                    f"[TUNE] Backbone generation seed rows={len(data)} "
+                    f"datasets={datasets} nn_prefixes={sft_nn_prefixes} sft_dataset={sft_dataset}"
+                )
             addon_task = key_config.get("addon_task")
             addon_data = lemur.data(
                 only_best_accuracy=True, task=addon_task) if addon_task else None
@@ -608,7 +621,9 @@ def generate_step(state: AgentState) -> dict:
             state.get("nn_name_prefix"),
             state.get("unsloth_max_input_length"),
             state.get("prompt_batch", 1),
-            use_backbone=state.get("use_backbone", False),
+            use_backbone=state.get("use_backbone",False),
+            sft_nn_prefixes=state.get("sft_nn_prefixes"),
+            sft_dataset=state.get("sft_dataset"),
         )
 
     # Classification prompts may intentionally emit labels or structured output
@@ -624,7 +639,15 @@ def generate_step(state: AgentState) -> dict:
     return {"next_action": "evaluate"}
 
 
-def _evaluate_epoch(epoch, out_path, nn_name_prefix, nn_train_epochs, trans_mode, classification_mode=False):
+def _evaluate_epoch(
+    epoch,
+    out_path,
+    nn_name_prefix,
+    nn_train_epochs,
+    trans_mode,
+    classification_mode=False,
+    custom_synth_dir=None,
+):
     """
     Single source of truth for one evaluation epoch.
     Runs NNEval (trains generated NNs for nn_train_epochs and records accuracy).
@@ -648,13 +671,50 @@ def _evaluate_epoch(epoch, out_path, nn_name_prefix, nn_train_epochs, trans_mode
                 print(f"Error running evaluation main(): {e}", flush=True)
             print('Folder data reload will occur next epoch.')
         else:
-            NNEval.main(
-                nn_name_prefix=nn_name_prefix,
-                nn_train_epochs=nn_train_epochs,
-                only_epoch=epoch,
-            )
+            eval_cuda_visible_devices = os.getenv(_EVAL_CUDA_VISIBLE_DEVICES_ENV, "").strip()
+            if eval_cuda_visible_devices:
+                env = os.environ.copy()
+                env["CUDA_VISIBLE_DEVICES"] = eval_cuda_visible_devices
+                env["NNGPT_NNEVAL_USE_ALL_VISIBLE_GPUS"] = "1"
+                env.pop("NNGPT_NNEVAL_GPU_TOKENS", None)
+                cmd = [
+                    sys.executable,
+                    "-m",
+                    "ab.gpt.NNEval",
+                    "--nn_train_epochs",
+                    str(nn_train_epochs),
+                    "--only_epoch",
+                    str(epoch),
+                ]
+                if custom_synth_dir:
+                    cmd.extend(["--custom_synth_dir", str(custom_synth_dir)])
+                if nn_name_prefix:
+                    cmd.extend(["--nn_name_prefix", str(nn_name_prefix)])
+                print(
+                    f"[TUNE] Running NNEval subprocess with "
+                    f"CUDA_VISIBLE_DEVICES={eval_cuda_visible_devices} "
+                    f"custom_synth_dir={custom_synth_dir or ''}"
+                )
+                subprocess.run(cmd, check=True, env=env)
+            else:
+                NNEval.main(
+                    nn_name_prefix=nn_name_prefix,
+                    nn_train_epochs=nn_train_epochs,
+                    only_epoch=epoch,
+                    custom_synth_dir=custom_synth_dir,
+                )
             print('[DEBUG] Release_memory.')
             release_memory()
+
+            generated_count = len(glob.glob(str(models_dir / "B*" / new_nn_file)))
+            artifact_count = len(glob.glob(str(models_dir / "B*" / "eval_info.json")))
+            artifact_count += len(glob.glob(str(models_dir / "B*" / "error.txt")))
+            if generated_count > 0 and artifact_count == 0:
+                raise RuntimeError(
+                    "NNEval produced no per-model artifacts after generated code was found: "
+                    f"models_dir={models_dir}, generated={generated_count}. "
+                    "Check custom_synth_dir and epoch_root settings."
+                )
 
         print('Clear LEMUR query cache.')
         lemur.data.cache_clear()
@@ -788,6 +848,7 @@ def _finetune_epoch(
     resume_trainer_checkpoint=None,
     use_backbone=False,
     sft_nn_prefixes=None,
+    sft_dataset=None,
 ):
     """
     Single source of truth for one finetune epoch.
@@ -808,6 +869,7 @@ def _finetune_epoch(
             context_length if context_length else model_loader.get_max_length(),
             tokenizer,
             nn_prefixes=sft_nn_prefixes,
+            dataset=sft_dataset,
         )
     else:
         length = (
@@ -829,6 +891,7 @@ def _finetune_epoch(
         dataset,
         tokenizer,
         out_path / base_model_name,
+        train_on_completions_only=use_backbone,
         resume_from_checkpoint=resume_trainer_checkpoint,
         checkpoint_label="trainer",
     )
@@ -860,6 +923,7 @@ def finetune_step(state: AgentState) -> dict:
         state.get("trainer_resume_checkpoint"),
         state.get("use_backbone", False),
         state.get("sft_nn_prefixes"),
+        state.get("sft_dataset"),
     )
 
     return {
@@ -917,7 +981,9 @@ def tune(
     classification_mode=False,
     use_backbone=False,
     sft_nn_prefixes=None,
+    sft_dataset=None,
     num_cycles=None,
+    epoch_root=None,
 ):
     if not isinstance(conf_keys, (list, tuple)):
         conf_keys = (conf_keys,)
@@ -945,6 +1011,7 @@ def tune(
     unsloth_load_in_4bit = config.get("load_in_4bit", True)
     max_new_tokens = config.get("max_new_tokens", max_new_tokens)
     use_backbone = config.get("backbone", use_backbone)
+    chat_template_path = config.get("chat_template_path")
 
     access_token = None
     if token_from_file:
@@ -955,6 +1022,14 @@ def tune(
         f'[DEBUG]Argument Information:\nSkip generation until Epoch: {skip_epoch}\nPath to saved LoRA Layers: {llm_path}')
 
     train_config_path = conf_train_dir / llm_tune_conf
+    epoch_root_path = Path(epoch_root).expanduser() if epoch_root else epoch_dir()
+    print(f"[EVOLUTION] Epoch root: {epoch_root_path}")
+
+    def run_epoch_dir(*parts):
+        out = epoch_root_path
+        for part in parts:
+            out = out / f"A{part}"
+        return out
 
     with open(conf_test_dir / nn_gen_conf) as prompt_file:
         prompt_dict = json.load(prompt_file)
@@ -964,13 +1039,14 @@ def tune(
 
     model_loader = LLM(
         base_model_name,
-        quantization_config_4bit,
+        quantization_config_4bit if unsloth_load_in_4bit else None,
         access_token=access_token,
         use_deepspeed=use_deepspeed,
         context_length=context_length,
         training_args=training_args,
         use_unsloth=use_unsloth,
         load_in_4bit=unsloth_load_in_4bit,
+        chat_template_path=chat_template_path,
     )
 
     model = model_loader.get_model()
@@ -1039,12 +1115,13 @@ def tune(
         "use_predictor": use_predictor,
         "use_backbone": use_backbone,
         "sft_nn_prefixes": sft_nn_prefixes,
+        "sft_dataset": sft_dataset,
         "trainer_resume_checkpoint": trainer_resume_checkpoint,
         "enable_merge": enable_merge,
         "classification_mode": classification_mode,
     }
 
-    shutil.rmtree(epoch_dir(), ignore_errors=True)
+    shutil.rmtree(epoch_root_path, ignore_errors=True)
 
     if use_agents:
         from ab.gpt.agents.run_agent import run_agent_controller
@@ -1052,7 +1129,7 @@ def tune(
 
     for epoch in range(llm_tune_epochs):
         print(f'[INFO]Start Epoch {epoch}')
-        out_path = epoch_dir(epoch)
+        out_path = run_epoch_dir(epoch)
         if epoch < skip_epoch:
             print(f'Skipped generation at epoch {epoch}')
         else:
@@ -1060,11 +1137,17 @@ def tune(
                 trans_gen(epoch, out_path, chat_bot, conf_keys, nn_train_epochs,
                           prompt_dict, test_nn, max_new_tokens, save_llm_output, nn_name_prefix)
             else:
-                nn_gen(epoch, out_path, chat_bot, conf_keys, nn_train_epochs, prompt_dict, test_nn, max_new_tokens,
-                       save_llm_output, nn_name_prefix, unsloth_max_input_length, prompt_batch, use_backbone=use_backbone)
+                nn_gen(epoch, out_path, chat_bot, conf_keys, nn_train_epochs, prompt_dict, test_nn, max_new_tokens, save_llm_output, nn_name_prefix, unsloth_max_input_length, prompt_batch, use_backbone=use_backbone, sft_nn_prefixes=sft_nn_prefixes, sft_dataset=sft_dataset)
 
-            _evaluate_epoch(epoch, out_path, nn_name_prefix,
-                            nn_train_epochs, trans_mode, classification_mode)
+            _evaluate_epoch(
+                epoch,
+                out_path,
+                nn_name_prefix,
+                nn_train_epochs,
+                trans_mode,
+                classification_mode,
+                custom_synth_dir=synth_dir(out_path),
+            )
 
         print(f'[DEBUG]Perform finetune at epoch {epoch}.')
         model, chat_bot = _finetune_epoch(
@@ -1076,5 +1159,6 @@ def tune(
             trainer_resume_checkpoint,
             use_backbone=use_backbone,
             sft_nn_prefixes=sft_nn_prefixes,
+            sft_dataset=sft_dataset,
         )
         trainer_resume_checkpoint = None

--- a/ab/gpt/util/nneval_worker_pool.py
+++ b/ab/gpt/util/nneval_worker_pool.py
@@ -14,6 +14,7 @@ import torch
 _AUX_GPU_TOKENS_ENV = "NNGPT_AUX_GPU_TOKENS"
 _TRAIN_GPU_TOKENS_ENV = "NNGPT_TRAIN_GPU_TOKENS"
 _LEGACY_REWARD_GPU_TOKENS_ENV = "NNGPT_REWARD_GPU_TOKENS"
+_REWARD_GPU_INDICES_ENV = "NNGPT_REWARD_GPU_INDICES"
 _NNEVAL_GPU_TOKENS_ENV = "NNGPT_NNEVAL_GPU_TOKENS"
 
 _NNEVAL_WORKER_POOL: Optional["_NNEvalWorkerPool"] = None
@@ -188,6 +189,8 @@ def _resolve_target_gpu_tokens(
     aux_gpu_tokens = _configured_cuda_device_tokens(_AUX_GPU_TOKENS_ENV)
     if aux_gpu_tokens is None:
         aux_gpu_tokens = _configured_cuda_device_tokens(_LEGACY_REWARD_GPU_TOKENS_ENV)
+    if aux_gpu_tokens is None:
+        aux_gpu_tokens = _configured_cuda_device_tokens(_REWARD_GPU_INDICES_ENV)
     if aux_gpu_tokens:
         tokens = [token for token in aux_gpu_tokens if token in visible_gpu_tokens]
         return tokens, "aux_gpu_tokens"
@@ -1115,7 +1118,10 @@ def _persistent_nneval_worker_entry(conn, assigned_gpu: Optional[int], assigned_
                 }
             finally:
                 _clear_cuda_state()
-            result["worker_restart_requested"] = _is_fatal_cuda_worker_error(result.get("error"))
+            result["worker_restart_requested"] = (
+                bool(result.get("is_oom", False))
+                or _is_fatal_cuda_worker_error(result.get("error"))
+            )
             result["assigned_gpu"] = assigned_gpu
             result["worker_device"] = worker_device
             result["worker_slot"] = request.get("worker_slot")

--- a/ab/gpt/util/prompt/SFTGenPrompt.py
+++ b/ab/gpt/util/prompt/SFTGenPrompt.py
@@ -26,24 +26,29 @@ class SFTGenPrompt(Prompt):
     Uses SFTUtil for specialized parsing and formatting.
     """
 
-    def __init__(self, max_len: int, tokenizer: PreTrainedTokenizerBase, nn_prefixes=None):
+    def __init__(self, max_len: int, tokenizer: PreTrainedTokenizerBase, nn_prefixes=None, dataset: str = None):
         # prompts_path is not needed for SFTGenPrompt as it uses SFTUtil templates
         super().__init__(max_len, tokenizer)
         self.nn_prefixes = _normalize_nn_prefixes(nn_prefixes)
+        self.dataset = dataset
 
     @override
     def get_raw_dataset(self, only_best_accuracy, n_training_prompts=None) -> DataFrame:
         """
         Extracts data from Lemur and formats it using SFTUtil.
-        Returns DataFrame with 'text' column.
+        Returns prompt/completion chat columns so TRL can build completion masks.
         """
-        print(f"extracting data from Lemur for SFT with nn_prefixes={self.nn_prefixes}...")
-        df = lemur.data(
-            task='img-classification',
-            # dataset='cifar-10',
-            # metric='acc',
-            nn_prefixes=self.nn_prefixes,
+        print(
+            f"extracting data from Lemur for SFT with "
+            f"nn_prefixes={self.nn_prefixes}, dataset={self.dataset}..."
         )
+        data_kwargs = {
+            "task": "img-classification",
+            "nn_prefixes": self.nn_prefixes,
+        }
+        if self.dataset:
+            data_kwargs["dataset"] = self.dataset
+        df = lemur.data(**data_kwargs)
         print(f"extracted {len(df)} samples.")
         
         if n_training_prompts:
@@ -59,23 +64,16 @@ class SFTGenPrompt(Prompt):
             
             if block_code and init_code and forward_code and target_pattern:
                 assistant_response = f"<block>\n{block_code}\n</block>\n<init>\n{init_code}\n</init>\n<forward>\n{forward_code}\n</forward>"
-                messages = [
-                    {"role": "user", "content": SFTUtil.prompt_template.format(
-                        accuracy=accuracy, 
-                        target_pattern=target_pattern,
-                        skeleton_code=SFTUtil.skeleton_code, 
-                        available_patterns=", ".join(SFTUtil.available_patterns), 
-                        available_backbones=", ".join(SFTUtil.available_backbones)
-                    )},
-                    {"role": "assistant", "content": assistant_response}
-                ]
-                text = self.tokenizer.apply_chat_template(
-                    messages, 
-                    tokenize=False, 
-                    add_generation_prompt=False,
-                    add_special_tokens=False
+                user_prompt = SFTUtil.format_backbone_prompt(
+                    accuracy=accuracy,
+                    target_pattern=target_pattern,
                 )
-                formatted_data.append({"text": text})
+                formatted_data.append(
+                    {
+                        "prompt": [{"role": "user", "content": user_prompt}],
+                        "completion": [{"role": "assistant", "content": assistant_response}],
+                    }
+                )
             else:
                  print(f"Skipping row {row.name} due to parsing failure or missing target_pattern")
 
@@ -85,7 +83,7 @@ class SFTGenPrompt(Prompt):
     def get_dataset(self, only_best_accuracy=False, seed=None, max_prompts=None, max_new_tokens=4096):
         """
         Override to return dataset WITHOUT tokenization/column stripping.
-        LoRA.py's train() method will see the 'text' column and use SFTTrainer.
+        LoRA.py's train() method will let SFTTrainer tokenize prompt/completion pairs.
         """
         raw_df = self.get_raw_dataset(only_best_accuracy, max_prompts)
         dataset = Dataset.from_pandas(raw_df)

--- a/util/py/plot_rl_reward.py
+++ b/util/py/plot_rl_reward.py
@@ -31,6 +31,13 @@ def _coerce_float(value: Any) -> Optional[float]:
     return parsed
 
 
+def _coerce_horizon_metric(api_result: dict[str, Any], field_name: str, horizon: str = "1") -> Optional[float]:
+    payload = api_result.get(field_name)
+    if not isinstance(payload, dict):
+        return None
+    return _coerce_float(payload.get(horizon))
+
+
 def _require_float(value: Any, *, field_name: str, line_no: int) -> float:
     parsed = _coerce_float(value)
     if parsed is None:
@@ -345,14 +352,32 @@ def load_reward_log(log_dir: Path | str) -> RewardLogData:
         seed_accuracy_baseline = _coerce_float(
             api_result.get("seed_accuracy_baseline", api_result.get("accuracy_baseline"))
         )
+        horizon1_test_acc = _coerce_horizon_metric(api_result, "formal_horizon_test_acc")
+        horizon1_train_acc = _coerce_horizon_metric(api_result, "formal_horizon_train_acc")
+        horizon1_target_value = _coerce_horizon_metric(api_result, "formal_horizon_scores")
         reward_target_value = _coerce_float(
-            api_result.get(
-                "reward_target_value",
-                api_result.get("frozen_test_acc", api_result.get("test_acc", api_result.get("val_metric"))),
-            )
+            horizon1_target_value
+            if horizon1_target_value is not None
+            else api_result.get(
+                    "reward_target_value",
+                    api_result.get("frozen_test_acc", api_result.get("test_acc", api_result.get("val_metric"))),
+                )
         )
-        frozen_test_acc = _coerce_float(api_result.get("frozen_test_acc", api_result.get("test_acc", api_result.get("val_metric"))))
-        frozen_train_acc = _coerce_float(api_result.get("frozen_train_acc", api_result.get("train_acc")))
+        frozen_test_acc = (
+            horizon1_test_acc
+            if horizon1_test_acc is not None
+            else _coerce_float(api_result.get("frozen_test_acc", api_result.get("test_acc", api_result.get("val_metric"))))
+        )
+        train_acc = (
+            horizon1_train_acc
+            if horizon1_train_acc is not None
+            else _coerce_float(api_result.get("train_acc"))
+        )
+        frozen_train_acc = (
+            horizon1_train_acc
+            if horizon1_train_acc is not None
+            else _coerce_float(api_result.get("frozen_train_acc", api_result.get("train_acc")))
+        )
         error_message = str(api_result.get("error") or "")
         error_stage = str(api_result.get("error_stage") or "")
 
@@ -364,7 +389,7 @@ def load_reward_log(log_dir: Path | str) -> RewardLogData:
         data.backward_ok.append(_bool_or_nan(backward_ok))
         data.loss_drop_ok.append(_bool_or_nan(loss_drop_ok))
         data.timed_out.append(_bool_or_nan(timed_out))
-        data.train_acc.append(_float_or_nan(_coerce_float(api_result.get("train_acc"))))
+        data.train_acc.append(_float_or_nan(train_acc))
         data.frozen_train_acc.append(_float_or_nan(frozen_train_acc))
         data.frozen_test_acc.append(_float_or_nan(frozen_test_acc))
         data.unfrozen_train_acc.append(_float_or_nan(_coerce_float(api_result.get("unfrozen_train_acc"))))
@@ -524,6 +549,25 @@ def _group_progress_series(data: RewardLogData, key: str) -> tuple[list[int], li
         for cycle in cycles
     ]
     return cycles, values
+
+
+def _cycle_cumulative_mean_series(group_ids: Iterable[int], values: Iterable[float]) -> tuple[list[int], list[float]]:
+    grouped: dict[int, list[float]] = {}
+    for group_id, value in zip(group_ids, values):
+        parsed = _coerce_float(value)
+        if parsed is None:
+            continue
+        grouped.setdefault(int(group_id), []).append(parsed)
+    cycles = sorted(grouped)
+    cumulative_sum = 0.0
+    cumulative_count = 0
+    cumulative_values: list[float] = []
+    for cycle in cycles:
+        current_values = grouped[cycle]
+        cumulative_sum += float(sum(current_values))
+        cumulative_count += len(current_values)
+        cumulative_values.append(cumulative_sum / float(cumulative_count))
+    return cycles, cumulative_values
 
 
 def _cycle_xticks(cycles: list[int], *, max_ticks: int = 20) -> list[int]:
@@ -769,8 +813,8 @@ def _plot_dashboard(
     else:
         cycle_summary = _cycle_metric_summary(data.reward_group_id, data.frozen_test_acc)
         cycles = [int(cycle) for cycle in cycle_summary["cycles"]]
-        train_cycles, closed_train = _group_progress_series(data, "closed_mean_train_acc")
-        test_cycles, closed_test = _group_progress_series(data, "closed_mean_test_acc")
+        train_cycles, closed_train = _cycle_cumulative_mean_series(data.reward_group_id, data.frozen_train_acc)
+        test_cycles, closed_test = _cycle_cumulative_mean_series(data.reward_group_id, data.frozen_test_acc)
         if cycles:
             axes[3].errorbar(
                 cycles,
@@ -816,9 +860,9 @@ def _plot_dashboard(
                 zorder=4,
             )
         if train_cycles:
-            axes[3].plot(train_cycles, closed_train, color="#2E7D32", linewidth=1.8, label="Closed Mean Train")
+            axes[3].plot(train_cycles, closed_train, color="#2E7D32", linewidth=1.8, label="Cumulative Mean Train")
         if test_cycles:
-            axes[3].plot(test_cycles, closed_test, color="#1565C0", linewidth=1.8, label="Closed Mean Frozen Test")
+            axes[3].plot(test_cycles, closed_test, color="#1565C0", linewidth=1.8, label="Cumulative Mean Frozen Test")
         cycle_axis = sorted(set(cycles) | set(train_cycles) | set(test_cycles))
         axes[3].set_title("Cycle Actual Metrics")
         axes[3].set_ylabel("Accuracy")


### PR DESCRIPTION
- Add SFT adapter loading for RL runs with trainable adapter mode.
- Add fixed `trainvaltest` reward/eval split handling.
- Parameterize formal reward datasets, including CIFAR-10, CIFAR-100, and Imagenette output shapes.
- Improve completion parsing, reward runtime state handling, and eval worker stability.
- Add public model configs for DeepSeek, Mistral, Qwen, Granite, and OlympicCoder.
