### PR TITLE
KTO reward: near-duplicate similarity penalty + novelty/metrics reporting

### DIFF
--- a/ab/gpt/TuneNNGenKTO.py
+++ b/ab/gpt/TuneNNGenKTO.py
@@ -108,6 +108,7 @@ def _build_kto_dataset(records: List[Dict[str, Any]], tokenizer) -> Dataset:
     prompts: List[str] = []
     completions: List[str] = []
     labels: List[bool] = []
+    sim_penalties: List[float] = []
 
     skipped = 0
     for rec in records:
@@ -135,6 +136,7 @@ def _build_kto_dataset(records: List[Dict[str, Any]], tokenizer) -> Dataset:
         prompts.append(prompt_str)
         completions.append(completion)
         labels.append(bool(label))
+        sim_penalties.append(float(rec.get("sim_penalty", 0.0) or 0.0))
 
     if skipped > 0:
         print(f"[KTO][WARN] Skipped {skipped} malformed records (missing prompt/completion/label)")
@@ -150,6 +152,7 @@ def _build_kto_dataset(records: List[Dict[str, Any]], tokenizer) -> Dataset:
         "prompt": prompts,
         "completion": completions,
         "label": labels,
+        "sim_penalty": sim_penalties,
     })
 
 
@@ -240,6 +243,7 @@ def run_kto(
     kto_beta: float = KTO_BETA,
     kto_desirable_weight: float = KTO_DESIRABLE_WEIGHT,
     kto_undesirable_weight: float = KTO_UNDESIRABLE_WEIGHT,
+    sim_alpha: float = 0.0,
     max_prompt_length: int = MAX_PROMPT_LENGTH,
     max_completion_length: int = MAX_COMPLETION_LENGTH,
     # Standard training hyperparameters
@@ -371,6 +375,7 @@ def run_kto(
         beta=kto_beta,
         desirable_weight=kto_desirable_weight,
         undesirable_weight=kto_undesirable_weight,
+        sim_alpha=sim_alpha,
         max_prompt_length=max_prompt_length,
         max_completion_length=max_completion_length,
     )
@@ -422,6 +427,8 @@ def main():
     parser.add_argument("--kto_beta", type=float, default=KTO_BETA)
     parser.add_argument("--kto_desirable_weight", type=float, default=KTO_DESIRABLE_WEIGHT)
     parser.add_argument("--kto_undesirable_weight", type=float, default=KTO_UNDESIRABLE_WEIGHT)
+    parser.add_argument("--sim_alpha", type=float, default=0.0,
+                        help="If >0, subtract alpha*sim_penalty from the KTO chosen reward")
     parser.add_argument("--max_prompt_length", type=int, default=MAX_PROMPT_LENGTH)
     parser.add_argument("--max_completion_length", type=int, default=MAX_COMPLETION_LENGTH)
 
@@ -531,6 +538,7 @@ def main():
         kto_beta=args.kto_beta,
         kto_desirable_weight=args.kto_desirable_weight,
         kto_undesirable_weight=args.kto_undesirable_weight,
+        sim_alpha=args.sim_alpha,
         max_prompt_length=args.max_prompt_length,
         max_completion_length=args.max_completion_length,
         num_train_epochs=args.num_train_epochs,

--- a/ab/gpt/kto_pipeline/compile_partial_metrics.py
+++ b/ab/gpt/kto_pipeline/compile_partial_metrics.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Compile card-style metrics from a (possibly still-running) generation benchmark.
+
+NNEval writes a per-model eval_info.json the moment each architecture finishes, but
+the aggregate metrics.json / all_cycles_results.json are only written at the end of a
+cycle. This tool reads whatever per-model eval_info.json files exist so far under a
+run folder and prints the card block — so you can summarize a live run without
+waiting for or interrupting it.
+
+Usage:
+    python -m ab.gpt.kto_pipeline.compile_partial_metrics --run_dir out_2777004
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+# ── stats (self-contained: no numpy / scipy / matplotlib, so it runs anywhere) ──
+def wilson_ci(k: int, n: int, z: float = 1.96):
+    if n <= 0:
+        return (0.0, 0.0)
+    p = k / n
+    denom = 1.0 + z * z / n
+    center = (p + z * z / (2 * n)) / denom
+    half = (z * ((p * (1 - p) / n + z * z / (4 * n * n)) ** 0.5)) / denom
+    return (max(0.0, center - half), min(1.0, center + half))
+
+
+_T95 = {1: 12.706, 2: 4.303, 3: 3.182, 4: 2.776, 5: 2.571, 6: 2.447, 7: 2.365,
+        8: 2.306, 9: 2.262, 10: 2.228, 11: 2.201, 12: 2.179, 13: 2.160, 14: 2.145,
+        15: 2.131, 16: 2.120, 17: 2.110, 18: 2.101, 19: 2.093, 20: 2.086, 21: 2.080,
+        22: 2.074, 23: 2.069, 24: 2.064, 25: 2.060, 26: 2.056, 27: 2.052, 28: 2.048,
+        29: 2.045, 30: 2.042, 40: 2.021, 50: 2.009, 60: 2.000, 80: 1.990, 100: 1.984,
+        120: 1.980}
+
+
+def _t_crit(df: int) -> float:
+    if df <= 0:
+        return 0.0
+    if df in _T95:
+        return _T95[df]
+    if df > 120:
+        return 1.960
+    keys = [k for k in _T95 if k <= df]
+    return _T95[max(keys)] if keys else 12.706
+
+
+def mean_t_ci(values: List[float]):
+    n = len(values)
+    if n == 0:
+        return (float("nan"), float("nan"), float("nan"))
+    mean = sum(values) / n
+    if n == 1:
+        return (mean, mean, mean)
+    var = sum((v - mean) ** 2 for v in values) / (n - 1)
+    se = (var ** 0.5) / (n ** 0.5)
+    t = _t_crit(n - 1)
+    return (mean, mean - t * se, mean + t * se)
+
+
+def _median(values: List[float]) -> float:
+    if not values:
+        return float("nan")
+    s = sorted(values)
+    n = len(s)
+    mid = n // 2
+    return s[mid] if n % 2 else (s[mid - 1] + s[mid]) / 2.0
+
+
+def _acc_from_eval_info(payload: Dict[str, Any]) -> Optional[float]:
+    res = payload.get("eval_results")
+    a = None
+    if isinstance(res, (list, tuple)) and len(res) >= 2:
+        a = res[1]
+    elif isinstance(res, dict):
+        a = res.get("accuracy", res.get("acc"))
+        if a is None:
+            eps = res.get("epochs", [])
+            if eps and isinstance(eps[0], dict):
+                a = eps[0].get("accuracy", eps[0].get("acc"))
+    try:
+        return float(a) if a is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _read_code(model_dir: Path) -> Optional[str]:
+    for name in ("new_nn.py", "new_nn.notnovel.py"):
+        f = model_dir / name
+        if f.exists():
+            try:
+                return f.read_text(encoding="utf-8", errors="replace")
+            except Exception:  # noqa: BLE001
+                return None
+    return None
+
+
+def _count_generated(run_dir: Path) -> int:
+    total = 0
+    for rec in run_dir.rglob("generation_records.jsonl"):
+        try:
+            with open(rec, encoding="utf-8") as fh:
+                total += sum(1 for line in fh if line.strip())
+        except Exception:  # noqa: BLE001
+            pass
+    return total
+
+
+def _structural_unique(codes: List[str]) -> Optional[int]:
+    """Count structurally-distinct architectures via the repo's NoveltyChecker."""
+    try:
+        from ab.gpt.iterative_pipeline.novelty_checker import NoveltyChecker
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        nc = NoveltyChecker(None)  # fresh — only among these generations
+        u = 0
+        for c in codes:
+            if nc.is_novel(c):
+                u += 1
+                nc.mark_as_seen(c)
+        return u
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Compile partial card-style metrics from a live run")
+    p.add_argument("--run_dir", type=str, required=True,
+                   help="Run folder (e.g. out_2777004) or an experiment subdir")
+    p.add_argument("--threshold", type=float, default=0.40,
+                   help="Accuracy threshold for the '>=T%%' quality stat")
+    args = p.parse_args()
+
+    run_dir = Path(args.run_dir)
+    if not run_dir.exists():
+        raise SystemExit(f"run_dir not found: {run_dir}")
+    thr = args.threshold
+
+    accs: List[float] = []
+    codes: List[str] = []
+    n_processed = 0
+    for info in run_dir.rglob("eval_info.json"):
+        # keep only per-model files: .../nneval/<model>/eval_info.json
+        if info.parent.parent.name != "nneval":
+            continue
+        n_processed += 1
+        try:
+            payload = json.loads(info.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001 — a file being written right now
+            continue
+        a = _acc_from_eval_info(payload)
+        if a is not None:
+            accs.append(a)
+            c = _read_code(info.parent)
+            if c:
+                codes.append(c)
+
+    generated = _count_generated(run_dir)
+    valid = len(accs)
+    unique = _structural_unique(codes) if codes else None
+
+    lines = [
+        "=" * 72,
+        f"PARTIAL metrics (live) — {run_dir}",
+        f"  generated         : {generated}",
+        f"  evaluated so far  : {n_processed}"
+        + (f"  ({100.0 * n_processed / generated:.1f}% of generated)" if generated else ""),
+    ]
+    card = ""
+    if valid:
+        m, lo, hi = mean_t_ci(accs)
+        ge = 100.0 * sum(1 for a in accs if a >= thr) / valid
+        denom = generated or valid
+        card = (f"Valid: {valid}/{denom} ({100.0 * valid / denom:.1f}%) · "
+                f"Average (all valid): {m * 100:.2f}% [95% CI {lo * 100:.2f}-{hi * 100:.2f}] · "
+                f"Median: {_median(accs) * 100:.2f}% · "
+                f"Best: {max(accs) * 100:.2f}% · "
+                f"≥{thr * 100:.0f}%: {ge:.2f}%")
+        if unique is not None:
+            card += f" · Unique: {unique}/{valid} ({100.0 * unique / valid:.1f}%)"
+        lines.append("  " + card)
+    else:
+        lines.append("  (no evaluated models with an accuracy yet)")
+    lines.append("=" * 72)
+
+    out = "\n".join(lines)
+    try:
+        print(out)
+    except UnicodeEncodeError:
+        print(out.encode("ascii", "replace").decode())
+
+    try:
+        (run_dir / "partial_metrics_summary.txt").write_text(
+            (card + "\n") if card else (out + "\n"), encoding="utf-8")
+        print(f"  written: {run_dir / 'partial_metrics_summary.txt'}")
+    except Exception:  # noqa: BLE001
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/ab/gpt/kto_pipeline/kto_selfcontained_finetune.py
+++ b/ab/gpt/kto_pipeline/kto_selfcontained_finetune.py
@@ -64,6 +64,7 @@ class SelfContainedKTOPipeline:
         models_per_cycle: int = 30,
         accuracy_threshold: float = 0.50,
         novelty_check: bool = True,
+        eval_skip: bool = True,
         undesirable_ratio: float = 1.0,
         max_undesirable_total: int = 1000,
         min_train_examples: int = 10,
@@ -126,6 +127,7 @@ class SelfContainedKTOPipeline:
         self.models_per_cycle = models_per_cycle
         self.accuracy_threshold = accuracy_threshold
         self.novelty_check = novelty_check
+        self.eval_skip = eval_skip
         self.undesirable_ratio = undesirable_ratio
         self.max_undesirable_total = max_undesirable_total
         self.min_train_examples = min_train_examples
@@ -411,8 +413,9 @@ class SelfContainedKTOPipeline:
         point spending GPU on duplicates that won't enter training. Flagged records
         get new_nn.py moved aside (so NNEval ignores them) and are counted as
         not_novel_skipped in bucketing. Idempotent across resumes via the moved file.
+        Disabled by eval_skip=False (e.g. benchmark runs that must evaluate ALL).
         """
-        if not self.novelty_check:
+        if not self.novelty_check or not self.eval_skip:
             return 0
         n = 0
         for rec in generation_records:
@@ -851,6 +854,10 @@ def main() -> None:
                              "(ABrain's first-epoch ceiling is ~0.68; keep this well below it)")
     parser.add_argument("--novelty_check", action="store_true", default=True)
     parser.add_argument("--no_novelty_check", dest="novelty_check", action="store_false")
+    parser.add_argument("--eval_skip", dest="eval_skip", action="store_true", default=True,
+                        help="Skip eval of duplicate (non-novel) generations to save GPU")
+    parser.add_argument("--no_eval_skip", dest="eval_skip", action="store_false",
+                        help="Evaluate ALL generations; novelty stays a reported metric only")
     parser.add_argument("--undesirable_ratio", type=float, default=1.0)
     parser.add_argument("--max_undesirable_total", type=int, default=1000)
     parser.add_argument("--min_train_examples", type=int, default=10)
@@ -910,6 +917,7 @@ def main() -> None:
         models_per_cycle=args.models_per_cycle,
         accuracy_threshold=args.accuracy_threshold,
         novelty_check=args.novelty_check,
+        eval_skip=args.eval_skip,
         undesirable_ratio=args.undesirable_ratio,
         max_undesirable_total=args.max_undesirable_total,
         min_train_examples=args.min_train_examples,

--- a/ab/gpt/kto_pipeline/kto_selfcontained_finetune.py
+++ b/ab/gpt/kto_pipeline/kto_selfcontained_finetune.py
@@ -52,6 +52,16 @@ def _fenced(code: str) -> str:
     return f"```python\n{code.strip()}\n```"
 
 
+def _unfenced(text: str) -> str:
+    """Recover raw code from a ```python ... ``` fence (best-effort)."""
+    t = (text or "").strip()
+    if t.startswith("```"):
+        t = t.split("\n", 1)[1] if "\n" in t else ""
+        if "```" in t:
+            t = t[: t.rfind("```")]
+    return t.strip()
+
+
 # ── pipeline ──────────────────────────────────────────────────────────────────
 
 class SelfContainedKTOPipeline:
@@ -78,6 +88,16 @@ class SelfContainedKTOPipeline:
         # desirable_weight*n_D ~= class_weight_target * undesirable_weight*n_U.
         class_weight_mode: str = "fixed",
         class_weight_target: float = 1.0,
+        # similarity penalty (#3): subtract alpha*shaped_jaccard from the KTO chosen
+        # reward for near-duplicate generations (vs LEMUR DB + our own prior gens).
+        # When on, non-novel passers are NOT dropped — they enter as desirable with
+        # a penalty; novelty stays a reported metric.
+        sim_penalty: bool = False,
+        sim_alpha: float = 0.4,
+        sim_threshold: float = 0.85,
+        sim_shape: str = "exponential",
+        sim_db_task: str = "img-classification",
+        sim_db_dataset: str = "cifar-10",
         # KTO hyperparameters
         kto_beta: float = 0.1,
         kto_desirable_weight: float = 1.0,
@@ -139,6 +159,13 @@ class SelfContainedKTOPipeline:
         self.class_weight_mode = class_weight_mode
         self.class_weight_target = class_weight_target
 
+        self.sim_penalty = sim_penalty
+        self.sim_alpha = sim_alpha
+        self.sim_threshold = sim_threshold
+        self.sim_shape = sim_shape
+        self.sim_db_task = sim_db_task
+        self.sim_db_dataset = sim_db_dataset
+
         self.kto_beta = kto_beta
         self.kto_desirable_weight = kto_desirable_weight
         self.kto_undesirable_weight = kto_undesirable_weight
@@ -186,6 +213,19 @@ class SelfContainedKTOPipeline:
 
         # Novelty checker — starts EMPTY (no dataset); grows as we accept models.
         self.novelty_checker = NoveltyChecker(self.output_dir / "seen_models.json")
+
+        # Similarity-penalty index (#3): LEMUR DB code + our own prior generations.
+        # Built once; new generations are added as they're accepted (cumulative).
+        self.sim_index = None
+        if self.sim_penalty:
+            from ab.gpt.kto_pipeline.similarity_penalty import SimilarityIndex
+            self.sim_index = SimilarityIndex(threshold=self.sim_threshold)
+            n_db = self.sim_index.add_db(self.sim_db_task, self.sim_db_dataset)
+            n_prev = self.sim_index.add_codes(
+                [_unfenced(r.get("completion", "")) for r in self.desirable])
+            logger.info(f"[sim] index built: {n_db} DB models + {n_prev} prior generations "
+                        f"(alpha={self.sim_alpha}, threshold={self.sim_threshold}, "
+                        f"shape={self.sim_shape})")
 
         self._setup_logging()
         self.cycle_results: List[Dict[str, Any]] = []
@@ -413,9 +453,11 @@ class SelfContainedKTOPipeline:
         point spending GPU on duplicates that won't enter training. Flagged records
         get new_nn.py moved aside (so NNEval ignores them) and are counted as
         not_novel_skipped in bucketing. Idempotent across resumes via the moved file.
-        Disabled by eval_skip=False (e.g. benchmark runs that must evaluate ALL).
+        Disabled by eval_skip=False (e.g. benchmark runs that must evaluate ALL),
+        and always disabled under the similarity penalty (non-novel passers must be
+        evaluated so they can enter training as desirable).
         """
-        if not self.novelty_check or not self.eval_skip:
+        if not self.novelty_check or not self.eval_skip or self.sim_index is not None:
             return 0
         n = 0
         for rec in generation_records:
@@ -476,12 +518,19 @@ class SelfContainedKTOPipeline:
         n_und_unparseable = 0
         n_skipped = 0
         accuracies: List[float] = []
+        cycle_penalties: List[float] = []  # similarity penalties of this cycle's desirables
 
         def add_desirable(code: str, model_id: str, accuracy: float) -> None:
+            pen = 0.0
+            if self.sim_index is not None:
+                pen = self.sim_index.penalty_for(code, self.sim_shape)  # vs DB + prior gens
+                self.sim_index.add(code)                                # becomes a "prior" too
+                cycle_penalties.append(pen)
             self.desirable.append({
                 "prompt_messages": prompt_messages,
                 "completion": _fenced(code),
                 "label": True,
+                "sim_penalty": pen,
                 "_meta": {
                     "model_id": model_id, "cycle": cycle,
                     "accuracy": accuracy, "reason": "passed",
@@ -570,17 +619,20 @@ class SelfContainedKTOPipeline:
                 n_und_lowacc += 1
                 continue
 
-            # passed the accuracy bar → novel ones become desirable; exact
-            # duplicates of already-accepted architectures are skipped (dedup),
-            # NOT penalised as undesirable (they cleared the bar — they're good).
+            # passed the accuracy bar. Without the similarity penalty, exact
+            # duplicates of already-accepted designs are skipped (legacy dedup).
+            # WITH the similarity penalty (sim_index set), non-novel passers are
+            # NOT skipped — they enter as desirable carrying a penalty; novelty
+            # stays a reported metric only.
             is_novel = self.novelty_checker.is_novel(code, model_id) if self.novelty_check else True
-            if not is_novel:
+            if is_novel:
+                n_desirable += 1
+            else:
                 n_not_novel += 1
-                continue
-
+                if self.sim_index is None:
+                    continue  # legacy: drop the duplicate
             add_desirable(code, model_id, accuracy)
             self.novelty_checker.mark_as_seen(code, model_id, source=f"cycle_{cycle}")
-            n_desirable += 1
 
         # Persist caches + novelty.
         _write_jsonl(self.desirable, self.desirable_cache_file)
@@ -606,6 +658,8 @@ class SelfContainedKTOPipeline:
                 "unparseable": n_und_unparseable,
             },
             "not_novel_skipped": n_not_novel,
+            "sim_penalty_mean": (sum(cycle_penalties) / len(cycle_penalties)) if cycle_penalties else 0.0,
+            "sim_penalty_nonzero": sum(1 for p in cycle_penalties if p > 0.0),
             "skipped_no_signal": n_skipped,
             "evaluated_accuracies": len(accuracies),
             "best_accuracy": best_acc,
@@ -654,11 +708,12 @@ class SelfContainedKTOPipeline:
 
         combined = [
             {"prompt_messages": r["prompt_messages"], "completion": r["completion"],
-             "label": True, "_meta": r.get("_meta", {})}
+             "label": True, "sim_penalty": float(r.get("sim_penalty", 0.0)),
+             "_meta": r.get("_meta", {})}
             for r in desirables
         ] + [
             {"prompt_messages": r["prompt_messages"], "completion": r["completion"],
-             "label": False, "_meta": r.get("_meta", {})}
+             "label": False, "sim_penalty": 0.0, "_meta": r.get("_meta", {})}
             for r in selected_u
         ]
         _write_jsonl(combined, kto_file)
@@ -723,6 +778,8 @@ class SelfContainedKTOPipeline:
             "--lora_alpha", str(self.kto_lora_alpha),
             "--max_grad_norm", str(self.kto_max_grad_norm),
         ]
+        if self.sim_penalty:
+            cmd.extend(["--sim_alpha", str(self.sim_alpha)])
         if prev_adapter is not None:
             logger.info(f"[cycle {cycle}] warm-starting from previous adapter: {prev_adapter}")
             cmd.extend(["--peft", str(prev_adapter)])
@@ -873,6 +930,17 @@ def main() -> None:
                         choices=["fixed", "auto"])
     parser.add_argument("--class_weight_target", type=float, default=1.0)
 
+    # similarity penalty (#3)
+    parser.add_argument("--sim_penalty", action="store_true", default=False,
+                        help="Penalize near-duplicate generations in the KTO reward "
+                             "(vs LEMUR DB + own prior gens); non-novel passers kept as desirable")
+    parser.add_argument("--sim_alpha", type=float, default=0.4)
+    parser.add_argument("--sim_threshold", type=float, default=0.85)
+    parser.add_argument("--sim_shape", type=str, default="exponential",
+                        choices=["exponential", "linear"])
+    parser.add_argument("--sim_db_task", type=str, default="img-classification")
+    parser.add_argument("--sim_db_dataset", type=str, default="cifar-10")
+
     parser.add_argument("--kto_beta", type=float, default=0.1)
     parser.add_argument("--kto_desirable_weight", type=float, default=1.0)
     parser.add_argument("--kto_undesirable_weight", type=float, default=1.0)
@@ -927,6 +995,12 @@ def main() -> None:
         threshold_slope=args.threshold_slope,
         class_weight_mode=args.class_weight_mode,
         class_weight_target=args.class_weight_target,
+        sim_penalty=args.sim_penalty,
+        sim_alpha=args.sim_alpha,
+        sim_threshold=args.sim_threshold,
+        sim_shape=args.sim_shape,
+        sim_db_task=args.sim_db_task,
+        sim_db_dataset=args.sim_db_dataset,
         kto_beta=args.kto_beta,
         kto_desirable_weight=args.kto_desirable_weight,
         kto_undesirable_weight=args.kto_undesirable_weight,

--- a/ab/gpt/kto_pipeline/plot_kto_cycles.py
+++ b/ab/gpt/kto_pipeline/plot_kto_cycles.py
@@ -190,18 +190,6 @@ def apply_pass_average(cycles: List[Dict[str, Any]], per_model: Dict[int, List[f
         r["ge_threshold_pct"] = 100.0 * sum(1 for a in accs if a >= thr) / len(accs)
 
 
-def _line_plot(xs, ys, title, ylabel, label, color, path, ylim=None) -> Path:
-    """One image, one plotted line (single legend entry)."""
-    fig, ax = plt.subplots(figsize=(10, 5))
-    ax.plot(xs, ys, "o-", color=color, label=label)
-    ax.set_title(title); ax.set_xlabel("Cycle"); ax.set_ylabel(ylabel)
-    ax.grid(True, alpha=0.3); ax.legend(fontsize=10)
-    if ylim is not None:
-        ax.set_ylim(*ylim)
-    fig.tight_layout(); fig.savefig(path, dpi=130); plt.close(fig)
-    return path
-
-
 def _ci_plot(xs, ys, lo, hi, title, ylabel, label, color, path, ylim=None) -> Path:
     """One image, one metric, with 95% CI error bars per point."""
     fig, ax = plt.subplots(figsize=(10, 5))
@@ -215,11 +203,13 @@ def _ci_plot(xs, ys, lo, hi, title, ylabel, label, color, path, ylim=None) -> Pa
     return path
 
 
-def plot_separate(cycles: List[Dict[str, Any]], out_dir: Path) -> List[Path]:
-    """One image per metric. Means get a t-based CI, proportions a Wilson CI."""
+def plot_separate(cycles: List[Dict[str, Any]], out_dir: Path,
+                  run_threshold: float = 0.40) -> List[Path]:
+    """Per-cycle plots: combined avg+best accuracy (with #evaluated), valid count,
+    Wilson-CI rates, and bucketing counts."""
     xs = [r["cycle"] for r in cycles]
 
-    # Average accuracy: t-based 95% CI over models that cleared the threshold.
+    # ── Combined accuracy: average (t-CI) + best, with #models-evaluated bars ──
     avg_y, avg_lo, avg_hi = [], [], []
     for r in cycles:
         accs = r.get("pass_accs") or []
@@ -228,8 +218,41 @@ def plot_separate(cycles: List[Dict[str, Any]], out_dir: Path) -> List[Path]:
             avg_y.append(m * 100); avg_lo.append((m - lo) * 100); avg_hi.append((hi - m) * 100)
         else:
             avg_y.append(r["avg"] * 100); avg_lo.append(0.0); avg_hi.append(0.0)
+    best_y = [r["best"] * 100 for r in cycles]
+    evaluated = [int(r["evaluated"]) for r in cycles]
 
-    # Valid-rate proportions: Wilson 95% CI (k / generated).
+    fig, ax = plt.subplots(figsize=(11, 5.5))
+    ax2 = ax.twinx()
+    ax2.bar(xs, evaluated, width=0.6, color="#b0b0b0", alpha=0.35,
+            label="Models evaluated", zorder=1)
+    ax2.set_ylabel("Models evaluated / cycle")
+    ax.errorbar(xs, avg_y, yerr=[avg_lo, avg_hi], fmt="o-", color="#ff7f0e",
+                ecolor="#ff7f0e", capsize=3, label="Average (≥ threshold)", zorder=3)
+    ax.plot(xs, best_y, "s-", color="#1f77b4", label="Best", zorder=3)
+    ax.set_xlabel("Cycle"); ax.set_ylabel("Accuracy (%)")
+    ax.set_title("Accuracy per Cycle — average (95% CI) & best, with #evaluated")
+    ax.grid(True, alpha=0.3)
+    ax.set_zorder(ax2.get_zorder() + 1); ax.patch.set_visible(False)  # lines over bars
+    h1, l1 = ax.get_legend_handles_labels()
+    h2, l2 = ax2.get_legend_handles_labels()
+    ax.legend(h1 + h2, l1 + l2, fontsize=9, loc="best")
+    acc_path = out_dir / "kto_accuracy.png"
+    fig.tight_layout(); fig.savefig(acc_path, dpi=130); plt.close(fig)
+
+    # ── Valid count: compiled + >=threshold models per cycle (novelty-agnostic) ──
+    counts = [int(r["pass_acc"]) for r in cycles]
+    fig, ax = plt.subplots(figsize=(10, 5))
+    ax.bar(xs, counts, width=0.6, color="#2ca02c",
+           label=f"Valid (compiled + ≥{run_threshold*100:.0f}%)")
+    for x, c in zip(xs, counts):
+        ax.text(x, c, str(c), ha="center", va="bottom", fontsize=8)
+    ax.set_title(f"Valid Models per Cycle (compiled + ≥{run_threshold*100:.0f}%, novelty-agnostic)")
+    ax.set_xlabel("Cycle"); ax.set_ylabel("Count")
+    ax.grid(True, alpha=0.3, axis="y"); ax.legend(fontsize=10)
+    vcount_path = out_dir / "kto_valid_count.png"
+    fig.tight_layout(); fig.savefig(vcount_path, dpi=130); plt.close(fig)
+
+    # ── Wilson-CI rate plots (kept) ──
     vt_y, vt_lo, vt_hi, ct_y, ct_lo, ct_hi = [], [], [], [], [], []
     for r in cycles:
         n = r["generated"]
@@ -240,13 +263,8 @@ def plot_separate(cycles: List[Dict[str, Any]], out_dir: Path) -> List[Path]:
             ys.append(p * 100); los.append((p - lo) * 100); his.append((hi - p) * 100)
 
     paths = [
-        _ci_plot(xs, avg_y, avg_lo, avg_hi,
-                 "Average Accuracy per Cycle (models ≥ threshold) — t 95% CI",
-                 "Accuracy (%)", "Average accuracy (≥ threshold)", "#ff7f0e",
-                 out_dir / "kto_avg_accuracy.png"),
-        _line_plot(xs, [r["best"] * 100 for r in cycles],
-                   "Best Accuracy per Cycle", "Accuracy (%)", "Best accuracy",
-                   "#1f77b4", out_dir / "kto_best_accuracy.png"),
+        acc_path,
+        vcount_path,
         _ci_plot(xs, vt_y, vt_lo, vt_hi,
                  "Valid Generation Rate per Cycle (compiled+trained) — Wilson 95% CI",
                  "Valid generation rate (%)", "Valid (compiled+trained)", "#17becf",
@@ -318,7 +336,7 @@ def main() -> None:
         print("[plot][warn] no per-model eval_info.json found — 'avg' uses the stored "
               "metric (above-threshold only if produced by the updated pipeline).")
 
-    figs = plot_separate(cycles, out_dir)
+    figs = plot_separate(cycles, out_dir, run_threshold)
     csv_path = save_csv(cycles, out_dir)
 
     # ── Card-style summary (over ALL valid models, matching the HF model card) ──

--- a/ab/gpt/kto_pipeline/plot_kto_cycles.py
+++ b/ab/gpt/kto_pipeline/plot_kto_cycles.py
@@ -118,6 +118,15 @@ def mean_t_ci(values: List[float]):
     return (mean, mean - t * se, mean + t * se)
 
 
+def _median(values: List[float]) -> float:
+    if not values:
+        return float("nan")
+    s = sorted(values)
+    n = len(s)
+    mid = n // 2
+    return s[mid] if n % 2 else (s[mid - 1] + s[mid]) / 2.0
+
+
 def _acc_from_eval_info(payload: Dict[str, Any]) -> Optional[float]:
     """Pull accuracy from a per-model eval_info.json (eval_results may be tuple or dict)."""
     res = payload.get("eval_results")
@@ -174,6 +183,11 @@ def apply_pass_average(cycles: List[Dict[str, Any]], per_model: Dict[int, List[f
         passed = [a for a in accs if a >= thr]
         r["avg"] = (sum(passed) / len(passed)) if passed else float("nan")
         r["pass_accs"] = passed  # sample for the t-based CI on the mean
+        # Card-style stats over ALL valid (evaluated) models this cycle.
+        r["valid"] = len(accs)
+        r["avg_all"] = sum(accs) / len(accs)
+        r["median"] = _median(accs)
+        r["ge_threshold_pct"] = 100.0 * sum(1 for a in accs if a >= thr) / len(accs)
 
 
 def _line_plot(xs, ys, title, ylabel, label, color, path, ylim=None) -> Path:
@@ -260,9 +274,9 @@ def plot_separate(cycles: List[Dict[str, Any]], out_dir: Path) -> List[Path]:
 
 def save_csv(cycles: List[Dict[str, Any]], out_dir: Path) -> Path:
     path = out_dir / "kto_cycle_summary.csv"
-    cols = ["cycle", "generated", "evaluated", "best", "avg", "new_desirable",
-            "new_undesirable", "low_accuracy", "not_novel", "desirable_total",
-            "undesirable_total", "trained"]
+    cols = ["cycle", "generated", "evaluated", "valid", "best", "avg", "avg_all",
+            "median", "ge_threshold_pct", "new_desirable", "new_undesirable",
+            "low_accuracy", "not_novel", "desirable_total", "undesirable_total", "trained"]
     with open(path, "w", newline="", encoding="utf-8") as f:
         w = csv.DictWriter(f, fieldnames=cols, extrasaction="ignore")
         w.writeheader()
@@ -307,17 +321,40 @@ def main() -> None:
     figs = plot_separate(cycles, out_dir)
     csv_path = save_csv(cycles, out_dir)
 
-    # Console summary (handy for the report).
+    # ── Card-style summary (over ALL valid models, matching the HF model card) ──
     best_overall = max(cycles, key=lambda r: r["best"])
+    generated_total = sum(int(r.get("generated", 0)) for r in cycles)
+    all_valid = [a for accs in per_model.values() for a in accs]
+    above = [a for r in cycles for a in (r.get("pass_accs") or [])]
+
     print("=" * 64)
     print(f"KTO run: {len(cycles)} cycles ({cycles[0]['cycle']}..{cycles[-1]['cycle']})")
-    print(f"  best accuracy this run : {best_overall['best']*100:.2f}%  (cycle {best_overall['cycle']})")
-    # Paper-style aggregate: mean over all above-threshold models + t-based 95% CI.
-    pooled = [a for r in cycles for a in (r.get("pass_accs") or [])]
-    if pooled:
-        m, lo, hi = mean_t_ci(pooled)
-        print(f"  Average Accuracy       : {m*100:.2f}%  "
-              f"(95% CI: {lo*100:.2f}% - {hi*100:.2f}%, n={len(pooled)})")
+    if all_valid:
+        n_valid = len(all_valid)
+        denom = generated_total or n_valid
+        m, lo, hi = mean_t_ci(all_valid)
+        ge = 100.0 * sum(1 for a in all_valid if a >= run_threshold) / n_valid
+        card = (f"Valid: {n_valid}/{denom} ({100.0 * n_valid / denom:.1f}%) · "
+                f"Average (all valid): {m*100:.2f}% [95% CI {lo*100:.2f}-{hi*100:.2f}] · "
+                f"Median: {_median(all_valid)*100:.2f}% · "
+                f"Best: {max(all_valid)*100:.2f}% · "
+                f"≥{run_threshold*100:.0f}%: {ge:.2f}%")
+        try:
+            print("  " + card)
+        except UnicodeEncodeError:
+            print("  " + card.encode("ascii", "replace").decode())
+        try:
+            (out_dir / "kto_card_summary.txt").write_text(card + "\n", encoding="utf-8")
+        except Exception:  # noqa: BLE001
+            pass
+    else:
+        print(f"  best accuracy this run : {best_overall['best']*100:.2f}%  "
+              f"(cycle {best_overall['cycle']})")
+        print("  [card block needs per-model eval_info.json — median/all-valid avg/>=thr skipped]")
+    # Above-threshold average (the per-cycle plot's definition), kept for reference.
+    if above:
+        m, lo, hi = mean_t_ci(above)
+        print(f"  Average (>= threshold) : {m*100:.2f}%  (95% CI {lo*100:.2f}-{hi*100:.2f}, n={len(above)})")
     print(f"  desirable accumulated  : {cycles[-1]['desirable_total']}")
     print("-" * 64)
     for f in figs:

--- a/ab/gpt/kto_pipeline/plot_kto_cycles.py
+++ b/ab/gpt/kto_pipeline/plot_kto_cycles.py
@@ -334,11 +334,17 @@ def main() -> None:
         denom = generated_total or n_valid
         m, lo, hi = mean_t_ci(all_valid)
         ge = 100.0 * sum(1 for a in all_valid if a >= run_threshold) / n_valid
+        # Novelty as a pure metric: structurally distinct vs duplicate generations.
+        uniq = sum(int(r.get("new_desirable", 0)) for r in cycles)
+        dup = sum(int(r.get("not_novel", 0)) for r in cycles)
+        checked = uniq + dup
+        uniq_str = (f" · Unique: {uniq}/{checked} ({100.0 * uniq / checked:.1f}%)"
+                    if checked else "")
         card = (f"Valid: {n_valid}/{denom} ({100.0 * n_valid / denom:.1f}%) · "
                 f"Average (all valid): {m*100:.2f}% [95% CI {lo*100:.2f}-{hi*100:.2f}] · "
                 f"Median: {_median(all_valid)*100:.2f}% · "
                 f"Best: {max(all_valid)*100:.2f}% · "
-                f"≥{run_threshold*100:.0f}%: {ge:.2f}%")
+                f"≥{run_threshold*100:.0f}%: {ge:.2f}%" + uniq_str)
         try:
             print("  " + card)
         except UnicodeEncodeError:

--- a/ab/gpt/kto_pipeline/plot_kto_cycles.py
+++ b/ab/gpt/kto_pipeline/plot_kto_cycles.py
@@ -73,6 +73,51 @@ def load_cycles(results_path: Path, cycles_dir: Optional[Path]) -> List[Dict[str
     return [by_cycle[k] for k in sorted(by_cycle)]
 
 
+def wilson_ci(k: int, n: int, z: float = 1.96):
+    """95% Wilson score interval for a proportion k/n → (lo, hi) in [0, 1]."""
+    if n <= 0:
+        return (0.0, 0.0)
+    p = k / n
+    denom = 1.0 + z * z / n
+    center = (p + z * z / (2 * n)) / denom
+    half = (z * ((p * (1 - p) / n + z * z / (4 * n * n)) ** 0.5)) / denom
+    return (max(0.0, center - half), min(1.0, center + half))
+
+
+# Two-sided 95% Student-t critical values by degrees of freedom (→ 1.96 for large df).
+_T95 = {1: 12.706, 2: 4.303, 3: 3.182, 4: 2.776, 5: 2.571, 6: 2.447, 7: 2.365,
+        8: 2.306, 9: 2.262, 10: 2.228, 11: 2.201, 12: 2.179, 13: 2.160, 14: 2.145,
+        15: 2.131, 16: 2.120, 17: 2.110, 18: 2.101, 19: 2.093, 20: 2.086, 21: 2.080,
+        22: 2.074, 23: 2.069, 24: 2.064, 25: 2.060, 26: 2.056, 27: 2.052, 28: 2.048,
+        29: 2.045, 30: 2.042, 40: 2.021, 50: 2.009, 60: 2.000, 80: 1.990, 100: 1.984,
+        120: 1.980}
+
+
+def _t_crit(df: int) -> float:
+    if df <= 0:
+        return 0.0
+    if df in _T95:
+        return _T95[df]
+    if df > 120:
+        return 1.960
+    keys = [k for k in _T95 if k <= df]
+    return _T95[max(keys)] if keys else 12.706
+
+
+def mean_t_ci(values: List[float]):
+    """Sample mean and t-based 95% CI → (mean, lo, hi)."""
+    n = len(values)
+    if n == 0:
+        return (float("nan"), float("nan"), float("nan"))
+    mean = sum(values) / n
+    if n == 1:
+        return (mean, mean, mean)
+    var = sum((v - mean) ** 2 for v in values) / (n - 1)
+    se = (var ** 0.5) / (n ** 0.5)
+    t = _t_crit(n - 1)
+    return (mean, mean - t * se, mean + t * se)
+
+
 def _acc_from_eval_info(payload: Dict[str, Any]) -> Optional[float]:
     """Pull accuracy from a per-model eval_info.json (eval_results may be tuple or dict)."""
     res = payload.get("eval_results")
@@ -128,6 +173,7 @@ def apply_pass_average(cycles: List[Dict[str, Any]], per_model: Dict[int, List[f
         thr = r["effective_threshold"] or run_threshold
         passed = [a for a in accs if a >= thr]
         r["avg"] = (sum(passed) / len(passed)) if passed else float("nan")
+        r["pass_accs"] = passed  # sample for the t-based CI on the mean
 
 
 def _line_plot(xs, ys, title, ylabel, label, color, path, ylim=None) -> Path:
@@ -142,25 +188,59 @@ def _line_plot(xs, ys, title, ylabel, label, color, path, ylim=None) -> Path:
     return path
 
 
+def _ci_plot(xs, ys, lo, hi, title, ylabel, label, color, path, ylim=None) -> Path:
+    """One image, one metric, with 95% CI error bars per point."""
+    fig, ax = plt.subplots(figsize=(10, 5))
+    ax.errorbar(xs, ys, yerr=[lo, hi], fmt="o-", color=color, ecolor=color,
+                capsize=3, label=label)
+    ax.set_title(title); ax.set_xlabel("Cycle"); ax.set_ylabel(ylabel)
+    ax.grid(True, alpha=0.3); ax.legend(fontsize=10)
+    if ylim is not None:
+        ax.set_ylim(*ylim)
+    fig.tight_layout(); fig.savefig(path, dpi=130); plt.close(fig)
+    return path
+
+
 def plot_separate(cycles: List[Dict[str, Any]], out_dir: Path) -> List[Path]:
-    """One image per metric, each a single-line trend."""
+    """One image per metric. Means get a t-based CI, proportions a Wilson CI."""
     xs = [r["cycle"] for r in cycles]
+
+    # Average accuracy: t-based 95% CI over models that cleared the threshold.
+    avg_y, avg_lo, avg_hi = [], [], []
+    for r in cycles:
+        accs = r.get("pass_accs") or []
+        if len(accs) >= 2:
+            m, lo, hi = mean_t_ci(accs)
+            avg_y.append(m * 100); avg_lo.append((m - lo) * 100); avg_hi.append((hi - m) * 100)
+        else:
+            avg_y.append(r["avg"] * 100); avg_lo.append(0.0); avg_hi.append(0.0)
+
+    # Valid-rate proportions: Wilson 95% CI (k / generated).
+    vt_y, vt_lo, vt_hi, ct_y, ct_lo, ct_hi = [], [], [], [], [], []
+    for r in cycles:
+        n = r["generated"]
+        for k, ys, los, his in ((r["evaluated"], vt_y, vt_lo, vt_hi),
+                                (r["pass_acc"], ct_y, ct_lo, ct_hi)):
+            p = k / n if n else 0.0
+            lo, hi = wilson_ci(k, n)
+            ys.append(p * 100); los.append((p - lo) * 100); his.append((hi - p) * 100)
+
     paths = [
-        _line_plot(xs, [r["avg"] * 100 for r in cycles],
-                   "Average Accuracy per Cycle (models ≥ threshold)", "Accuracy (%)",
-                   "Average accuracy (≥ threshold)", "#ff7f0e",
-                   out_dir / "kto_avg_accuracy.png"),
+        _ci_plot(xs, avg_y, avg_lo, avg_hi,
+                 "Average Accuracy per Cycle (models ≥ threshold) — t 95% CI",
+                 "Accuracy (%)", "Average accuracy (≥ threshold)", "#ff7f0e",
+                 out_dir / "kto_avg_accuracy.png"),
         _line_plot(xs, [r["best"] * 100 for r in cycles],
                    "Best Accuracy per Cycle", "Accuracy (%)", "Best accuracy",
                    "#1f77b4", out_dir / "kto_best_accuracy.png"),
-        _line_plot(xs, [100 * r["evaluated"] / r["generated"] for r in cycles],
-                   "Valid Models per Cycle (compiled+trained)", "% of generated",
-                   "Valid (compiled+trained)", "#17becf",
-                   out_dir / "kto_valid_trained.png", ylim=(0, 100)),
-        _line_plot(xs, [100 * r["pass_acc"] / r["generated"] for r in cycles],
-                   "Valid Models per Cycle (cleared threshold)", "% of generated",
-                   "Cleared threshold", "#9467bd",
-                   out_dir / "kto_valid_cleared_threshold.png", ylim=(0, 100)),
+        _ci_plot(xs, vt_y, vt_lo, vt_hi,
+                 "Valid Generation Rate per Cycle (compiled+trained) — Wilson 95% CI",
+                 "Valid generation rate (%)", "Valid (compiled+trained)", "#17becf",
+                 out_dir / "kto_valid_trained.png", ylim=(0, 100)),
+        _ci_plot(xs, ct_y, ct_lo, ct_hi,
+                 "Cleared-Threshold Rate per Cycle — Wilson 95% CI",
+                 "Cleared-threshold rate (%)", "Cleared threshold", "#9467bd",
+                 out_dir / "kto_valid_cleared_threshold.png", ylim=(0, 100)),
     ]
 
     # Bucket counts: desirable + undesirable (the two requested series).
@@ -232,7 +312,12 @@ def main() -> None:
     print("=" * 64)
     print(f"KTO run: {len(cycles)} cycles ({cycles[0]['cycle']}..{cycles[-1]['cycle']})")
     print(f"  best accuracy this run : {best_overall['best']*100:.2f}%  (cycle {best_overall['cycle']})")
-    print(f"  last-cycle avg accuracy: {cycles[-1]['avg']*100:.2f}%")
+    # Paper-style aggregate: mean over all above-threshold models + t-based 95% CI.
+    pooled = [a for r in cycles for a in (r.get("pass_accs") or [])]
+    if pooled:
+        m, lo, hi = mean_t_ci(pooled)
+        print(f"  Average Accuracy       : {m*100:.2f}%  "
+              f"(95% CI: {lo*100:.2f}% - {hi*100:.2f}%, n={len(pooled)})")
     print(f"  desirable accumulated  : {cycles[-1]['desirable_total']}")
     print("-" * 64)
     for f in figs:

--- a/ab/gpt/kto_pipeline/plot_kto_cycles.py
+++ b/ab/gpt/kto_pipeline/plot_kto_cycles.py
@@ -39,6 +39,12 @@ def _parse_cycle(c: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         "desirable_total": int(b.get("desirable_total", 0)),
         "undesirable_total": int(b.get("undesirable_total", 0)),
         "pass_acc": new_des + not_novel,  # cleared the accuracy bar (novel + duplicate)
+        # Novelty read-out: among models that cleared the bar, how many were
+        # structurally new vs duplicates of an already-accepted design.
+        "novelty_rate": (new_des / (new_des + not_novel)) if (new_des + not_novel) else float("nan"),
+        # Similarity-penalty telemetry (present only on sim-penalty runs).
+        "sim_penalty_nonzero": int(b.get("sim_penalty_nonzero", 0)),
+        "sim_penalty_mean": float(b.get("sim_penalty_mean", 0.0) or 0.0),
         "trained": bool(c.get("training", {}).get("success", False)),
     }
 
@@ -287,6 +293,32 @@ def plot_separate(cycles: List[Dict[str, Any]], out_dir: Path,
     bpath = out_dir / "kto_bucket_counts.png"
     fig.tight_layout(); fig.savefig(bpath, dpi=130); plt.close(fig)
     paths.append(bpath)
+
+    # ── Novelty per cycle: novel vs duplicate among threshold-clearing models ──
+    # Direct read-out of whether the similarity penalty is pushing generation
+    # toward structurally new architectures. Under the penalty, non-novel passers
+    # still enter training, but a working penalty should slow their growth / lift
+    # the novelty rate over cycles relative to the no-penalty baseline.
+    novel = [int(r["new_desirable"]) for r in cycles]
+    dup = [int(r["not_novel"]) for r in cycles]
+    rate = [100.0 * n / (n + d) if (n + d) else float("nan")
+            for n, d in zip(novel, dup)]
+    fig, ax = plt.subplots(figsize=(11, 5.5))
+    ax.bar(xs, novel, width=0.6, color="#2ca02c", label="Novel (unique)")
+    ax.bar(xs, dup, width=0.6, bottom=novel, color="#ff7f0e", alpha=0.85,
+           label="Duplicate (non-novel)")
+    ax.set_xlabel("Cycle"); ax.set_ylabel("Threshold-clearing models")
+    ax.set_title("Novel vs Duplicate Architectures per Cycle (with novelty rate)")
+    ax.grid(True, alpha=0.3, axis="y")
+    ax2 = ax.twinx()
+    ax2.plot(xs, rate, "o-", color="#1f77b4", label="Novelty rate")
+    ax2.set_ylabel("Novelty rate (%)"); ax2.set_ylim(0, 100)
+    h1, l1 = ax.get_legend_handles_labels()
+    h2, l2 = ax2.get_legend_handles_labels()
+    ax.legend(h1 + h2, l1 + l2, fontsize=9, loc="best")
+    npath = out_dir / "kto_novelty.png"
+    fig.tight_layout(); fig.savefig(npath, dpi=130); plt.close(fig)
+    paths.append(npath)
     return paths
 
 
@@ -294,7 +326,8 @@ def save_csv(cycles: List[Dict[str, Any]], out_dir: Path) -> Path:
     path = out_dir / "kto_cycle_summary.csv"
     cols = ["cycle", "generated", "evaluated", "valid", "best", "avg", "avg_all",
             "median", "ge_threshold_pct", "new_desirable", "new_undesirable",
-            "low_accuracy", "not_novel", "desirable_total", "undesirable_total", "trained"]
+            "low_accuracy", "not_novel", "novelty_rate", "sim_penalty_nonzero",
+            "sim_penalty_mean", "desirable_total", "undesirable_total", "trained"]
     with open(path, "w", newline="", encoding="utf-8") as f:
         w = csv.DictWriter(f, fieldnames=cols, extrasaction="ignore")
         w.writeheader()

--- a/ab/gpt/kto_pipeline/similarity_penalty.py
+++ b/ab/gpt/kto_pipeline/similarity_penalty.py
@@ -1,0 +1,116 @@
+"""Near-duplicate similarity penalty for KTO (MinHash-Jaccard).
+
+Self-contained (KTO-only): builds a MinHash-LSH index over a reference corpus
+(LEMUR DB models + our own accepted generations) and scores each generated model
+by its nearest-neighbour Jaccard similarity. A shaped penalty is then subtracted
+from the KTO chosen reward (see ab/gpt/util/KTO.py).
+
+Reference corpus:
+  * LEMUR DB code via ab.nn.api.data(...)["nn_code"]  (static)
+  * our own accepted generations, added cumulatively across cycles ("previous gens")
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import List, Optional
+
+from datasketch import MinHash, MinHashLSH
+
+
+_TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*|\d+|[^\sA-Za-z0-9_]")
+
+
+def _tokenize(code: str) -> List[str]:
+    return _TOKEN_RE.findall(code or "")
+
+
+def _shingles(tokens: List[str], n: int) -> set:
+    if not tokens:
+        return set()
+    if len(tokens) < n:
+        return {" ".join(tokens)}
+    return {" ".join(tokens[i:i + n]) for i in range(len(tokens) - n + 1)}
+
+
+def to_minhash(code: str, num_perm: int = 128, n: int = 5) -> MinHash:
+    mh = MinHash(num_perm=num_perm)
+    for sh in _shingles(_tokenize(code), n):
+        mh.update(sh.encode("utf-8"))
+    return mh
+
+
+def shape_penalty(s: float, threshold: float = 0.85, shape: str = "exponential",
+                  gamma: float = 4.0) -> float:
+    """Map a Jaccard similarity s -> penalty in [0, 1]. Zero below threshold.
+
+    linear:      ramps linearly from 0 (at threshold) to 1 (at s=1).
+    exponential: mild for moderate similarity, harsh near exact copies.
+    """
+    if s <= threshold or threshold >= 1.0:
+        return 0.0
+    t = max(0.0, min(1.0, (s - threshold) / (1.0 - threshold)))
+    if shape == "linear":
+        return t
+    return (math.exp(gamma * t) - 1.0) / (math.exp(gamma) - 1.0)
+
+
+class SimilarityIndex:
+    """MinHash-LSH over a code corpus; nearest-neighbour Jaccard queries."""
+
+    def __init__(self, threshold: float = 0.85, num_perm: int = 128, shingle_n: int = 5):
+        # LSH threshold slightly below the penalty threshold so near-threshold
+        # neighbours are still retrieved as candidates (exact Jaccard is recomputed).
+        self.penalty_threshold = threshold
+        self.num_perm = num_perm
+        self.shingle_n = shingle_n
+        lsh_thr = max(0.3, threshold - 0.1)
+        self.lsh = MinHashLSH(threshold=lsh_thr, num_perm=num_perm)
+        self.id2mh = {}
+        self._next = 0
+        self.size = 0
+
+    def add(self, code: str) -> None:
+        if not code or not code.strip():
+            return
+        mh = to_minhash(code, self.num_perm, self.shingle_n)
+        key = f"m{self._next}"
+        self._next += 1
+        try:
+            self.lsh.insert(key, mh)
+        except Exception:  # noqa: BLE001 — duplicate key / index hiccup is non-fatal
+            return
+        self.id2mh[key] = mh
+        self.size += 1
+
+    def add_codes(self, codes: List[str]) -> int:
+        before = self.size
+        for c in codes:
+            self.add(c)
+        return self.size - before
+
+    def add_db(self, task: str = "img-classification", dataset: str = "cifar-10",
+               unique_nn: bool = True) -> int:
+        """Index the LEMUR DB model code (via ab.nn.api.data). Returns #added."""
+        from ab.nn.api import data
+        df = data(task=task, dataset=dataset, unique_nn=unique_nn)
+        if "nn_code" not in getattr(df, "columns", []):
+            return 0
+        codes = [c for c in df["nn_code"].tolist() if isinstance(c, str) and c.strip()]
+        return self.add_codes(codes)
+
+    def nearest_jaccard(self, code: str) -> float:
+        if not code or self.size == 0:
+            return 0.0
+        mh = to_minhash(code, self.num_perm, self.shingle_n)
+        best = 0.0
+        for k in self.lsh.query(mh):
+            j = mh.jaccard(self.id2mh[k])
+            if j > best:
+                best = j
+        return best
+
+    def penalty_for(self, code: str, shape: str = "exponential") -> float:
+        """Shaped penalty in [0, 1] for a code vs the indexed corpus (excludes alpha)."""
+        return shape_penalty(self.nearest_jaccard(code), self.penalty_threshold, shape)

--- a/ab/gpt/util/KTO.py
+++ b/ab/gpt/util/KTO.py
@@ -51,6 +51,68 @@ except ImportError as e:
     )
 
 
+class _SimPenaltyCollator:
+    """Wrap the trainer's collator to preserve the per-example sim_penalty column
+    (TRL's collator only pads its known fields; this re-attaches sim_penalty,
+    aligned to the same per-example order as 'label')."""
+
+    def __init__(self, base):
+        self.base = base
+
+    def __call__(self, features):
+        batch = self.base(features)
+        if features and "sim_penalty" in features[0]:
+            batch["sim_penalty"] = [float(f.get("sim_penalty", 0.0) or 0.0) for f in features]
+        return batch
+
+
+class KTOSimPenaltyTrainer(KTOTrainer):
+    """KTO with a near-duplicate similarity penalty on the chosen (desirable) reward.
+
+    Implements r̃_chosen = r_chosen − alpha·sim_penalty (prospect-theory value
+    function preserved). Since chosen_logratios = policy_chosen_logps −
+    reference_chosen_logps, we bias reference_chosen_logps by +alpha·sim so the
+    chosen log-ratio drops by alpha·sim — no reimplementation of kto_loss's body,
+    so it stays correct across TRL patch versions (validated vs trl 0.22.2).
+    """
+
+    sim_alpha: float = 0.0
+
+    def get_batch_loss_metrics(self, model, batch):
+        # Align the per-example penalty to the chosen subset, in the SAME order
+        # TRL's forward uses for chosen_idx (label[i] is True), then stash it.
+        self._chosen_sim_penalty = None
+        pen = batch.get("sim_penalty")
+        if pen is not None and self.sim_alpha and self.sim_alpha > 0:
+            labels = batch.get("label", [])
+            chosen = [float(pen[i]) for i in range(len(labels)) if labels[i] is True]
+            if chosen:
+                import torch
+                self._chosen_sim_penalty = torch.tensor(
+                    chosen, dtype=torch.float, device=self.accelerator.device)
+            if not getattr(self, "_sim_logged", False):
+                self._sim_logged = True
+                nz = sum(1 for x in chosen if x > 0.0)
+                print(f"[sim] penalty ACTIVE: alpha={self.sim_alpha}; first batch has "
+                      f"{len(chosen)} chosen, {nz} with nonzero penalty", flush=True)
+        elif self.sim_alpha and self.sim_alpha > 0 and not getattr(self, "_sim_warned", False):
+            self._sim_warned = True
+            print("[sim][WARN] sim_alpha>0 but no 'sim_penalty' column reached the loss "
+                  "(dropped during KTO data processing) — penalty NOT applied.", flush=True)
+        return super().get_batch_loss_metrics(model, batch)
+
+    def kto_loss(self, policy_chosen_logps, policy_rejected_logps, policy_KL_logps,
+                 reference_chosen_logps, reference_rejected_logps, reference_KL_logps):
+        pen = getattr(self, "_chosen_sim_penalty", None)
+        if (pen is not None and self.sim_alpha and self.sim_alpha > 0
+                and tuple(pen.shape) == tuple(reference_chosen_logps.shape)):
+            reference_chosen_logps = reference_chosen_logps + self.sim_alpha * pen.to(
+                reference_chosen_logps.dtype)
+        return super().kto_loss(
+            policy_chosen_logps, policy_rejected_logps, policy_KL_logps,
+            reference_chosen_logps, reference_rejected_logps, reference_KL_logps)
+
+
 def kto_lora_config(target_modules, r=16, lora_alpha=16, lora_dropout=0.05,
                     bias="none", task_type="CAUSAL_LM", layers_to_transform=None):
     """LoRA config for KTO — lower-rank defaults than SFT for drift control."""
@@ -140,6 +202,7 @@ class KTO:
         beta: float = 0.1,
         desirable_weight: float = 1.0,
         undesirable_weight: float = 1.0,
+        sim_alpha: float = 0.0,
         max_prompt_length: int = 2048,
         max_completion_length: int = 2048,
     ):
@@ -165,8 +228,12 @@ class KTO:
         # If the caller passed metadata fields too, strip them now so the trainer
         # doesn't choke on unexpected columns.
         required_cols = {"prompt", "completion", "label"}
+        # Keep sim_penalty when the penalty is active — the trainer reads it in the loss.
+        keep_cols = set(required_cols)
+        if sim_alpha and sim_alpha > 0:
+            keep_cols.add("sim_penalty")
         if hasattr(dataset, "column_names"):
-            extra = [c for c in dataset.column_names if c not in required_cols]
+            extra = [c for c in dataset.column_names if c not in keep_cols]
             if extra:
                 print(f"[KTO] Removing non-KTO columns from dataset: {extra}")
                 dataset = dataset.remove_columns(extra)
@@ -245,7 +312,14 @@ class KTO:
         if "ref_model" in kto_init_sig.parameters:
             kto_kwargs["ref_model"] = None
 
-        trainer = KTOTrainer(**kto_kwargs)
+        if sim_alpha and sim_alpha > 0:
+            trainer = KTOSimPenaltyTrainer(**kto_kwargs)
+            trainer.sim_alpha = float(sim_alpha)
+            trainer.data_collator = _SimPenaltyCollator(trainer.data_collator)
+            print(f"[KTO] similarity penalty enabled: alpha={sim_alpha} "
+                  "(subtracted from chosen reward)")
+        else:
+            trainer = KTOTrainer(**kto_kwargs)
 
         # Verify dtypes before training
         dtypes = {}


### PR DESCRIPTION
Follow-up to the self-contained KTO pipeline (base already merged). 

### Reward
- Near-duplicate similarity penalty: r̃ = r_θ − α·sim, injected via a
  `KTOSimPenaltyTrainer` that biases `reference_chosen_logps` before the stock
  KTO loss (version-robust, no loss-body rewrite). Similarity = MinHash-Jaccard
  vs the LEMUR DB + our own prior generations (`similarity_penalty.py`).
  Fully gated behind `--sim_penalty` (default off) — no effect on existing runs.
- Non-novel passing models now enter training as desirable (carrying the
  penalty); novelty is kept as a reported metric only.

### Metrics & plots
- Per-cycle novelty chart (novel vs duplicate + novelty rate).
- Combined avg+best accuracy plot, per-cycle valid-count chart.
- Paper-style 95% CIs (Wilson for rates, Student-t for means) + full model-card
  stats block.
- `--no_eval_skip` to force all-model evaluation for benchmarks.
- Live partial-metrics compiler for in-flight generation runs.

### Files
- ab/gpt/util/KTO.py
- ab/gpt/TuneNNGenKTO.py
- ab/gpt/kto_pipeline/{kto_selfcontained_finetune,plot_kto_cycles,similarity_penalty,compile_partial_metrics}.py
